### PR TITLE
CLI standing approval rule proposals with web/mobile inbox (#1267)

### DIFF
--- a/api/agent_standing_approval_requests.go
+++ b/api/agent_standing_approval_requests.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/shared"
+)
+
+type agentStandingApprovalRequestBody struct {
+	ActionType                  string          `json:"action_type" validate:"required"`
+	ActionVersion               string          `json:"action_version"`
+	Constraints                 json.RawMessage `json:"constraints" validate:"required"`
+	MaxExecutions               *int            `json:"max_executions,omitempty" validate:"omitempty,gt=0"`
+	ExpiresInSeconds            *int            `json:"expires_in_seconds,omitempty" validate:"omitempty,gt=0"`
+	SourceActionConfigurationID *string         `json:"source_action_configuration_id"`
+}
+
+type agentStandingApprovalRequestResponse struct {
+	RequestID string `json:"request_id"`
+	Status    string `json:"status"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterAgentStandingApprovalRequestRoutes)
+}
+
+// RegisterAgentStandingApprovalRequestRoutes adds agent-signed standing approval proposal endpoint.
+func RegisterAgentStandingApprovalRequestRoutes(mux *http.ServeMux, deps *Deps) {
+	requireAgent := RequireAgentSignature(deps)
+	mux.Handle("POST /standing-approvals/request", requireAgent(handleAgentCreateStandingApprovalRequest(deps)))
+}
+
+func handleAgentCreateStandingApprovalRequest(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		agent := AuthenticatedAgent(r.Context())
+
+		var req agentStandingApprovalRequestBody
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		req.ActionType = strings.TrimSpace(req.ActionType)
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		if len(req.ActionType) > shared.ActionTypeMaxLength {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_type exceeds maximum length"))
+			return
+		}
+		if len(req.ActionVersion) > shared.ActionVersionMaxLength {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_version exceeds maximum length"))
+			return
+		}
+		if len(req.Constraints) > shared.MaxConstraintsBytes {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "constraints exceeds maximum size"))
+			return
+		}
+
+		if req.ActionVersion == "" {
+			req.ActionVersion = "1"
+		} else if !actionVersionPattern.MatchString(req.ActionVersion) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_version must contain only digits"))
+			return
+		}
+
+		constraintsBytes, err := validateStandingApprovalConstraints(req.Constraints)
+		if err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidConstraints, err.Error()))
+			return
+		}
+
+		if req.SourceActionConfigurationID != nil {
+			id := strings.TrimSpace(*req.SourceActionConfigurationID)
+			if id == "" {
+				req.SourceActionConfigurationID = nil
+			} else {
+				req.SourceActionConfigurationID = &id
+				if len(id) > maxActionConfigIDLength {
+					RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id exceeds maximum length"))
+					return
+				}
+			}
+		}
+
+		requestID, err := generatePrefixedID("sar_", 16)
+		if err != nil {
+			log.Printf("[%s] CreateStandingApprovalRequest: generate ID: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval request"))
+			return
+		}
+
+		sar, err := db.InsertStandingApprovalRequest(r.Context(), deps.DB, db.InsertStandingApprovalRequestParams{
+			RequestID:                   requestID,
+			AgentID:                     agent.AgentID,
+			UserID:                      agent.ApproverID,
+			ActionType:                  req.ActionType,
+			ActionVersion:               req.ActionVersion,
+			Constraints:                 constraintsBytes,
+			MaxExecutions:               req.MaxExecutions,
+			ExpiresInSeconds:            req.ExpiresInSeconds,
+			SourceActionConfigurationID: req.SourceActionConfigurationID,
+		})
+		if err != nil {
+			log.Printf("[%s] InsertStandingApprovalRequest: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval request"))
+			return
+		}
+
+		approver, err := db.GetProfileByUserID(r.Context(), deps.DB, agent.ApproverID)
+		if err != nil {
+			log.Printf("[%s] GetProfileByUserID for notify: %v", TraceID(r.Context()), err)
+		} else if approver != nil {
+			NotifyStandingApprovalRequest(r.Context(), deps, sar, agent, approver)
+		}
+
+		RespondJSON(w, http.StatusOK, agentStandingApprovalRequestResponse{
+			RequestID: sar.RequestID,
+			Status:    sar.Status,
+		})
+	}
+}

--- a/api/standing_approval_request_notify.go
+++ b/api/standing_approval_request_notify.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/notify"
+)
+
+// NotifyStandingApprovalRequest dispatches email/push for a new rule proposal.
+func NotifyStandingApprovalRequest(ctx context.Context, deps *Deps, sar *db.StandingApprovalRequest, agent *db.Agent, approver *db.Profile) {
+	if deps.Notifier == nil {
+		return
+	}
+	if deps.BaseURL == "" {
+		log.Printf("notify: skipping standing approval request notification for %s — BASE_URL is not configured", sar.RequestID)
+		return
+	}
+
+	agentName := extractAgentName(agent)
+	approvalURL := fmt.Sprintf("%s/approve-rule/%s", deps.BaseURL, sar.RequestID)
+
+	actionPayload, err := json.Marshal(map[string]any{
+		"type":        sar.ActionType,
+		"constraints": json.RawMessage(sar.Constraints),
+	})
+	if err != nil {
+		log.Printf("notify: marshal standing approval request action: %v", err)
+		return
+	}
+
+	ctxPayload, err := json.Marshal(map[string]any{
+		"description": fmt.Sprintf("Proposed auto-approve rule for %s", sar.ActionType),
+		"kind":        "standing_approval_request",
+	})
+	if err != nil {
+		log.Printf("notify: marshal standing approval request context: %v", err)
+		return
+	}
+
+	expiresAt := sar.CreatedAt.Add(30 * 24 * time.Hour) // display-only default for template
+	if sar.ExpiresInSeconds != nil {
+		expiresAt = sar.CreatedAt.Add(time.Duration(*sar.ExpiresInSeconds) * time.Second)
+	}
+
+	notifApproval := notify.Approval{
+		ApprovalID:  sar.RequestID,
+		AgentID:     sar.AgentID,
+		AgentName:   agentName,
+		Action:      actionPayload,
+		Context:     ctxPayload,
+		ApprovalURL: approvalURL,
+		ExpiresAt:   expiresAt,
+		CreatedAt:   sar.CreatedAt,
+		Type:        notify.NotificationTypeStandingApprovalRequest,
+	}
+
+	recipient := notify.Recipient{
+		UserID:   approver.ID,
+		Username: approver.Username,
+		Email:    approver.Email,
+		Phone:    approver.Phone,
+	}
+
+	deps.Notifier.Dispatch(ctx, notifApproval, recipient)
+	log.Printf("notify: dispatched standing approval request notification for %s to user %s", sar.RequestID, approver.ID)
+}

--- a/api/standing_approval_requests.go
+++ b/api/standing_approval_requests.go
@@ -1,0 +1,368 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+type standingApprovalRequestResponse struct {
+	RequestID                   string     `json:"request_id"`
+	AgentID                     int64      `json:"agent_id"`
+	UserID                      string     `json:"user_id"`
+	ActionType                  string     `json:"action_type"`
+	ActionVersion               string     `json:"action_version"`
+	Constraints                 any        `json:"constraints"`
+	MaxExecutions               *int       `json:"max_executions,omitempty"`
+	ExpiresInSeconds            *int       `json:"expires_in_seconds,omitempty"`
+	SourceActionConfigurationID *string    `json:"source_action_configuration_id,omitempty"`
+	Status                      string     `json:"status"`
+	DecidedAt                   *time.Time `json:"decided_at,omitempty"`
+	ResultingStandingApprovalID *string    `json:"resulting_standing_approval_id,omitempty"`
+	CreatedAt                   time.Time  `json:"created_at"`
+	UpdatedAt                   time.Time  `json:"updated_at"`
+}
+
+type standingApprovalRequestListResponse struct {
+	Data       []standingApprovalRequestResponse `json:"data"`
+	HasMore    bool                              `json:"has_more"`
+	NextCursor *string                           `json:"next_cursor,omitempty"`
+}
+
+type approveStandingApprovalRequestResponse struct {
+	RequestID                   string                    `json:"request_id"`
+	Status                      string                    `json:"status"`
+	ResultingStandingApprovalID string                    `json:"resulting_standing_approval_id"`
+	StandingApproval            *standingApprovalResponse `json:"standing_approval,omitempty"`
+}
+
+type denyStandingApprovalRequestResponse struct {
+	RequestID string    `json:"request_id"`
+	Status    string    `json:"status"`
+	DecidedAt time.Time `json:"decided_at"`
+}
+
+var validStandingApprovalRequestStatusFilters = map[string]bool{
+	"pending":  true,
+	"approved": true,
+	"denied":   true,
+	"all":      true,
+}
+
+func init() {
+	RegisterRouteGroup(RegisterStandingApprovalRequestRoutes)
+}
+
+func RegisterStandingApprovalRequestRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /standing-approval-requests", requireProfile(handleListStandingApprovalRequests(deps)))
+	mux.Handle("GET /standing-approval-requests/{request_id}", requireProfile(handleGetStandingApprovalRequest(deps)))
+	mux.Handle("POST /standing-approval-requests/{request_id}/approve", requireProfile(handleApproveStandingApprovalRequest(deps)))
+	mux.Handle("POST /standing-approval-requests/{request_id}/deny", requireProfile(handleDenyStandingApprovalRequest(deps)))
+}
+
+func toStandingApprovalRequestResponse(sar db.StandingApprovalRequest) standingApprovalRequestResponse {
+	var constraints any
+	if len(sar.Constraints) > 0 {
+		_ = json.Unmarshal(sar.Constraints, &constraints)
+	}
+	return standingApprovalRequestResponse{
+		RequestID:                   sar.RequestID,
+		AgentID:                     sar.AgentID,
+		UserID:                      sar.UserID,
+		ActionType:                  sar.ActionType,
+		ActionVersion:               sar.ActionVersion,
+		Constraints:                 constraints,
+		MaxExecutions:               sar.MaxExecutions,
+		ExpiresInSeconds:            sar.ExpiresInSeconds,
+		SourceActionConfigurationID: sar.SourceActionConfigurationID,
+		Status:                      sar.Status,
+		DecidedAt:                   sar.DecidedAt,
+		ResultingStandingApprovalID: sar.ResultingStandingApprovalID,
+		CreatedAt:                   sar.CreatedAt,
+		UpdatedAt:                   sar.UpdatedAt,
+	}
+}
+
+func handleListStandingApprovalRequests(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		statusFilter := r.URL.Query().Get("status")
+		if statusFilter == "" {
+			statusFilter = "pending"
+		}
+		if !validStandingApprovalRequestStatusFilters[statusFilter] {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Invalid status filter; must be one of: pending, approved, denied, all"))
+			return
+		}
+
+		limit, ok := parsePaginationLimit(w, r)
+		if !ok {
+			return
+		}
+
+		var cursor *db.StandingApprovalRequestCursor
+		if v := r.URL.Query().Get("after"); v != "" {
+			c, err := parseStandingApprovalRequestCursor(v)
+			if err != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "invalid pagination cursor"))
+				return
+			}
+			cursor = c
+		}
+
+		page, err := db.ListStandingApprovalRequestsByUser(r.Context(), deps.DB, profile.ID, statusFilter, limit, cursor)
+		if err != nil {
+			log.Printf("[%s] ListStandingApprovalRequests: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to list standing approval requests"))
+			return
+		}
+
+		data := make([]standingApprovalRequestResponse, len(page.Requests))
+		for i, sar := range page.Requests {
+			data[i] = toStandingApprovalRequestResponse(sar)
+		}
+
+		resp := standingApprovalRequestListResponse{Data: data, HasMore: page.HasMore}
+		if page.HasMore && len(page.Requests) > 0 {
+			last := page.Requests[len(page.Requests)-1]
+			c := encodeStandingApprovalRequestCursor(last)
+			resp.NextCursor = &c
+		}
+
+		RespondJSON(w, http.StatusOK, resp)
+	}
+}
+
+func handleGetStandingApprovalRequest(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		requestID := strings.TrimSpace(r.PathValue("request_id"))
+		if requestID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "request_id is required"))
+			return
+		}
+
+		sar, err := db.GetStandingApprovalRequestByIDAndUser(r.Context(), deps.DB, requestID, profile.ID)
+		if err != nil {
+			log.Printf("[%s] GetStandingApprovalRequest: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get standing approval request"))
+			return
+		}
+		if sar == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Standing approval request not found"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, toStandingApprovalRequestResponse(*sar))
+	}
+}
+
+func handleApproveStandingApprovalRequest(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		requestID := strings.TrimSpace(r.PathValue("request_id"))
+		if requestID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "request_id is required"))
+			return
+		}
+
+		sar, err := db.GetStandingApprovalRequestByIDAndUser(r.Context(), deps.DB, requestID, profile.ID)
+		if err != nil {
+			log.Printf("[%s] ApproveStandingApprovalRequest load: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+			return
+		}
+		if sar == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Standing approval request not found"))
+			return
+		}
+
+		if sar.Status == db.StandingApprovalRequestStatusApproved && sar.ResultingStandingApprovalID != nil {
+			sa, _ := db.GetStandingApprovalByIDAndUser(r.Context(), deps.DB, *sar.ResultingStandingApprovalID, profile.ID)
+			resp := approveStandingApprovalRequestResponse{
+				RequestID:                   sar.RequestID,
+				Status:                      sar.Status,
+				ResultingStandingApprovalID: *sar.ResultingStandingApprovalID,
+			}
+			if sa != nil {
+				saResp := toStandingApprovalResponse(*sa)
+				resp.StandingApproval = &saResp
+			}
+			RespondJSON(w, http.StatusOK, resp)
+			return
+		}
+		if sar.Status != db.StandingApprovalRequestStatusPending {
+			RespondError(w, r, http.StatusConflict, Conflict(ErrApprovalAlreadyResolved, "Standing approval request is no longer pending"))
+			return
+		}
+
+		sourceConfigID, err := db.FindActionConfigIDForStandingApprovalRequest(
+			r.Context(), deps.DB, sar.AgentID, profile.ID, sar.ActionType, sar.SourceActionConfigurationID,
+		)
+		if err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+			return
+		}
+
+		startsAt := time.Now().UTC()
+		var expiresAt *time.Time
+		if sar.ExpiresInSeconds != nil {
+			t := startsAt.Add(time.Duration(*sar.ExpiresInSeconds) * time.Second)
+			expiresAt = &t
+			const maxStandingApprovalDuration = 90 * 24 * time.Hour
+			if expiresAt.Sub(startsAt) > maxStandingApprovalDuration {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Duration exceeds maximum of 90 days"))
+				return
+			}
+		}
+
+		saID, err := generatePrefixedID("sa_", 16)
+		if err != nil {
+			log.Printf("[%s] ApproveStandingApprovalRequest generate SA id: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+			return
+		}
+
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] ApproveStandingApprovalRequest begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		sa, err := db.CreateStandingApproval(r.Context(), tx, db.CreateStandingApprovalParams{
+			StandingApprovalID:          saID,
+			AgentID:                     sar.AgentID,
+			UserID:                      profile.ID,
+			ActionType:                  sar.ActionType,
+			ActionVersion:               sar.ActionVersion,
+			Constraints:                 sar.Constraints,
+			SourceActionConfigurationID: &sourceConfigID,
+			StartsAt:                    startsAt,
+			ExpiresAt:                   expiresAt,
+		})
+		if err != nil {
+			if handleStandingApprovalError(w, r, err) {
+				return
+			}
+			log.Printf("[%s] CreateStandingApproval from request: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+			return
+		}
+
+		updated, err := db.ApproveStandingApprovalRequest(r.Context(), tx, db.ApproveStandingApprovalRequestParams{
+			RequestID:          requestID,
+			UserID:             profile.ID,
+			StandingApprovalID: saID,
+		})
+		if err != nil {
+			var reqErr *db.StandingApprovalRequestError
+			if errors.As(err, &reqErr) {
+				handleStandingApprovalRequestError(w, r, err)
+				return
+			}
+			log.Printf("[%s] ApproveStandingApprovalRequest update: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+			return
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] ApproveStandingApprovalRequest commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to approve standing approval request"))
+				return
+			}
+		}
+
+		saResp := toStandingApprovalResponse(*sa)
+		RespondJSON(w, http.StatusOK, approveStandingApprovalRequestResponse{
+			RequestID:                   updated.RequestID,
+			Status:                      updated.Status,
+			ResultingStandingApprovalID: saID,
+			StandingApproval:            &saResp,
+		})
+	}
+}
+
+func handleDenyStandingApprovalRequest(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		requestID := strings.TrimSpace(r.PathValue("request_id"))
+		if requestID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "request_id is required"))
+			return
+		}
+
+		sar, err := db.DenyStandingApprovalRequest(r.Context(), deps.DB, requestID, profile.ID)
+		if err != nil {
+			if handleStandingApprovalRequestError(w, r, err) {
+				return
+			}
+			log.Printf("[%s] DenyStandingApprovalRequest: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to deny standing approval request"))
+			return
+		}
+
+		decidedAt := time.Now().UTC()
+		if sar.DecidedAt != nil {
+			decidedAt = *sar.DecidedAt
+		}
+
+		RespondJSON(w, http.StatusOK, denyStandingApprovalRequestResponse{
+			RequestID: sar.RequestID,
+			Status:    sar.Status,
+			DecidedAt: decidedAt,
+		})
+	}
+}
+
+func handleStandingApprovalRequestError(w http.ResponseWriter, r *http.Request, err error) bool {
+	var reqErr *db.StandingApprovalRequestError
+	if !errors.As(err, &reqErr) {
+		return false
+	}
+	switch reqErr.Code {
+	case db.StandingApprovalRequestErrNotFound:
+		RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Standing approval request not found"))
+	case db.StandingApprovalRequestErrApprovalAlreadyResolved:
+		RespondError(w, r, http.StatusConflict, Conflict(ErrApprovalAlreadyResolved, "Standing approval request is no longer pending"))
+	default:
+		RespondError(w, r, http.StatusForbidden, Forbidden(ErrAgentNotAuthorized, "Not allowed to modify this standing approval request"))
+	}
+	return true
+}
+
+func parseStandingApprovalRequestCursor(v string) (*db.StandingApprovalRequestCursor, error) {
+	parts := strings.SplitN(v, ",", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("invalid cursor")
+	}
+	ts, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return nil, err
+	}
+	return &db.StandingApprovalRequestCursor{CreatedAt: ts, RequestID: parts[1]}, nil
+}
+
+func encodeStandingApprovalRequestCursor(sar db.StandingApprovalRequest) string {
+	return sar.CreatedAt.UTC().Format(time.RFC3339Nano) + "," + sar.RequestID
+}

--- a/api/standing_approval_requests.go
+++ b/api/standing_approval_requests.go
@@ -343,7 +343,7 @@ func handleStandingApprovalRequestError(w http.ResponseWriter, r *http.Request, 
 	switch reqErr.Code {
 	case db.StandingApprovalRequestErrNotFound:
 		RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Standing approval request not found"))
-	case db.StandingApprovalRequestErrApprovalAlreadyResolved:
+	case db.StandingApprovalRequestErrAlreadyResolved:
 		RespondError(w, r, http.StatusConflict, Conflict(ErrApprovalAlreadyResolved, "Standing approval request is no longer pending"))
 	default:
 		RespondError(w, r, http.StatusForbidden, Forbidden(ErrAgentNotAuthorized, "Not allowed to modify this standing approval request"))

--- a/api/standing_approval_requests_test.go
+++ b/api/standing_approval_requests_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestAgentCreateStandingApprovalRequest_Success(t *testing.T) {
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+	configID := standingApprovalTestConfigID(t, tx, agentID, uid, "email.send")
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret, BaseURL: "https://app.example.com"}
+	router := NewRouter(deps)
+
+	reqBody := `{"action_type":"email.send","constraints":{"to":"*@example.com"},"source_action_configuration_id":"` + configID + `"}`
+	r := signedJSONRequest(t, http.MethodPost, "/standing-approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp agentStandingApprovalRequestResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.RequestID == "" {
+		t.Error("expected request_id")
+	}
+	if resp.Status != "pending" {
+		t.Errorf("expected pending, got %q", resp.Status)
+	}
+}
+
+func TestApproveStandingApprovalRequest_HappyPath(t *testing.T) {
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	configID := standingApprovalTestConfigID(t, tx, agentID, uid, "email.send")
+
+	requestID := testhelper.GenerateID(t, "sar_")
+	constraints := []byte(`{"to":"*@example.com"}`)
+	_, err := tx.Exec(t.Context(),
+		`INSERT INTO standing_approval_requests
+		   (request_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status)
+		 VALUES ($1, $2, $3, 'email.send', '1', $4, $5, 'pending')`,
+		requestID, agentID, uid, constraints, configID,
+	)
+	if err != nil {
+		t.Fatalf("insert request: %v", err)
+	}
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/standing-approval-requests/"+requestID+"/approve", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp approveStandingApprovalRequestResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Status != "approved" {
+		t.Errorf("expected approved, got %q", resp.Status)
+	}
+	if resp.ResultingStandingApprovalID == "" {
+		t.Error("expected resulting_standing_approval_id")
+	}
+}
+
+func TestDenyStandingApprovalRequest(t *testing.T) {
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	configID := standingApprovalTestConfigID(t, tx, agentID, uid, "email.send")
+
+	requestID := testhelper.GenerateID(t, "sar_")
+	testhelper.InsertStandingApprovalRequest(t, tx, requestID, agentID, uid, "email.send", []byte(`{"to":"*@example.com"}`))
+	_, _ = tx.Exec(t.Context(),
+		`UPDATE standing_approval_requests SET source_action_configuration_id = $1 WHERE request_id = $2`,
+		configID, requestID,
+	)
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/standing-approval-requests/"+requestID+"/deny", uid)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveStandingApprovalRequest_ForbiddenOtherUser(t *testing.T) {
+	tx := testhelper.SetupTestDB(t)
+	uid1 := testhelper.GenerateUID(t)
+	uid2 := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid2, "u_"+uid2[:8])
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid1, "u_"+uid1[:8])
+
+	requestID := testhelper.GenerateID(t, "sar_")
+	testhelper.InsertStandingApprovalRequest(t, tx, requestID, agentID, uid1, "email.send", []byte(`{"to":"*@example.com"}`))
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedRequest(t, http.MethodPost, "/standing-approval-requests/"+requestID+"/approve", uid2)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for other user, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveStandingApprovalRequest_Idempotent(t *testing.T) {
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	configID := standingApprovalTestConfigID(t, tx, agentID, uid, "email.send")
+
+	requestID := testhelper.GenerateID(t, "sar_")
+	constraints := []byte(`{"to":"*@example.com"}`)
+	_, err := tx.Exec(t.Context(),
+		`INSERT INTO standing_approval_requests
+		   (request_id, agent_id, user_id, action_type, action_version, constraints, source_action_configuration_id, status)
+		 VALUES ($1, $2, $3, 'email.send', '1', $4, $5, 'pending')`,
+		requestID, agentID, uid, constraints, configID,
+	)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+	path := "/standing-approval-requests/" + requestID + "/approve"
+
+	r1 := authenticatedRequest(t, http.MethodPost, path, uid)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first approve: %d %s", w1.Code, w1.Body.String())
+	}
+
+	r2 := authenticatedRequest(t, http.MethodPost, path, uid)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second approve (idempotent): %d %s", w2.Code, w2.Body.String())
+	}
+}

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -281,6 +281,25 @@ export class ApiClient {
     });
   }
 
+  /** POST /standing-approvals/request — propose a standing approval rule */
+  async requestStandingApproval(body: {
+    action_type: string;
+    action_version?: string;
+    constraints: unknown;
+    max_executions?: number;
+    expires_in_seconds?: number;
+    source_action_configuration_id?: string;
+  }) {
+    return this.request<{
+      request_id: string;
+      status: string;
+    }>({
+      method: "POST",
+      routerPath: "/standing-approvals/request",
+      body,
+    });
+  }
+
   /** GET /approvals/{id}/status — check approval and execution status */
   async approvalStatus(approvalId: string): Promise<ApprovalStatusResult> {
     return this.request<ApprovalStatusResult>({

--- a/cli/src/commands/autoApproveRequest.ts
+++ b/cli/src/commands/autoApproveRequest.ts
@@ -1,0 +1,79 @@
+/**
+ * permission-slip auto-approve request — propose a standing approval rule for human review.
+ */
+
+import type { Command } from "commander";
+import { ApiClient } from "../api/client.js";
+import { resolveAgentId } from "./status.js";
+import { requireServerUrl } from "../config/serverUrl.js";
+import { output, type OutputOptions } from "../output.js";
+import { parseDurationToSeconds } from "../util/parseDuration.js";
+
+export function autoApproveRequestCommand(program: Command): void {
+  const autoApprove = program
+    .command("auto-approve")
+    .description("Propose auto-approve (standing approval) rules");
+
+  autoApprove
+    .command("request")
+    .description("Request creation of a new auto-approve rule (requires approval in web or mobile)")
+    .requiredOption("--action-type <type>", "Action type (e.g. email.send)")
+    .requiredOption("--constraints <json>", "Constraints JSON object")
+    .option("--action-version <version>", "Action version (digits only)", "1")
+    .option("--max-executions <n>", "Max executions (stored on proposal for audit)", parseInt)
+    .option("--expires-in <duration>", "Rule expiry window after approval (e.g. 30d, 12h)")
+    .option("--source-action-configuration-id <id>", "Backing action configuration ID")
+    .option("--server <url>", "Permission Slip server URL")
+    .option("--agent-id <id>", "Agent ID (from saved registration)")
+    .option("--pretty", "Pretty-printed JSON")
+    .action(async (opts: {
+      actionType: string;
+      constraints: string;
+      actionVersion?: string;
+      maxExecutions?: number;
+      expiresIn?: string;
+      sourceActionConfigurationId?: string;
+      server?: string;
+      agentId?: string;
+      pretty?: boolean;
+    }) => {
+      const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
+      try {
+        const { url: server } = requireServerUrl({ serverFlag: opts.server });
+        let constraints: unknown;
+        try {
+          constraints = JSON.parse(opts.constraints);
+        } catch {
+          throw new Error(`--constraints must be valid JSON. Got: ${opts.constraints}`);
+        }
+
+        let expiresInSeconds: number | undefined;
+        if (opts.expiresIn) {
+          expiresInSeconds = parseDurationToSeconds(opts.expiresIn);
+        }
+
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
+
+        const result = await client.requestStandingApproval({
+          action_type: opts.actionType,
+          action_version: opts.actionVersion,
+          constraints,
+          max_executions: opts.maxExecutions,
+          expires_in_seconds: expiresInSeconds,
+          source_action_configuration_id: opts.sourceActionConfigurationId,
+        });
+
+        output(
+          {
+            ...result,
+            hint: "Approve or deny this rule proposal from the Permission Slip web or mobile app.",
+          },
+          outputOpts,
+        );
+      } catch (err) {
+        output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -29,6 +29,7 @@ import { requestCommand } from "./commands/request.js";
 import { requestStatusCommand } from "./commands/request-status.js";
 import { configCommand } from "./commands/config.js";
 import { whoamiCommand } from "./commands/whoami.js";
+import { autoApproveRequestCommand } from "./commands/autoApproveRequest.js";
 
 const program = new Command();
 
@@ -55,5 +56,6 @@ requestCommand(program);
 requestStatusCommand(program);
 configCommand(program);
 whoamiCommand(program);
+autoApproveRequestCommand(program);
 
 program.parse(process.argv);

--- a/cli/src/util/parseDuration.test.ts
+++ b/cli/src/util/parseDuration.test.ts
@@ -1,0 +1,22 @@
+import { parseDurationToSeconds } from "./parseDuration.js";
+
+describe("parseDurationToSeconds", () => {
+  it("parses days", () => {
+    expect(parseDurationToSeconds("30d")).toBe(30 * 86400);
+  });
+
+  it("parses hours", () => {
+    expect(parseDurationToSeconds("12h")).toBe(12 * 3600);
+  });
+
+  it("parses minutes and seconds", () => {
+    expect(parseDurationToSeconds("90m")).toBe(5400);
+    expect(parseDurationToSeconds("45s")).toBe(45);
+  });
+
+  it("rejects invalid input", () => {
+    expect(() => parseDurationToSeconds("")).toThrow();
+    expect(() => parseDurationToSeconds("30x")).toThrow();
+    expect(() => parseDurationToSeconds("abc")).toThrow();
+  });
+});

--- a/cli/src/util/parseDuration.ts
+++ b/cli/src/util/parseDuration.ts
@@ -1,0 +1,27 @@
+/**
+ * Parses a duration string like "30d", "12h", "90m" into seconds.
+ * Supported units: d (days), h (hours), m (minutes), s (seconds).
+ */
+export function parseDurationToSeconds(input: string): number {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("duration must not be empty");
+  }
+  const match = /^(\d+)([dhms])$/i.exec(trimmed);
+  if (!match) {
+    throw new Error(`invalid duration "${input}"; use forms like 30d, 12h, 90m, 3600s`);
+  }
+  const value = Number.parseInt(match[1]!, 10);
+  const unit = match[2]!.toLowerCase();
+  const multipliers: Record<string, number> = {
+    d: 86400,
+    h: 3600,
+    m: 60,
+    s: 1,
+  };
+  const mult = multipliers[unit];
+  if (!mult) {
+    throw new Error(`unsupported duration unit in "${input}"`);
+  }
+  return value * mult;
+}

--- a/db/migrations/20260523141831_standing_approval_requests.sql
+++ b/db/migrations/20260523141831_standing_approval_requests.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Agent-proposed standing approval rules awaiting human approval.
+
+CREATE TABLE standing_approval_requests (
+    request_id                      text        PRIMARY KEY CHECK (char_length(request_id) <= 255),
+    agent_id                        bigint      NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+    user_id                         uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    action_type                     text        NOT NULL CHECK (char_length(action_type) <= 128),
+    action_version                  text        NOT NULL DEFAULT '1' CHECK (char_length(action_version) <= 10),
+    constraints                     jsonb       NOT NULL CHECK (pg_column_size(constraints) <= 65536),
+    max_executions                  int         CHECK (max_executions IS NULL OR max_executions > 0),
+    expires_in_seconds              int         CHECK (expires_in_seconds IS NULL OR expires_in_seconds > 0),
+    source_action_configuration_id  text        REFERENCES action_configurations(id) ON DELETE RESTRICT,
+    status                          text        NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'expired', 'cancelled')),
+    decided_at                      timestamptz,
+    resulting_standing_approval_id  text        REFERENCES standing_approvals(standing_approval_id) ON DELETE SET NULL,
+    created_at                      timestamptz NOT NULL DEFAULT now(),
+    updated_at                      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_standing_approval_requests_user_status_created
+    ON standing_approval_requests (user_id, status, created_at DESC, request_id DESC);
+
+CREATE INDEX idx_standing_approval_requests_agent_status
+    ON standing_approval_requests (agent_id, status);
+
+ALTER TABLE standing_approval_requests ENABLE ROW LEVEL SECURITY;
+CREATE POLICY app_backend_all ON standing_approval_requests FOR ALL TO app_backend USING (true) WITH CHECK (true);
+
+-- +goose Down
+DROP TABLE IF EXISTS standing_approval_requests;

--- a/db/migrations_sqlite/00002_standing_approval_requests.sql
+++ b/db/migrations_sqlite/00002_standing_approval_requests.sql
@@ -1,0 +1,38 @@
+-- +goose Up
+
+CREATE TABLE standing_approval_requests (
+    request_id TEXT PRIMARY KEY,
+    agent_id INTEGER NOT NULL,
+    user_id TEXT NOT NULL,
+    action_type TEXT NOT NULL,
+    action_version TEXT NOT NULL DEFAULT '1',
+    constraints TEXT NOT NULL,
+    max_executions INTEGER,
+    expires_in_seconds INTEGER,
+    source_action_configuration_id TEXT,
+    status TEXT NOT NULL,
+    decided_at TEXT,
+    resulting_standing_approval_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    CONSTRAINT standing_approval_requests_action_type_check CHECK (length(action_type) <= 128),
+    CONSTRAINT standing_approval_requests_action_version_check CHECK (length(action_version) <= 10),
+    CONSTRAINT standing_approval_requests_constraints_check CHECK (length(constraints) <= 65536),
+    CONSTRAINT standing_approval_requests_max_executions_check CHECK (max_executions IS NULL OR max_executions > 0),
+    CONSTRAINT standing_approval_requests_expires_in_seconds_check CHECK (expires_in_seconds IS NULL OR expires_in_seconds > 0),
+    CONSTRAINT standing_approval_requests_request_id_check CHECK (length(request_id) <= 255),
+    CONSTRAINT standing_approval_requests_status_check CHECK (status IN ('pending', 'approved', 'denied', 'expired', 'cancelled')),
+    FOREIGN KEY (agent_id) REFERENCES agents(agent_id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES profiles(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    FOREIGN KEY (source_action_configuration_id) REFERENCES action_configurations(id) ON DELETE RESTRICT,
+    FOREIGN KEY (resulting_standing_approval_id) REFERENCES standing_approvals(standing_approval_id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_standing_approval_requests_user_status_created
+    ON standing_approval_requests (user_id, status, created_at DESC, request_id DESC);
+
+CREATE INDEX idx_standing_approval_requests_agent_status
+    ON standing_approval_requests (agent_id, status);
+
+-- +goose Down
+DROP TABLE IF EXISTS standing_approval_requests;

--- a/db/standing_approval_requests.go
+++ b/db/standing_approval_requests.go
@@ -1,0 +1,338 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// StandingApprovalRequest represents a row from standing_approval_requests.
+type StandingApprovalRequest struct {
+	RequestID                   string
+	AgentID                     int64
+	UserID                      string
+	ActionType                  string
+	ActionVersion               string
+	Constraints                 []byte
+	MaxExecutions               *int
+	ExpiresInSeconds            *int
+	SourceActionConfigurationID *string
+	Status                      string
+	DecidedAt                   *time.Time
+	ResultingStandingApprovalID *string
+	CreatedAt                   time.Time
+	UpdatedAt                   time.Time
+}
+
+const standingApprovalRequestColumns = `request_id, agent_id, user_id, action_type, action_version,
+	constraints, max_executions, expires_in_seconds, source_action_configuration_id,
+	status, decided_at, resulting_standing_approval_id, created_at, updated_at`
+
+// StandingApprovalRequestCursor identifies pagination position.
+type StandingApprovalRequestCursor struct {
+	CreatedAt time.Time
+	RequestID string
+}
+
+// StandingApprovalRequestPage holds a page of requests.
+type StandingApprovalRequestPage struct {
+	Requests []StandingApprovalRequest
+	HasMore  bool
+}
+
+const (
+	StandingApprovalRequestStatusPending   = "pending"
+	StandingApprovalRequestStatusApproved  = "approved"
+	StandingApprovalRequestStatusDenied    = "denied"
+	StandingApprovalRequestStatusExpired   = "expired"
+	StandingApprovalRequestStatusCancelled = "cancelled"
+)
+
+// StandingApprovalRequestError is a domain error for request operations.
+type StandingApprovalRequestError struct {
+	Code   string
+	Status string
+}
+
+func (e *StandingApprovalRequestError) Error() string { return e.Code }
+
+const (
+	StandingApprovalRequestErrNotFound        = "not_found"
+	StandingApprovalRequestErrAlreadyResolved = "already_resolved"
+	StandingApprovalRequestErrForbidden       = "forbidden"
+)
+
+func scanStandingApprovalRequest(row rowScanner) (*StandingApprovalRequest, error) {
+	var sar StandingApprovalRequest
+	var maxExec, expiresIn sql.NullInt64
+	var sourceConfigID, resultingSAID sql.NullString
+	var decidedAt, createdAt, updatedAt sql.NullString
+	err := row.Scan(
+		&sar.RequestID, &sar.AgentID, &sar.UserID, &sar.ActionType, &sar.ActionVersion,
+		&sar.Constraints, &maxExec, &expiresIn, &sourceConfigID,
+		&sar.Status, &decidedAt, &resultingSAID, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if maxExec.Valid {
+		v := int(maxExec.Int64)
+		sar.MaxExecutions = &v
+	}
+	if expiresIn.Valid {
+		v := int(expiresIn.Int64)
+		sar.ExpiresInSeconds = &v
+	}
+	if sourceConfigID.Valid {
+		s := sourceConfigID.String
+		sar.SourceActionConfigurationID = &s
+	}
+	if resultingSAID.Valid {
+		s := resultingSAID.String
+		sar.ResultingStandingApprovalID = &s
+	}
+	var err2 error
+	sar.DecidedAt, err2 = sqliteTimePtr(decidedAt)
+	if err2 != nil {
+		return nil, err2
+	}
+	sar.CreatedAt, err2 = sqliteTimeRequired(createdAt)
+	if err2 != nil {
+		return nil, err2
+	}
+	sar.UpdatedAt, err2 = sqliteTimeRequired(updatedAt)
+	if err2 != nil {
+		return nil, err2
+	}
+	return &sar, nil
+}
+
+// InsertStandingApprovalRequestParams holds insert parameters.
+type InsertStandingApprovalRequestParams struct {
+	RequestID                   string
+	AgentID                     int64
+	UserID                      string
+	ActionType                  string
+	ActionVersion               string
+	Constraints                 []byte
+	MaxExecutions               *int
+	ExpiresInSeconds            *int
+	SourceActionConfigurationID *string
+}
+
+// InsertStandingApprovalRequest inserts a pending standing approval request.
+func InsertStandingApprovalRequest(ctx context.Context, db DBTX, p InsertStandingApprovalRequestParams) (*StandingApprovalRequest, error) {
+	row := db.QueryRow(ctx,
+		`INSERT INTO standing_approval_requests
+		   (request_id, agent_id, user_id, action_type, action_version, constraints,
+		    max_executions, expires_in_seconds, source_action_configuration_id, status)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending')
+		 RETURNING `+standingApprovalRequestColumns,
+		p.RequestID, p.AgentID, p.UserID, p.ActionType, p.ActionVersion, p.Constraints,
+		nullableIntArg(p.MaxExecutions), nullableIntArg(p.ExpiresInSeconds),
+		p.SourceActionConfigurationID,
+	)
+	return scanStandingApprovalRequest(row)
+}
+
+// GetStandingApprovalRequestByIDAndUser returns a request for the given user or nil.
+func GetStandingApprovalRequestByIDAndUser(ctx context.Context, db DBTX, requestID, userID string) (*StandingApprovalRequest, error) {
+	row := db.QueryRow(ctx,
+		`SELECT `+standingApprovalRequestColumns+`
+		 FROM standing_approval_requests
+		 WHERE request_id = $1 AND user_id = $2`,
+		requestID, userID,
+	)
+	sar, err := scanStandingApprovalRequest(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return sar, err
+}
+
+// ListStandingApprovalRequestsByUser returns paginated requests for a user.
+func ListStandingApprovalRequestsByUser(ctx context.Context, db DBTX, userID, statusFilter string, limit int, cursor *StandingApprovalRequestCursor) (*StandingApprovalRequestPage, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	fetchLimit := limit + 1
+
+	b := &queryBuilder{}
+	b.addArg(userID)
+	where := []string{"user_id = $1"}
+
+	switch statusFilter {
+	case "", "pending":
+		where = append(where, "status = 'pending'")
+	case "all":
+	default:
+		p := b.addArg(statusFilter)
+		where = append(where, "status = "+p)
+	}
+
+	if cursor != nil {
+		tsPlaceholder := b.addArg(TimestampForSQLite(cursor.CreatedAt))
+		idPlaceholder := b.addArg(cursor.RequestID)
+		where = append(where, fmt.Sprintf("(created_at, request_id) < (%s, %s)", tsPlaceholder, idPlaceholder))
+	}
+
+	limitPlaceholder := b.addArg(fetchLimit)
+	query := fmt.Sprintf(
+		`SELECT %s FROM standing_approval_requests WHERE %s ORDER BY created_at DESC, request_id DESC LIMIT %s`,
+		standingApprovalRequestColumns, strings.Join(where, " AND "), limitPlaceholder,
+	)
+
+	rows, err := db.Query(ctx, query, b.args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var requests []StandingApprovalRequest
+	for rows.Next() {
+		sar, err := scanStandingApprovalRequest(rows)
+		if err != nil {
+			return nil, err
+		}
+		requests = append(requests, *sar)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	hasMore := len(requests) > limit
+	if hasMore {
+		requests = requests[:limit]
+	}
+	return &StandingApprovalRequestPage{Requests: requests, HasMore: hasMore}, nil
+}
+
+// ApproveStandingApprovalRequestParams holds approve mutation parameters.
+type ApproveStandingApprovalRequestParams struct {
+	RequestID                   string
+	UserID                      string
+	StandingApprovalID          string
+	SourceActionConfigurationID string
+	ExpiresAt                   *time.Time
+}
+
+// ApproveStandingApprovalRequest marks a pending request approved and links the created standing approval.
+// Returns the updated request. Idempotent: if already approved with same standing approval, returns success.
+func ApproveStandingApprovalRequest(ctx context.Context, db DBTX, p ApproveStandingApprovalRequestParams) (*StandingApprovalRequest, error) {
+	now := time.Now().UTC()
+	row := db.QueryRow(ctx,
+		`UPDATE standing_approval_requests
+		 SET status = 'approved',
+		     decided_at = $3,
+		     resulting_standing_approval_id = $4,
+		     updated_at = $3
+		 WHERE request_id = $1 AND user_id = $2 AND status = 'pending'
+		 RETURNING `+standingApprovalRequestColumns,
+		p.RequestID, p.UserID, TimestampForSQLite(now), p.StandingApprovalID,
+	)
+	sar, err := scanStandingApprovalRequest(row)
+	if err == nil {
+		return sar, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	// Not pending — return existing row if already approved (idempotent).
+	existing, err := GetStandingApprovalRequestByIDAndUser(ctx, db, p.RequestID, p.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, &StandingApprovalRequestError{Code: StandingApprovalRequestErrNotFound}
+	}
+	if existing.Status == StandingApprovalRequestStatusApproved {
+		return existing, nil
+	}
+	return nil, &StandingApprovalRequestError{Code: StandingApprovalRequestErrAlreadyResolved, Status: existing.Status}
+}
+
+// DenyStandingApprovalRequest marks a pending request denied.
+func DenyStandingApprovalRequest(ctx context.Context, db DBTX, requestID, userID string) (*StandingApprovalRequest, error) {
+	now := time.Now().UTC()
+	row := db.QueryRow(ctx,
+		`UPDATE standing_approval_requests
+		 SET status = 'denied', decided_at = $3, updated_at = $3
+		 WHERE request_id = $1 AND user_id = $2 AND status = 'pending'
+		 RETURNING `+standingApprovalRequestColumns,
+		requestID, userID, TimestampForSQLite(now),
+	)
+	sar, err := scanStandingApprovalRequest(row)
+	if err == nil {
+		return sar, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	existing, err := GetStandingApprovalRequestByIDAndUser(ctx, db, requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, &StandingApprovalRequestError{Code: StandingApprovalRequestErrNotFound}
+	}
+	if existing.Status == StandingApprovalRequestStatusDenied {
+		return existing, nil
+	}
+	return nil, &StandingApprovalRequestError{Code: StandingApprovalRequestErrAlreadyResolved, Status: existing.Status}
+}
+
+// FindActionConfigIDForStandingApprovalRequest resolves source_action_configuration_id
+// for approving a request. Uses explicit ID when set; otherwise finds a unique config
+// for the agent and action type owned by the user.
+func FindActionConfigIDForStandingApprovalRequest(ctx context.Context, db DBTX, agentID int64, userID, actionType string, explicitID *string) (string, error) {
+	if explicitID != nil && *explicitID != "" {
+		ac, err := GetActionConfigByID(ctx, db, *explicitID, userID)
+		if err != nil {
+			return "", err
+		}
+		if ac == nil {
+			return "", fmt.Errorf("source_action_configuration_id not found")
+		}
+		if ac.AgentID != agentID {
+			return "", fmt.Errorf("action configuration does not belong to agent")
+		}
+		if ac.ActionType != actionType {
+			return "", fmt.Errorf("action configuration action_type mismatch")
+		}
+		return *explicitID, nil
+	}
+
+	configs, err := ListActionConfigsByAgent(ctx, db, agentID, userID)
+	if err != nil {
+		return "", err
+	}
+	var matches []string
+	for _, ac := range configs {
+		if ac.ActionType == actionType {
+			matches = append(matches, ac.ID)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no action configuration found for action_type; create one in the dashboard or pass source_action_configuration_id")
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("multiple action configurations match action_type; pass source_action_configuration_id")
+	}
+}
+
+func nullableIntArg(p *int) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/db/testhelper/fixtures_standing_approval_requests.go
+++ b/db/testhelper/fixtures_standing_approval_requests.go
@@ -1,0 +1,23 @@
+package testhelper
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// InsertStandingApprovalRequest inserts a pending standing approval request.
+func InsertStandingApprovalRequest(t *testing.T, d db.DBTX, requestID string, agentID int64, userID, actionType string, constraints []byte) {
+	t.Helper()
+	_, err := db.InsertStandingApprovalRequest(t.Context(), d, db.InsertStandingApprovalRequestParams{
+		RequestID:     requestID,
+		AgentID:       agentID,
+		UserID:        userID,
+		ActionType:    actionType,
+		ActionVersion: "1",
+		Constraints:   constraints,
+	})
+	if err != nil {
+		t.Fatalf("InsertStandingApprovalRequest: %v", err)
+	}
+}

--- a/frontend/src/hooks/useApproveStandingApprovalRequest.ts
+++ b/frontend/src/hooks/useApproveStandingApprovalRequest.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+
+export function useApproveStandingApprovalRequest() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.POST(
+        "/v1/standing-approval-requests/{request_id}/approve",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) throw new Error("Failed to approve rule proposal");
+      return data;
+    },
+    onSuccess: () => {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["standing-approval-requests"] });
+        queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
+      }, 2_000);
+    },
+  });
+
+  return {
+    approveRequest: (requestId: string) => mutation.mutateAsync(requestId),
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useDenyStandingApprovalRequest.ts
+++ b/frontend/src/hooks/useDenyStandingApprovalRequest.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+
+export function useDenyStandingApprovalRequest() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.POST(
+        "/v1/standing-approval-requests/{request_id}/deny",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) throw new Error("Failed to deny rule proposal");
+      return data;
+    },
+    onSuccess: () => {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["standing-approval-requests"] });
+      }, 2_000);
+    },
+  });
+
+  return {
+    denyRequest: (requestId: string) => mutation.mutateAsync(requestId),
+    isPending: mutation.isPending,
+  };
+}

--- a/frontend/src/hooks/useStandingApprovalRequestDetail.ts
+++ b/frontend/src/hooks/useStandingApprovalRequestDetail.ts
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type StandingApprovalRequestDetail =
+  components["schemas"]["StandingApprovalRequest"];
+
+export function useStandingApprovalRequestDetail(requestId: string | null) {
+  const { session } = useAuth();
+
+  const query = useQuery({
+    queryKey: ["standing-approval-requests", requestId],
+    queryFn: async (): Promise<StandingApprovalRequestDetail> => {
+      if (!session?.access_token || !requestId) {
+        throw new Error("Missing request");
+      }
+      const { data, error } = await client.GET(
+        "/v1/standing-approval-requests/{request_id}",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) throw new Error("Failed to load rule proposal");
+      return data;
+    },
+    enabled: !!session?.access_token && !!requestId,
+  });
+
+  return {
+    request: query.data,
+    isLoading: query.isLoading,
+    error: query.isError,
+  };
+}

--- a/frontend/src/hooks/useStandingApprovalRequests.test.ts
+++ b/frontend/src/hooks/useStandingApprovalRequests.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+
+describe("useStandingApprovalRequests", () => {
+  it("exports a hook module", async () => {
+    const mod = await import("./useStandingApprovalRequests");
+    expect(typeof mod.useStandingApprovalRequests).toBe("function");
+  });
+});

--- a/frontend/src/hooks/useStandingApprovalRequests.ts
+++ b/frontend/src/hooks/useStandingApprovalRequests.ts
@@ -1,0 +1,44 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type StandingApprovalRequestSummary =
+  components["schemas"]["StandingApprovalRequest"];
+
+export function useStandingApprovalRequests() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  const query = useQuery({
+    queryKey: ["standing-approval-requests", userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/standing-approval-requests", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: { status: "pending" } },
+      });
+      if (error) throw new Error("Failed to load rule proposals");
+      return data;
+    },
+    enabled: !!accessToken,
+    refetchInterval: 30_000,
+  });
+
+  return {
+    requests: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    error: query.isError
+      ? "Unable to load rule proposals. Please try again later."
+      : null,
+    refetch: query.refetch,
+  };
+}

--- a/frontend/src/pages/approve/ApproveRuleRedirectPage.tsx
+++ b/frontend/src/pages/approve/ApproveRuleRedirectPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import { useStandingApprovalRequestDetail } from "@/hooks/useStandingApprovalRequestDetail";
+import { useAgents } from "@/hooks/useAgents";
+import { getAgentDisplayName } from "@/lib/agents";
+import { ReviewStandingApprovalRequestDialog } from "@/pages/dashboard/ReviewStandingApprovalRequestDialog";
+
+export function ApproveRuleRedirectPage() {
+  const { requestId } = useParams<{ requestId: string }>();
+  const navigate = useNavigate();
+  const { request, isLoading, error } = useStandingApprovalRequestDetail(requestId ?? null);
+  const { agents } = useAgents();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (request && !dialogOpen) {
+      setDialogOpen(true);
+    }
+  }, [request, dialogOpen]);
+
+  const agentDisplayName = (() => {
+    if (!request) return "";
+    const agent = agents.find((a) => a.agent_id === request.agent_id);
+    if (agent) return getAgentDisplayName(agent);
+    return `Agent ${request.agent_id}`;
+  })();
+
+  function handleOpenChange(nextOpen: boolean) {
+    setDialogOpen(nextOpen);
+    if (!nextOpen) {
+      navigate("/", { replace: true });
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+        <p className="text-lg font-semibold">Rule proposal not found</p>
+        <button
+          type="button"
+          onClick={() => navigate("/", { replace: true })}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          Go to Dashboard
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading || !request) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+        <p className="text-muted-foreground text-sm">Loading rule proposal…</p>
+      </div>
+    );
+  }
+
+  return (
+    <ReviewStandingApprovalRequestDialog
+      request={request}
+      agentDisplayName={agentDisplayName}
+      open={dialogOpen}
+      onOpenChange={handleOpenChange}
+    />
+  );
+}

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -159,9 +159,9 @@ export function PendingApprovalsBanner() {
     }
   }, []);
 
-  if (isLoading && rulesLoading) return null;
+  if (isLoading || rulesLoading) return null;
 
-  if (error && rulesError) {
+  if (error || rulesError) {
     return (
       <div className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm text-foreground">
         Could not load pending approvals.{" "}

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -1,11 +1,17 @@
 import { useState, useCallback, useMemo, useRef } from "react";
-import { Bot } from "lucide-react";
+import { Bot, Shield } from "lucide-react";
 import { useApprovals, type ApprovalSummary } from "@/hooks/useApprovals";
+import {
+  useStandingApprovalRequests,
+  type StandingApprovalRequestSummary,
+} from "@/hooks/useStandingApprovalRequests";
 import { useAgents, type Agent } from "@/hooks/useAgents";
 import { getAgentDisplayName } from "@/lib/agents";
+import { Badge } from "@/components/ui/badge";
 import { buildSummary } from "@/components/ActionPreviewSummary";
 import { CountdownBadge, RiskBadge } from "./approval-components";
 import { ReviewApprovalDialog } from "./ReviewApprovalDialog";
+import { ReviewStandingApprovalRequestDialog } from "./ReviewStandingApprovalRequestDialog";
 
 function resolveAgentName(
   agentId: number,
@@ -14,6 +20,37 @@ function resolveAgentName(
   const agent = agentMap.get(agentId);
   if (agent) return getAgentDisplayName(agent);
   return String(agentId);
+}
+
+function RuleProposalBannerItem({
+  request,
+  agentDisplayName,
+  onOpenDialog,
+}: {
+  request: StandingApprovalRequestSummary;
+  agentDisplayName: string;
+  onOpenDialog: (request: StandingApprovalRequestSummary, agentDisplayName: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenDialog(request, agentDisplayName)}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-violet-500/30 bg-violet-500/5 px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:bg-violet-500/10"
+      aria-label={`Rule proposal: ${request.action_type} from ${agentDisplayName}`}
+    >
+      <Shield className="size-5 shrink-0 text-violet-600 dark:text-violet-400" />
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="font-medium">{request.action_type}</span>
+        <Badge variant="secondary" className="text-xs">
+          Rule proposal
+        </Badge>
+        <span className="text-xs opacity-75">{agentDisplayName}</span>
+      </div>
+      <span className="shrink-0 text-xs font-medium underline underline-offset-2 opacity-75">
+        Review
+      </span>
+    </button>
+  );
 }
 
 function ApprovalBannerItem({
@@ -62,6 +99,12 @@ function ApprovalBannerItem({
 
 export function PendingApprovalsBanner() {
   const { approvals, isLoading, error, refetch } = useApprovals();
+  const {
+    requests: ruleProposals,
+    isLoading: rulesLoading,
+    error: rulesError,
+    refetch: refetchRules,
+  } = useStandingApprovalRequests();
   const { agents } = useAgents();
 
   // Dialog state is lifted here so it survives the approval being removed
@@ -69,6 +112,10 @@ export function PendingApprovalsBanner() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const activeApprovalRef = useRef<ApprovalSummary | null>(null);
   const activeAgentNameRef = useRef<string>("");
+
+  const [ruleDialogOpen, setRuleDialogOpen] = useState(false);
+  const activeRuleRef = useRef<StandingApprovalRequestSummary | null>(null);
+  const activeRuleAgentNameRef = useRef<string>("");
 
   const agentMap = useMemo(() => {
     const map = new Map<number, Agent>();
@@ -95,16 +142,36 @@ export function PendingApprovalsBanner() {
     }
   }, []);
 
-  if (isLoading) return null;
+  const handleOpenRuleDialog = useCallback(
+    (request: StandingApprovalRequestSummary, agentDisplayName: string) => {
+      activeRuleRef.current = request;
+      activeRuleAgentNameRef.current = agentDisplayName;
+      setRuleDialogOpen(true);
+    },
+    [],
+  );
 
-  if (error) {
+  const handleRuleDialogChange = useCallback((nextOpen: boolean) => {
+    setRuleDialogOpen(nextOpen);
+    if (!nextOpen) {
+      activeRuleRef.current = null;
+      activeRuleAgentNameRef.current = "";
+    }
+  }, []);
+
+  if (isLoading && rulesLoading) return null;
+
+  if (error && rulesError) {
     return (
       <div className="rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm text-foreground">
         Could not load pending approvals.{" "}
         <button
           type="button"
           className="underline"
-          onClick={() => refetch()}
+          onClick={() => {
+            refetch();
+            refetchRules();
+          }}
         >
           Retry
         </button>
@@ -112,15 +179,24 @@ export function PendingApprovalsBanner() {
     );
   }
 
-  if (approvals.length === 0 && !dialogOpen) return null;
+  const totalPending = approvals.length + ruleProposals.length;
+  if (totalPending === 0 && !dialogOpen && !ruleDialogOpen) return null;
 
   return (
     <>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
-        {approvals.length} pending approval{approvals.length !== 1 ? "s" : ""}
+        {totalPending} pending item{totalPending !== 1 ? "s" : ""}
       </span>
-      {approvals.length > 0 && (
-        <div className="space-y-2" aria-label="Pending approvals">
+      {(ruleProposals.length > 0 || approvals.length > 0) && (
+        <div className="space-y-2" aria-label="Pending approvals and rule proposals">
+          {ruleProposals.map((request) => (
+            <RuleProposalBannerItem
+              key={request.request_id}
+              request={request}
+              agentDisplayName={resolveAgentName(request.agent_id, agentMap)}
+              onOpenDialog={handleOpenRuleDialog}
+            />
+          ))}
           {approvals.map((approval) => (
             <ApprovalBannerItem
               key={approval.approval_id}
@@ -139,6 +215,14 @@ export function PendingApprovalsBanner() {
           agentDisplayName={activeAgentNameRef.current}
           open={dialogOpen}
           onOpenChange={handleDialogChange}
+        />
+      )}
+      {activeRuleRef.current && (
+        <ReviewStandingApprovalRequestDialog
+          request={activeRuleRef.current}
+          agentDisplayName={activeRuleAgentNameRef.current}
+          open={ruleDialogOpen}
+          onOpenChange={handleRuleDialogChange}
         />
       )}
     </>

--- a/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.test.tsx
+++ b/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ReviewStandingApprovalRequestDialog } from "./ReviewStandingApprovalRequestDialog";
+
+vi.mock("@/hooks/useApproveStandingApprovalRequest", () => ({
+  useApproveStandingApprovalRequest: () => ({
+    approveRequest: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useDenyStandingApprovalRequest", () => ({
+  useDenyStandingApprovalRequest: () => ({
+    denyRequest: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+describe("ReviewStandingApprovalRequestDialog", () => {
+  it("shows rule proposal badge and action type", () => {
+    render(
+      <ReviewStandingApprovalRequestDialog
+        open
+        onOpenChange={() => {}}
+        agentDisplayName="Test Agent"
+        request={{
+          request_id: "sar_test",
+          agent_id: 1,
+          user_id: "user-1",
+          action_type: "email.send",
+          action_version: "1",
+          constraints: { to: "*@example.com" },
+          status: "pending",
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("Rule proposal").length).toBeGreaterThan(0);
+    expect(screen.getByText(/email.send/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Approve rule/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Loader2, Shield } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useApproveStandingApprovalRequest } from "@/hooks/useApproveStandingApprovalRequest";
+import { useDenyStandingApprovalRequest } from "@/hooks/useDenyStandingApprovalRequest";
+import type { StandingApprovalRequestSummary } from "@/hooks/useStandingApprovalRequests";
+
+interface ReviewStandingApprovalRequestDialogProps {
+  request: StandingApprovalRequestSummary;
+  agentDisplayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ReviewStandingApprovalRequestDialog({
+  request,
+  agentDisplayName,
+  open,
+  onOpenChange,
+}: ReviewStandingApprovalRequestDialogProps) {
+  const { approveRequest, isPending: isApproving } = useApproveStandingApprovalRequest();
+  const { denyRequest, isPending: isDenying } = useDenyStandingApprovalRequest();
+  const [done, setDone] = useState<"approved" | "denied" | null>(null);
+
+  const constraintsJson = JSON.stringify(request.constraints, null, 2);
+  const busy = isApproving || isDenying;
+
+  async function handleApprove() {
+    try {
+      await approveRequest(request.request_id);
+      setDone("approved");
+      toast.success("Auto-approve rule activated");
+      setTimeout(() => onOpenChange(false), 1500);
+    } catch {
+      toast.error("Failed to approve rule");
+    }
+  }
+
+  async function handleDeny() {
+    try {
+      await denyRequest(request.request_id);
+      setDone("denied");
+      toast.success("Rule proposal denied");
+      setTimeout(() => onOpenChange(false), 1500);
+    } catch {
+      toast.error("Failed to deny rule");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex flex-wrap items-center gap-2">
+            <Shield className="size-5" />
+            Rule proposal
+            <Badge variant="secondary">Rule proposal</Badge>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          <p>
+            <span className="font-medium">{agentDisplayName}</span> wants a standing
+            auto-approve rule for <span className="font-mono">{request.action_type}</span>.
+          </p>
+
+          <div>
+            <p className="text-muted-foreground mb-1 text-xs font-medium uppercase tracking-wide">
+              Constraints
+            </p>
+            <pre className="bg-muted max-h-48 overflow-auto rounded-md p-3 text-xs">
+              {constraintsJson}
+            </pre>
+          </div>
+
+          {request.max_executions != null && (
+            <p>
+              <span className="text-muted-foreground">Max executions:</span>{" "}
+              {request.max_executions}
+            </p>
+          )}
+          {request.expires_in_seconds != null && (
+            <p>
+              <span className="text-muted-foreground">Expires after approval:</span>{" "}
+              {Math.round(request.expires_in_seconds / 86400)} day(s) (
+              {request.expires_in_seconds}s)
+            </p>
+          )}
+
+          {done === "approved" && (
+            <p className="text-green-600 dark:text-green-400">Rule approved and active.</p>
+          )}
+          {done === "denied" && (
+            <p className="text-muted-foreground">Proposal denied.</p>
+          )}
+        </div>
+
+        {!done && (
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={handleDeny} disabled={busy}>
+              {isDenying ? <Loader2 className="size-4 animate-spin" /> : "Deny"}
+            </Button>
+            <Button onClick={handleApprove} disabled={busy}>
+              {isApproving ? <Loader2 className="size-4 animate-spin" /> : "Approve rule"}
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewStandingApprovalRequestDialog.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -64,6 +65,9 @@ export function ReviewStandingApprovalRequestDialog({
             Rule proposal
             <Badge variant="secondary">Rule proposal</Badge>
           </DialogTitle>
+          <DialogDescription>
+            Review constraints before approving this standing auto-approve rule.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 text-sm">

--- a/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
@@ -12,6 +12,15 @@ import { PendingApprovalsBanner } from "../PendingApprovalsBanner";
 
 vi.mock("../../../api/client");
 
+vi.mock("@/hooks/useStandingApprovalRequests", () => ({
+  useStandingApprovalRequests: () => ({
+    requests: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 const NOW = new Date("2026-02-21T10:00:00Z");
 
 const mockApproval = {

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -5,6 +5,7 @@ import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPa
 import { ActivityPage } from "./pages/activity/ActivityPage";
 import { SettingsLayout } from "./pages/settings/SettingsLayout";
 import { ApproveRedirectPage } from "./pages/approve/ApproveRedirectPage";
+import { ApproveRuleRedirectPage } from "./pages/approve/ApproveRuleRedirectPage";
 
 export interface RouteConfig {
   path: string;
@@ -26,4 +27,5 @@ export const appRoutes: RouteConfig[] = [
   { path: "/activity", Component: ActivityPage },
   { path: "/settings/*", Component: SettingsLayout },
   { path: "/approve/:approvalId", Component: ApproveRedirectPage },
+  { path: "/approve-rule/:requestId", Component: ApproveRuleRedirectPage },
 ];

--- a/mobile/src/hooks/useApproveStandingApprovalRequest.ts
+++ b/mobile/src/hooks/useApproveStandingApprovalRequest.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+
+export function useApproveStandingApprovalRequest() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.POST(
+        "/v1/standing-approval-requests/{request_id}/approve",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) {
+        throw new Error(getApiErrorMessage(error, "Failed to approve rule"));
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["standing-approval-requests"] });
+      queryClient.invalidateQueries({ queryKey: ["standing-approvals"] });
+    },
+  });
+}

--- a/mobile/src/hooks/useDenyStandingApprovalRequest.ts
+++ b/mobile/src/hooks/useDenyStandingApprovalRequest.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+
+export function useDenyStandingApprovalRequest() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (requestId: string) => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.POST(
+        "/v1/standing-approval-requests/{request_id}/deny",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) {
+        throw new Error(getApiErrorMessage(error, "Failed to deny rule"));
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["standing-approval-requests"] });
+    },
+  });
+}

--- a/mobile/src/hooks/useStandingApprovalRequest.ts
+++ b/mobile/src/hooks/useStandingApprovalRequest.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+export type StandingApprovalRequestDetail =
+  components["schemas"]["StandingApprovalRequest"];
+
+export function useStandingApprovalRequest(requestId: string) {
+  const { session } = useAuth();
+
+  const query = useQuery({
+    queryKey: ["standing-approval-requests", requestId],
+    queryFn: async (): Promise<StandingApprovalRequestDetail> => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.GET(
+        "/v1/standing-approval-requests/{request_id}",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { request_id: requestId } },
+        },
+      );
+      if (error) {
+        throw new Error(getApiErrorMessage(error, "Rule proposal not found"));
+      }
+      return data;
+    },
+    enabled: !!session?.access_token && !!requestId,
+  });
+
+  return {
+    request: query.data,
+    isLoading: query.isLoading,
+    error: query.error?.message ?? null,
+    refetch: query.refetch,
+  };
+}

--- a/mobile/src/hooks/useStandingApprovalRequests.ts
+++ b/mobile/src/hooks/useStandingApprovalRequests.ts
@@ -1,0 +1,48 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+export type StandingApprovalRequestSummary =
+  components["schemas"]["StandingApprovalRequest"];
+
+const PENDING_POLL_INTERVAL_MS = 10_000;
+
+export function useStandingApprovalRequests() {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const userId = session?.user?.id;
+  const tokenRef = useRef(accessToken);
+  tokenRef.current = accessToken;
+
+  const query = useQuery({
+    queryKey: ["standing-approval-requests", userId ?? ""],
+    queryFn: async () => {
+      const token = tokenRef.current;
+      if (!token) throw new Error("Missing access token");
+      const { data, error } = await client.GET("/v1/standing-approval-requests", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { query: { status: "pending" } },
+      });
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Unable to load rule proposals."),
+        );
+      }
+      return data;
+    },
+    enabled: !!accessToken,
+    refetchInterval: PENDING_POLL_INTERVAL_MS,
+  });
+
+  return {
+    requests: query.data?.data ?? [],
+    isLoading: query.isLoading,
+    isRefetching: query.isRefetching,
+    error: query.error?.message ?? null,
+    refetch: query.refetch,
+    dataUpdatedAt: query.dataUpdatedAt,
+  };
+}

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -6,6 +6,9 @@ import LoginScreen from "../screens/LoginScreen";
 import ApprovalListScreen from "../screens/approvals/ApprovalListScreen";
 import ApprovalDetailScreen from "../screens/approvals/ApprovalDetailScreen";
 import DeepLinkDetailScreen from "../screens/approvals/DeepLinkDetailScreen";
+import StandingApprovalRequestDetailScreen from "../screens/approvals/StandingApprovalRequestDetailScreen";
+import DeepLinkRuleDetailScreen from "../screens/approvals/DeepLinkRuleDetailScreen";
+import type { StandingApprovalRequestSummary } from "../hooks/useStandingApprovalRequests";
 import SettingsScreen from "../screens/settings/SettingsScreen";
 import type { ApprovalSummary } from "../hooks/useApprovals";
 import { linking } from "./linking";
@@ -21,6 +24,13 @@ export type RootStackParamList = {
   };
   DeepLinkDetail: {
     approvalId: string;
+  };
+  StandingApprovalRequestDetail: {
+    requestId: string;
+    request: StandingApprovalRequestSummary;
+  };
+  DeepLinkRuleDetail: {
+    requestId: string;
   };
   Settings: undefined;
 };
@@ -60,6 +70,24 @@ export default function RootNavigator() {
               options={{
                 headerShown: true,
                 headerTitle: "Approval Details",
+                headerBackTitle: "Back",
+              }}
+            />
+            <Stack.Screen
+              name="StandingApprovalRequestDetail"
+              component={StandingApprovalRequestDetailScreen}
+              options={{
+                headerShown: true,
+                headerTitle: "Rule Proposal",
+                headerBackTitle: "Back",
+              }}
+            />
+            <Stack.Screen
+              name="DeepLinkRuleDetail"
+              component={DeepLinkRuleDetailScreen}
+              options={{
+                headerShown: true,
+                headerTitle: "Rule Proposal",
                 headerBackTitle: "Back",
               }}
             />

--- a/mobile/src/navigation/linking.ts
+++ b/mobile/src/navigation/linking.ts
@@ -19,6 +19,7 @@ export const linking: LinkingOptions<RootStackParamList> = {
   config: {
     screens: {
       DeepLinkDetail: "permission-slip/approve/:approvalId",
+      DeepLinkRuleDetail: "permission-slip/approve-rule/:requestId",
       ApprovalList: "",
     },
   },

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -19,6 +19,10 @@ import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useIsFocused } from "@react-navigation/native";
 import type { RootStackParamList } from "../../navigation/RootNavigator";
 import { useApprovals, type ApprovalSummary } from "../../hooks/useApprovals";
+import {
+  useStandingApprovalRequests,
+  type StandingApprovalRequestSummary,
+} from "../../hooks/useStandingApprovalRequests";
 import { useAgents, getAgentDisplayName } from "../../hooks/useAgents";
 import { colors } from "../../theme/colors";
 import { buildActionSummary, humanizeActionType, safeParams, isExpired as checkExpired, formatRelativeTime, formatLastUpdated } from "./approvalUtils";
@@ -40,6 +44,11 @@ export default function ApprovalListScreen({ navigation }: Props) {
   const [activeTab, setActiveTab] = useState<StatusTab>("pending");
   const { approvals, isLoading, isRefetching, error, refetch, dataUpdatedAt } =
     useApprovals(activeTab);
+  const {
+    requests: ruleProposals,
+    refetch: refetchRules,
+    isRefetching: rulesRefetching,
+  } = useStandingApprovalRequests();
   const { agents } = useAgents();
   const insets = useSafeAreaInsets();
 
@@ -77,6 +86,16 @@ export default function ApprovalListScreen({ navigation }: Props) {
       navigation.navigate("ApprovalDetail", {
         approvalId: approval.approval_id,
         approval,
+      });
+    },
+    [navigation],
+  );
+
+  const handleRulePress = useCallback(
+    (request: StandingApprovalRequestSummary) => {
+      navigation.navigate("StandingApprovalRequestDetail", {
+        requestId: request.request_id,
+        request,
       });
     },
     [navigation],
@@ -188,13 +207,36 @@ export default function ApprovalListScreen({ navigation }: Props) {
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={
-            approvals.length === 0 ? styles.emptyContainer : styles.list
+            approvals.length === 0 && (activeTab !== "pending" || ruleProposals.length === 0)
+              ? styles.emptyContainer
+              : styles.list
           }
-          ListEmptyComponent={<EmptyState tab={activeTab} />}
+          ListHeaderComponent={
+            activeTab === "pending" && ruleProposals.length > 0 ? (
+              <View style={styles.ruleSection}>
+                {ruleProposals.map((request: StandingApprovalRequestSummary) => (
+                  <RuleProposalRow
+                    key={request.request_id}
+                    request={request}
+                    agentName={resolveAgentName(request.agent_id)}
+                    onPress={() => handleRulePress(request)}
+                  />
+                ))}
+              </View>
+            ) : null
+          }
+          ListEmptyComponent={
+            activeTab === "pending" && ruleProposals.length > 0 ? null : (
+              <EmptyState tab={activeTab} />
+            )
+          }
           refreshControl={
             <RefreshControl
-              refreshing={isRefetching}
-              onRefresh={() => refetch()}
+              refreshing={isRefetching || rulesRefetching}
+              onRefresh={() => {
+                refetch();
+                if (activeTab === "pending") refetchRules();
+              }}
               tintColor={colors.gray500}
             />
           }
@@ -203,6 +245,26 @@ export default function ApprovalListScreen({ navigation }: Props) {
     </View>
   );
 }
+
+const RuleProposalRow = memo(function RuleProposalRow({
+  request,
+  agentName,
+  onPress,
+}: {
+  request: StandingApprovalRequestSummary;
+  agentName: string;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity style={styles.ruleRow} onPress={onPress} accessibilityRole="button">
+      <View style={styles.ruleBadge}>
+        <Text style={styles.ruleBadgeText}>Rule proposal</Text>
+      </View>
+      <Text style={styles.rowTitle}>{humanizeActionType(request.action_type)}</Text>
+      <Text style={styles.rowSubtitle}>{agentName}</Text>
+    </TouchableOpacity>
+  );
+});
 
 /** A single row in the approval list showing action type, agent, risk, and countdown. */
 const ApprovalRow = memo(function ApprovalRow({
@@ -497,5 +559,39 @@ const styles = StyleSheet.create({
     color: colors.gray400,
     textAlign: "center",
     lineHeight: 20,
+  },
+  ruleSection: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray200,
+  },
+  ruleRow: {
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray100,
+    backgroundColor: "#f5f3ff",
+  },
+  ruleBadge: {
+    alignSelf: "flex-start",
+    backgroundColor: colors.gray200,
+    borderRadius: 4,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginBottom: 6,
+  },
+  ruleBadgeText: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: colors.gray700,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.gray900,
+  },
+  rowSubtitle: {
+    fontSize: 12,
+    color: colors.gray500,
+    marginTop: 2,
   },
 });

--- a/mobile/src/screens/approvals/DeepLinkRuleDetailScreen.tsx
+++ b/mobile/src/screens/approvals/DeepLinkRuleDetailScreen.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import { useStandingApprovalRequest } from "../../hooks/useStandingApprovalRequest";
+import { colors } from "../../theme/colors";
+
+type Props = NativeStackScreenProps<RootStackParamList, "DeepLinkRuleDetail">;
+
+export default function DeepLinkRuleDetailScreen({ route, navigation }: Props) {
+  const { requestId } = route.params;
+  const { request, isLoading, error } = useStandingApprovalRequest(requestId);
+
+  useEffect(() => {
+    if (request) {
+      navigation.replace("StandingApprovalRequestDetail", {
+        requestId: request.request_id,
+        request,
+      });
+    }
+  }, [request, navigation]);
+
+  if (isLoading || request) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={styles.text}>Loading rule proposal...</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.errorTitle}>Rule proposal not found</Text>
+        <Text style={styles.errorBody}>{error}</Text>
+      </View>
+    );
+  }
+
+  return null;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.white,
+    paddingHorizontal: 32,
+  },
+  text: { marginTop: 12, fontSize: 14, color: colors.gray500 },
+  errorTitle: { fontSize: 18, fontWeight: "600", color: colors.gray900, marginBottom: 8 },
+  errorBody: { fontSize: 14, color: colors.gray500, textAlign: "center" },
+});

--- a/mobile/src/screens/approvals/StandingApprovalRequestDetailScreen.tsx
+++ b/mobile/src/screens/approvals/StandingApprovalRequestDetailScreen.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import { useAgents, getAgentDisplayName, type AgentSummary } from "../../hooks/useAgents";
+import { useApproveStandingApprovalRequest } from "../../hooks/useApproveStandingApprovalRequest";
+import { useDenyStandingApprovalRequest } from "../../hooks/useDenyStandingApprovalRequest";
+import { colors } from "../../theme/colors";
+import { humanizeActionType } from "./approvalUtils";
+
+type Props = NativeStackScreenProps<
+  RootStackParamList,
+  "StandingApprovalRequestDetail"
+>;
+
+export default function StandingApprovalRequestDetailScreen({
+  route,
+  navigation,
+}: Props) {
+  const { request } = route.params;
+  const { agents } = useAgents();
+  const approve = useApproveStandingApprovalRequest();
+  const deny = useDenyStandingApprovalRequest();
+  const [busy, setBusy] = useState(false);
+
+  const agent = agents.find((a: AgentSummary) => a.agent_id === request.agent_id);
+  const agentName = agent ? getAgentDisplayName(agent) : `Agent ${request.agent_id}`;
+
+  const constraintsText = JSON.stringify(request.constraints, null, 2);
+
+  const handleApprove = useCallback(async () => {
+    setBusy(true);
+    try {
+      await approve.mutateAsync(request.request_id);
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Approve failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [approve, navigation, request.request_id]);
+
+  const handleDeny = useCallback(async () => {
+    setBusy(true);
+    try {
+      await deny.mutateAsync(request.request_id);
+      navigation.goBack();
+    } catch (e) {
+      Alert.alert("Error", e instanceof Error ? e.message : "Deny failed");
+    } finally {
+      setBusy(false);
+    }
+  }, [deny, navigation, request.request_id]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>Rule proposal</Text>
+      </View>
+      <Text style={styles.title}>{humanizeActionType(request.action_type)}</Text>
+      <Text style={styles.subtitle}>From {agentName}</Text>
+
+      <Text style={styles.sectionLabel}>Constraints</Text>
+      <Text style={styles.mono}>{constraintsText}</Text>
+
+      {request.expires_in_seconds != null && (
+        <Text style={styles.meta}>
+          Expires {Math.round(request.expires_in_seconds / 86400)} day(s) after you approve
+        </Text>
+      )}
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.button, styles.denyButton]}
+          onPress={handleDeny}
+          disabled={busy}
+        >
+          {busy ? (
+            <ActivityIndicator color={colors.gray700} />
+          ) : (
+            <Text style={styles.denyText}>Deny</Text>
+          )}
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.approveButton]}
+          onPress={handleApprove}
+          disabled={busy}
+        >
+          {busy ? (
+            <ActivityIndicator color={colors.white} />
+          ) : (
+            <Text style={styles.approveText}>Approve rule</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, paddingBottom: 40, backgroundColor: colors.white },
+  badge: {
+    alignSelf: "flex-start",
+    backgroundColor: colors.gray100,
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginBottom: 12,
+  },
+  badgeText: { fontSize: 12, fontWeight: "600", color: colors.gray700 },
+  title: { fontSize: 22, fontWeight: "700", color: colors.gray900 },
+  subtitle: { fontSize: 14, color: colors.gray500, marginTop: 4, marginBottom: 16 },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    color: colors.gray500,
+    marginBottom: 8,
+  },
+  mono: {
+    fontFamily: "monospace",
+    fontSize: 12,
+    backgroundColor: colors.gray100,
+    padding: 12,
+    borderRadius: 8,
+    color: colors.gray900,
+  },
+  meta: { marginTop: 12, fontSize: 14, color: colors.gray500 },
+  actions: { flexDirection: "row", gap: 12, marginTop: 24 },
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  denyButton: { borderWidth: 1, borderColor: colors.gray300 },
+  approveButton: { backgroundColor: colors.primary },
+  denyText: { color: colors.gray900, fontWeight: "600" },
+  approveText: { color: colors.white, fontWeight: "600" },
+});

--- a/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalListScreen.test.tsx
@@ -42,6 +42,17 @@ jest.mock("../../../hooks/useApprovals", () => ({
   useApprovals: () => mockUseApprovalsReturn,
 }));
 
+jest.mock("../../../hooks/useStandingApprovalRequests", () => ({
+  useStandingApprovalRequests: () => ({
+    requests: [],
+    isLoading: false,
+    isRefetching: false,
+    error: null,
+    refetch: jest.fn(),
+    dataUpdatedAt: Date.now(),
+  }),
+}));
+
 jest.mock("../../../hooks/useAgents", () => ({
   useAgents: () => ({
     agents: MOCK_AGENTS.map((a) => ({ ...a, status: "registered" })),

--- a/notify/email_template.go
+++ b/notify/email_template.go
@@ -17,6 +17,9 @@ func buildEmailSubject(approval Approval) string {
 	if approval.Type == NotificationTypeStandingExecution {
 		return buildStandingExecutionSubject(approval)
 	}
+	if approval.Type == NotificationTypeStandingApprovalRequest {
+		return buildStandingApprovalRequestSubject(approval)
+	}
 	actionType := extractActionType(approval.Action)
 	if actionType != "" {
 		return fmt.Sprintf("Approval needed: %s", actionType)
@@ -31,6 +34,9 @@ func buildEmailPlainBody(approval Approval) string {
 	}
 	if approval.Type == NotificationTypeStandingExecution {
 		return buildStandingExecutionPlainBody(approval)
+	}
+	if approval.Type == NotificationTypeStandingApprovalRequest {
+		return buildStandingApprovalRequestPlainBody(approval)
 	}
 
 	var b strings.Builder
@@ -75,6 +81,9 @@ func buildEmailHTMLBody(approval Approval) string {
 	}
 	if approval.Type == NotificationTypeStandingExecution {
 		return buildStandingExecutionHTMLBody(approval)
+	}
+	if approval.Type == NotificationTypeStandingApprovalRequest {
+		return buildStandingApprovalRequestHTMLBody(approval)
 	}
 
 	agentName := approval.AgentName

--- a/notify/format.go
+++ b/notify/format.go
@@ -82,6 +82,9 @@ func BuildPushContent(approval Approval) PushContent {
 	if approval.Type == NotificationTypeStandingExecution {
 		return buildStandingExecutionPushContent(approval)
 	}
+	if approval.Type == NotificationTypeStandingApprovalRequest {
+		return buildStandingApprovalRequestPushContent(approval)
+	}
 
 	if approval.Type == NotificationTypeCardExpiring {
 		info := extractCardExpiringInfo(approval.Context)

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -49,6 +49,9 @@ const (
 	// action via a standing approval. Informational only — not an approval
 	// request. Uses a distinct template with a blue accent and activity link.
 	NotificationTypeStandingExecution NotificationType = "standing_execution"
+	// NotificationTypeStandingApprovalRequest is sent when an agent proposes
+	// a new standing approval rule for human review.
+	NotificationTypeStandingApprovalRequest NotificationType = "standing_approval_request"
 )
 
 // Approval holds the fields a notification channel needs to construct its

--- a/notify/standing_approval_request.go
+++ b/notify/standing_approval_request.go
@@ -1,0 +1,101 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html"
+	"strings"
+)
+
+func buildStandingApprovalRequestSubject(approval Approval) string {
+	actionType := extractActionType(approval.Action)
+	if actionType != "" {
+		return fmt.Sprintf("Rule proposal: auto-approve %s", actionType)
+	}
+	return "Rule proposal: new auto-approve rule"
+}
+
+func buildStandingApprovalRequestPlainBody(approval Approval) string {
+	var b strings.Builder
+	agentName := approval.AgentName
+	if agentName == "" {
+		agentName = fmt.Sprintf("Agent %d", approval.AgentID)
+	}
+	b.WriteString(fmt.Sprintf("%s proposed a new auto-approve rule.\n\n", agentName))
+	actionType := extractActionType(approval.Action)
+	if actionType != "" {
+		b.WriteString(fmt.Sprintf("Action type: %s\n", actionType))
+	}
+	description := extractDescription(approval.Context)
+	if description != "" {
+		b.WriteString(fmt.Sprintf("Summary: %s\n", description))
+	}
+	if approval.ApprovalURL != "" {
+		b.WriteString(fmt.Sprintf("\nReview and respond:\n%s\n", approval.ApprovalURL))
+	}
+	b.WriteString("\n---\nThis is an automated notification from Permission Slip.\n")
+	return b.String()
+}
+
+func buildStandingApprovalRequestHTMLBody(approval Approval) string {
+	agentName := approval.AgentName
+	if agentName == "" {
+		agentName = fmt.Sprintf("Agent %d", approval.AgentID)
+	}
+	actionType := extractActionType(approval.Action)
+	description := extractDescription(approval.Context)
+
+	var b bytes.Buffer
+	b.WriteString(`<!DOCTYPE html><html><head><meta charset="UTF-8"></head>`)
+	b.WriteString(`<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:20px;color:#1a1a1a;">`)
+	b.WriteString(`<div style="border-bottom:2px solid #e5e7eb;padding-bottom:16px;margin-bottom:20px;">`)
+	b.WriteString(`<h2 style="margin:0 0 4px 0;font-size:20px;">Auto-Approve Rule Proposal</h2>`)
+	b.WriteString(fmt.Sprintf(`<p style="margin:0;color:#6b7280;font-size:14px;">from %s</p>`, html.EscapeString(agentName)))
+	b.WriteString(`</div>`)
+	if actionType != "" {
+		b.WriteString(fmt.Sprintf(`<p style="margin:0 0 8px 0;"><strong>Action:</strong> %s</p>`, html.EscapeString(actionType)))
+	}
+	if description != "" {
+		b.WriteString(fmt.Sprintf(`<p style="margin:0 0 16px 0;color:#374151;">%s</p>`, html.EscapeString(description)))
+	}
+	if constraints := formatConstraintsForEmail(approval.Action); constraints != "" {
+		b.WriteString(fmt.Sprintf(`<pre style="background:#f3f4f6;padding:12px;border-radius:6px;font-size:12px;overflow-x:auto;">%s</pre>`, html.EscapeString(constraints)))
+	}
+	if approval.ApprovalURL != "" {
+		b.WriteString(fmt.Sprintf(`<p style="margin-top:20px;"><a href="%s" style="display:inline-block;background:#2563eb;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;">Review rule proposal</a></p>`, html.EscapeString(approval.ApprovalURL)))
+	}
+	b.WriteString(`</body></html>`)
+	return b.String()
+}
+
+func formatConstraintsForEmail(action json.RawMessage) string {
+	var obj map[string]json.RawMessage
+	if json.Unmarshal(action, &obj) != nil {
+		return ""
+	}
+	raw, ok := obj["constraints"]
+	if !ok || len(raw) == 0 {
+		return ""
+	}
+	var pretty bytes.Buffer
+	if json.Indent(&pretty, raw, "", "  ") != nil {
+		return string(raw)
+	}
+	return pretty.String()
+}
+
+func buildStandingApprovalRequestPushContent(approval Approval) PushContent {
+	agentName := AgentDisplayName(approval.AgentName, approval.AgentID)
+	actionType := extractActionType(approval.Action)
+	body := "New auto-approve rule"
+	if actionType != "" {
+		body = actionType
+	}
+	return PushContent{
+		Title:      fmt.Sprintf("%s proposed a rule", agentName),
+		Body:       body,
+		URL:        approval.ApprovalURL,
+		ApprovalID: approval.ApprovalID,
+	}
+}

