### PR TITLE
chore: bump cli/package.json to 0.1.16

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Auto-generated by `/version-tag`. Syncs `cli/package.json` version to match tag `cli/v0.1.16`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017u9ktFQTDvwXqu3XXxASXz)_