### PR TITLE
Fix mobile Settings: hoist "Notify me about" out of Push Notifications card

### DIFF
--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -185,43 +185,45 @@ export default function SettingsScreen(_props: Props) {
             </TouchableOpacity>
           </View>
         ) : (
-          <View style={styles.card}>
-            <View style={styles.toggleRow}>
-              <View style={styles.toggleLabel}>
-                <Text style={styles.toggleTitle}>Push Notifications</Text>
-                <Text style={styles.toggleDescription}>
-                  Receive push notifications when actions need your approval.
-                </Text>
+          <>
+            <View style={styles.card}>
+              <View style={styles.toggleRow}>
+                <View style={styles.toggleLabel}>
+                  <Text style={styles.toggleTitle}>Push Notifications</Text>
+                  <Text style={styles.toggleDescription}>
+                    Receive push notifications when actions need your approval.
+                  </Text>
+                </View>
+                <Switch
+                  testID="mobile-push-toggle"
+                  value={mobilePushEnabled}
+                  onValueChange={handleToggleMobilePush}
+                  disabled={isUpdating}
+                  trackColor={{
+                    false: colors.gray300,
+                    true: colors.primary,
+                  }}
+                  accessibilityLabel="Push Notifications"
+                  accessibilityRole="switch"
+                  accessibilityState={{ checked: mobilePushEnabled }}
+                />
               </View>
-              <Switch
-                testID="mobile-push-toggle"
-                value={mobilePushEnabled}
-                onValueChange={handleToggleMobilePush}
-                disabled={isUpdating}
-                trackColor={{
-                  false: colors.gray300,
-                  true: colors.primary,
-                }}
-                accessibilityLabel="Push Notifications"
-                accessibilityRole="switch"
-                accessibilityState={{ checked: mobilePushEnabled }}
-              />
+              {osNotifPermGranted === false && (
+                <TouchableOpacity
+                  style={styles.permissionWarning}
+                  onPress={() => Linking.openSettings()}
+                  accessibilityRole="button"
+                  accessibilityLabel="Open device settings to enable notifications"
+                >
+                  <Text style={styles.permissionWarningText}>
+                    Notifications are blocked in your device settings.{" "}
+                    <Text style={styles.permissionWarningLink}>Open Settings →</Text>
+                  </Text>
+                </TouchableOpacity>
+              )}
             </View>
-            {osNotifPermGranted === false && (
-              <TouchableOpacity
-                style={styles.permissionWarning}
-                onPress={() => Linking.openSettings()}
-                accessibilityRole="button"
-                accessibilityLabel="Open device settings to enable notifications"
-              >
-                <Text style={styles.permissionWarningText}>
-                  Notifications are blocked in your device settings.{" "}
-                  <Text style={styles.permissionWarningLink}>Open Settings →</Text>
-                </Text>
-              </TouchableOpacity>
-            )}
             <Text style={styles.subsectionTitle}>Notify me about</Text>
-            <View style={[styles.card, styles.cardSpaced]}>
+            <View style={styles.card}>
               <View style={styles.toggleRow}>
                 <View style={styles.toggleLabel}>
                   <Text style={styles.toggleTitle}>Auto-approval executions</Text>
@@ -245,7 +247,7 @@ export default function SettingsScreen(_props: Props) {
                 />
               </View>
             </View>
-          </View>
+          </>
         )}
       </View>
 
@@ -365,9 +367,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     borderWidth: 1,
     borderColor: colors.gray200,
-  },
-  cardSpaced: {
-    marginTop: 12,
   },
   subsectionTitle: {
     fontSize: 13,


### PR DESCRIPTION
## Summary

On the mobile Settings screen, the "NOTIFY ME ABOUT" subsection header and the "Auto-approval executions" card were rendered **inside** the same card that wraps the "Push Notifications" toggle. This produced a nested card-in-card and made the header look like a label belonging to the Push toggle.

This PR hoists the subsection header and Auto-approval card to siblings of the Push Notifications card, so the header sits at the same visual level as other section headers (NOTIFICATIONS, ACCOUNT, SERVER).

### Changes
- `mobile/src/screens/settings/SettingsScreen.tsx`: wrap the loaded-state branch in a fragment, give each toggle its own top-level card, and drop the now-unused `cardSpaced` style.

## Test plan
- [x] `npx jest src/screens/settings/__tests__/SettingsScreen.test.tsx --ci` — 13/13 pass
- [x] `npm test -- --ci` — 300/300 pass across 35 suites
- [x] `npx tsc --noEmit` — clean
- [ ] Manually verify on a device: Push Notifications in its own card, "NOTIFY ME ABOUT" as a sibling section header, Auto-approval in its own card

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdLL2NaDRATg6mP9G7RHBN)_