--- a/spec/openapi/components/paths/standing_approval_requests.yaml
+++ b/spec/openapi/components/paths/standing_approval_requests.yaml
@@ -1,0 +1,125 @@
+agentCreateStandingApprovalRequest:
+  post:
+    operationId: agentCreateStandingApprovalRequest
+    summary: Propose Standing Approval Rule
+    description: |
+      Agent proposes a new auto-approve (standing approval) rule. The proposal stays
+      pending until the agent's owning user approves or denies it from web or mobile.
+      expires_at on the resulting rule is computed at approval time from expires_in_seconds.
+    tags:
+      - Standing Approval Requests
+    security:
+      - PermissionSlipSignature: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/standing_approval_requests.yaml#/AgentCreateStandingApprovalRequestBody'
+    responses:
+      '200':
+        description: Proposal created
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approval_requests.yaml#/AgentCreateStandingApprovalRequestResponse'
+
+listStandingApprovalRequests:
+  get:
+    operationId: listStandingApprovalRequests
+    summary: List Standing Approval Rule Proposals
+    tags:
+      - Standing Approval Requests
+    security:
+      - SupabaseSession: []
+    parameters:
+      - name: status
+        in: query
+        schema:
+          type: string
+          enum: [pending, approved, denied, all]
+          default: pending
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 50
+      - name: after
+        in: query
+        schema:
+          type: string
+    responses:
+      '200':
+        description: List of proposals
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approval_requests.yaml#/StandingApprovalRequestListResponse'
+
+getStandingApprovalRequest:
+  get:
+    operationId: getStandingApprovalRequest
+    summary: Get Standing Approval Rule Proposal
+    tags:
+      - Standing Approval Requests
+    security:
+      - SupabaseSession: []
+    parameters:
+      - name: request_id
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Proposal detail
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approval_requests.yaml#/StandingApprovalRequest'
+
+approveStandingApprovalRequest:
+  post:
+    operationId: approveStandingApprovalRequest
+    summary: Approve Standing Approval Rule Proposal
+    tags:
+      - Standing Approval Requests
+    security:
+      - SupabaseSession: []
+    parameters:
+      - name: request_id
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Approved; standing approval created
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approval_requests.yaml#/ApproveStandingApprovalRequestResponse'
+
+denyStandingApprovalRequest:
+  post:
+    operationId: denyStandingApprovalRequest
+    summary: Deny Standing Approval Rule Proposal
+    tags:
+      - Standing Approval Requests
+    security:
+      - SupabaseSession: []
+    parameters:
+      - name: request_id
+        in: path
+        required: true
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Denied
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/standing_approval_requests.yaml#/DenyStandingApprovalRequestResponse'

--- a/spec/openapi/components/schemas/standing_approval_requests.yaml
+++ b/spec/openapi/components/schemas/standing_approval_requests.yaml
@@ -1,0 +1,137 @@
+StandingApprovalRequest:
+  type: object
+  required:
+    - request_id
+    - agent_id
+    - user_id
+    - action_type
+    - action_version
+    - constraints
+    - status
+    - created_at
+    - updated_at
+  properties:
+    request_id:
+      type: string
+    agent_id:
+      type: integer
+      format: int64
+    user_id:
+      type: string
+      format: uuid
+    action_type:
+      type: string
+    action_version:
+      type: string
+    constraints:
+      type: object
+      additionalProperties: true
+    max_executions:
+      type: integer
+      nullable: true
+    expires_in_seconds:
+      type: integer
+      nullable: true
+      description: |
+        Relative expiry window in seconds. When the user approves, expires_at on
+        the resulting standing approval is computed from approval time (not request time).
+    source_action_configuration_id:
+      type: string
+      nullable: true
+    status:
+      type: string
+      enum: [pending, approved, denied, expired, cancelled]
+    decided_at:
+      type: string
+      format: date-time
+      nullable: true
+    resulting_standing_approval_id:
+      type: string
+      nullable: true
+    created_at:
+      type: string
+      format: date-time
+    updated_at:
+      type: string
+      format: date-time
+
+StandingApprovalRequestListResponse:
+  type: object
+  required:
+    - data
+    - has_more
+  properties:
+    data:
+      type: array
+      items:
+        $ref: '#/StandingApprovalRequest'
+    has_more:
+      type: boolean
+    next_cursor:
+      type: string
+      nullable: true
+
+AgentCreateStandingApprovalRequestBody:
+  type: object
+  required:
+    - action_type
+    - constraints
+  properties:
+    action_type:
+      type: string
+    action_version:
+      type: string
+    constraints:
+      type: object
+      additionalProperties: true
+    max_executions:
+      type: integer
+      minimum: 1
+    expires_in_seconds:
+      type: integer
+      minimum: 1
+    source_action_configuration_id:
+      type: string
+
+AgentCreateStandingApprovalRequestResponse:
+  type: object
+  required:
+    - request_id
+    - status
+  properties:
+    request_id:
+      type: string
+    status:
+      type: string
+      enum: [pending]
+
+ApproveStandingApprovalRequestResponse:
+  type: object
+  required:
+    - request_id
+    - status
+    - resulting_standing_approval_id
+  properties:
+    request_id:
+      type: string
+    status:
+      type: string
+    resulting_standing_approval_id:
+      type: string
+    standing_approval:
+      $ref: '../schemas/standing_approvals.yaml#/StandingApproval'
+
+DenyStandingApprovalRequestResponse:
+  type: object
+  required:
+    - request_id
+    - status
+    - decided_at
+  properties:
+    request_id:
+      type: string
+    status:
+      type: string
+    decided_at:
+      type: string
+      format: date-time

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -5013,6 +5013,131 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/standing-approvals/request:
+    post:
+      operationId: agentCreateStandingApprovalRequest
+      summary: Propose Standing Approval Rule
+      description: |
+        Agent proposes a new auto-approve (standing approval) rule. The proposal stays
+        pending until the agent's owning user approves or denies it from web or mobile.
+        expires_at on the resulting rule is computed at approval time from expires_in_seconds.
+      tags:
+        - Standing Approval Requests
+      security:
+        - PermissionSlipSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentCreateStandingApprovalRequestBody'
+      responses:
+        '200':
+          description: Proposal created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentCreateStandingApprovalRequestResponse'
+  /v1/standing-approval-requests:
+    get:
+      operationId: listStandingApprovalRequests
+      summary: List Standing Approval Rule Proposals
+      tags:
+        - Standing Approval Requests
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - pending
+              - approved
+              - denied
+              - all
+            default: pending
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: after
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of proposals
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandingApprovalRequestListResponse'
+  /v1/standing-approval-requests/{request_id}:
+    get:
+      operationId: getStandingApprovalRequest
+      summary: Get Standing Approval Rule Proposal
+      tags:
+        - Standing Approval Requests
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: request_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Proposal detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandingApprovalRequest'
+  /v1/standing-approval-requests/{request_id}/approve:
+    post:
+      operationId: approveStandingApprovalRequest
+      summary: Approve Standing Approval Rule Proposal
+      tags:
+        - Standing Approval Requests
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: request_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Approved; standing approval created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApproveStandingApprovalRequestResponse'
+  /v1/standing-approval-requests/{request_id}/deny:
+    post:
+      operationId: denyStandingApprovalRequest
+      summary: Deny Standing Approval Rule Proposal
+      tags:
+        - Standing Approval Requests
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: request_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Denied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DenyStandingApprovalRequestResponse'
   /v1/onboarding:
     post:
       operationId: createOnboarding
@@ -10793,6 +10918,144 @@ components:
         standing_approval:
           $ref: '#/components/schemas/StandingApproval'
           description: Present when the template bundles a standing approval.
+    AgentCreateStandingApprovalRequestBody:
+      type: object
+      required:
+        - action_type
+        - constraints
+      properties:
+        action_type:
+          type: string
+        action_version:
+          type: string
+        constraints:
+          type: object
+          additionalProperties: true
+        max_executions:
+          type: integer
+          minimum: 1
+        expires_in_seconds:
+          type: integer
+          minimum: 1
+        source_action_configuration_id:
+          type: string
+    AgentCreateStandingApprovalRequestResponse:
+      type: object
+      required:
+        - request_id
+        - status
+      properties:
+        request_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - pending
+    StandingApprovalRequest:
+      type: object
+      required:
+        - request_id
+        - agent_id
+        - user_id
+        - action_type
+        - action_version
+        - constraints
+        - status
+        - created_at
+        - updated_at
+      properties:
+        request_id:
+          type: string
+        agent_id:
+          type: integer
+          format: int64
+        user_id:
+          type: string
+          format: uuid
+        action_type:
+          type: string
+        action_version:
+          type: string
+        constraints:
+          type: object
+          additionalProperties: true
+        max_executions:
+          type: integer
+          nullable: true
+        expires_in_seconds:
+          type: integer
+          nullable: true
+          description: |
+            Relative expiry window in seconds. When the user approves, expires_at on
+            the resulting standing approval is computed from approval time (not request time).
+        source_action_configuration_id:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - denied
+            - expired
+            - cancelled
+        decided_at:
+          type: string
+          format: date-time
+          nullable: true
+        resulting_standing_approval_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    StandingApprovalRequestListResponse:
+      type: object
+      required:
+        - data
+        - has_more
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/StandingApprovalRequest'
+        has_more:
+          type: boolean
+        next_cursor:
+          type: string
+          nullable: true
+    ApproveStandingApprovalRequestResponse:
+      type: object
+      required:
+        - request_id
+        - status
+        - resulting_standing_approval_id
+      properties:
+        request_id:
+          type: string
+        status:
+          type: string
+        resulting_standing_approval_id:
+          type: string
+        standing_approval:
+          $ref: '#/components/schemas/StandingApproval'
+    DenyStandingApprovalRequestResponse:
+      type: object
+      required:
+        - request_id
+        - status
+        - decided_at
+      properties:
+        request_id:
+          type: string
+        status:
+          type: string
+        decided_at:
+          type: string
+          format: date-time
     NotificationPreferenceUpdate:
       type: object
       description: A channel preference update (request-only, no `available` field).

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -260,6 +260,21 @@ paths:
   /v1/standing-approvals/{standing_approval_id}/execute:
     $ref: './components/paths/standing_approvals.yaml#/executeStandingApproval'
 
+  /v1/standing-approvals/request:
+    $ref: './components/paths/standing_approval_requests.yaml#/agentCreateStandingApprovalRequest'
+
+  /v1/standing-approval-requests:
+    $ref: './components/paths/standing_approval_requests.yaml#/listStandingApprovalRequests'
+
+  /v1/standing-approval-requests/{request_id}:
+    $ref: './components/paths/standing_approval_requests.yaml#/getStandingApprovalRequest'
+
+  /v1/standing-approval-requests/{request_id}/approve:
+    $ref: './components/paths/standing_approval_requests.yaml#/approveStandingApprovalRequest'
+
+  /v1/standing-approval-requests/{request_id}/deny:
+    $ref: './components/paths/standing_approval_requests.yaml#/denyStandingApprovalRequest'
+
   /v1/onboarding:
     $ref: './components/paths/onboarding.yaml#/onboarding'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `standing_approval_requests` and APIs for agents to propose auto-approve rules (`POST /v1/standing-approvals/request`) and for owners to list, approve, or deny them.
- Sends rule-proposal notifications (email + push) with deep links to `/approve-rule/{request_id}`; approving creates an active `standing_approvals` row with `expires_at` computed at approval time from `expires_in_seconds`.
- Ships `permission-slip auto-approve request` CLI command plus web/mobile inbox UI with a "Rule proposal" badge.

Closes #1267

## Test plan

### Claude Code
- [x] CLI unit tests (`parseDuration`, jest suite)
- [x] Frontend vitest (rule proposal dialog + hook smoke)
- [x] Frontend `npm run build`
- [x] Mobile `tsc --noEmit`
- [x] `gofmt` on new Go files
- [ ] Backend `go test` — not run locally (sandbox Go 1.24 vs bigquery 1.25 requirement); CI must verify

### OpenClaw
- [ ] E2E: `permission-slip auto-approve request ...` → notification → approve on web → matching action auto-approves
- [ ] Deny path leaves no standing approval row
- [ ] Approve as another user returns 403/404
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa0ed38c-5022-4cda-90d8-0b010c6d230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa0ed38c-5022-4cda-90d8-0b010c6d230b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

