### PR TITLE
docs: clarify EXPO_ACCESS_TOKEN for self-hosted mobile push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,13 +228,17 @@ VAULT_SECRET_KEY=your-vault-secret-key-from-openssl-rand
 
 # ── Mobile Push (Expo) ───────────────────────────────────────────────────────
 #
-# Mobile push notifications are sent via the Expo Push Service to the
-# Permission Slip mobile app. The mobile push sender is always enabled when
-# the database is available — it automatically discovers registered Expo
-# push tokens for each user.
+# Mobile push notifications are sent via the Expo Push Service. The sender is
+# enabled when the database is available; it reads Expo push tokens registered
+# by the mobile app on login.
 #
-# The access token is optional. Without it, unauthenticated requests are
-# used (lower rate limits). Generate one at https://expo.dev/accounts/[account]/settings/access-tokens
+# EXPO_ACCESS_TOKEN must be from the SAME Expo project as the app on the phone.
+# - App Store build: needs a token for @supersuit-tech/permission-slip (your
+#   personal Expo token will get 403). See docs/deployment-self-hosted.md.
+# - Your own EAS build: use your Expo account token (enable push permission).
+#
+# Create at https://expo.dev/settings/access-tokens (enable push notifications).
+# See docs/deployment-self-hosted.md § Mobile Push Notifications.
 #
 # EXPO_ACCESS_TOKEN=
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -312,6 +312,37 @@ If you followed Step 3, this is already set to your Tailscale hostname. If you'r
 
 The server sends push requests to `exp.host` (Expo's push API). Your server needs outbound HTTPS access to reach it — this is typically available by default on any machine with internet access.
 
+### 3. `EXPO_ACCESS_TOKEN` (Expo project must match the mobile app)
+
+Expo push tokens are tied to the **Expo project that built the app**, not to your Permission Slip server URL. When you send a push, Expo checks that your server is allowed to deliver to that project.
+
+Set in `.env`:
+
+```bash
+EXPO_ACCESS_TOKEN=your_expo_access_token
+```
+
+Generate the token at [expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens). When creating it, enable permission to **send push notifications** (wording may vary; see Expo's [additional push security](https://docs.expo.dev/push-notifications/sending-notifications/#additional-security) docs).
+
+Restart the server and confirm startup logs say `Mobile Push: Expo access token configured (authenticated mode)`.
+
+**Which Expo account?** The token must belong to the **same Expo project** as the app on your phone:
+
+| Mobile app | What you need |
+|------------|----------------|
+| **App Store / official build** | An access token for the **Permission Slip** Expo project (`@supersuit-tech/permission-slip`). A token from your personal Expo account will **not** work — Expo returns `403` / "Insufficient permissions to send push notifications". Ask the project maintainers for a self-host token, or use a custom build (below). |
+| **Your own EAS build** | Your own Expo account: run `npx eas-cli init` in `mobile/`, configure iOS APNs (and Android FCM) in EAS, build and install that app, then set `EXPO_ACCESS_TOKEN` from **that** account. See [Mobile builds](mobile-builds.md). |
+
+**Self-hosted push with your own Expo (recommended if you cannot use the official token):**
+
+1. Create an [Expo account](https://expo.dev/signup) and link a project (`EXPO_PROJECT_ID`, `EXPO_OWNER` in `mobile/.env` — see [mobile/README.md](../mobile/README.md)).
+2. Configure push credentials in EAS (`eas credentials` for iOS APNs; Android FCM as needed).
+3. Build and install the app on your devices ([mobile-builds.md](mobile-builds.md)) — do **not** rely on the App Store build for this path.
+4. Create an access token with push permission and set `EXPO_ACCESS_TOKEN` on your server.
+5. Point the app at your self-hosted URL, sign in, and confirm `POST /api/v1/push-subscriptions` returns `201`.
+
+Without a matching token, registration can still succeed (`201`) while delivery fails when an approval is created.
+
 ### Troubleshooting
 
 **"Failed to update notification preference" error in the app:**
@@ -322,6 +353,9 @@ This was a bug (fixed in build `23c1cb5`) where self-hosted POST/PUT requests ar
 2. Check server logs for `[mobilepush]` lines showing push dispatch errors.
 3. Confirm the push subscription was registered: look for `POST /api/v1/push-subscriptions` returning `201` in your logs. If you don't see it, sign out and back in to force re-registration.
 4. On the phone, go to **Settings → Permission Slip → Notifications** and confirm notifications are allowed. The app's Settings screen will show a warning and an "Open Settings" link if device-level permission is blocked.
+
+**Expo `403` / "Insufficient permissions to send push notifications":**
+Your `EXPO_ACCESS_TOKEN` does not match the Expo project for the app on the device (common with the App Store build plus a personal Expo token). Use a token from the app's project, or switch to your own EAS build and your own token (see §3 above).
 
 **Using Cloudflare Tunnel instead of Tailscale:**
 Set `BASE_URL` to your Cloudflare Tunnel public URL (e.g. `https://your-subdomain.trycloudflare.com`). Everything else works the same — the server reaches Expo's push API via its own outbound connection, not through a callback to your URL.

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,7 @@ The server serves both the API and frontend on a single port (default 8080). The
 | `JWT_SIGNING_SECRET` | Yes (production) | HMAC secret for HS256 access tokens — `openssl rand -base64 32` (min 32 bytes) |
 | `BASE_URL` | Yes | Public URL (e.g. `https://your-server.example.com`) |
 | `INVITE_HMAC_KEY` | Recommended | HMAC key for invite codes — `openssl rand -hex 32` |
-| `EXPO_ACCESS_TOKEN` | Optional | Expo Push Service token for higher rate limits |
+| `EXPO_ACCESS_TOKEN` | Self-host push | Expo token allowed to send to the mobile app's Expo project; see [deployment-self-hosted.md](deployment-self-hosted.md#mobile-push-notifications) |
 
 Bootstrap the first user on a new database with `go run ./cmd/create-user user@example.com 'password'` (see repository README). For the full production deployment walkthrough, see [Self-hosted deployment](deployment-self-hosted.md).
 

--- a/docs/spec/notifications.md
+++ b/docs/spec/notifications.md
@@ -84,7 +84,7 @@ Permission Slip supports four notification channels. Channels are active only wh
 
 **Mobile push notifications** deliver alerts to iOS and Android devices via the [Expo Push Service](https://docs.expo.dev/push-notifications/overview/), which routes to APNs (iOS) and FCM (Android). Device tokens are registered on login via the Permission Slip mobile app.
 
-**Configuration:** Always enabled when a database is available. Set `EXPO_ACCESS_TOKEN` for higher rate limits (authenticated mode); unauthenticated mode is used otherwise.
+**Configuration:** Always enabled when a database is available. Set `EXPO_ACCESS_TOKEN` to an Expo access token that is permitted to send to the mobile app's Expo project (required when Expo push security is enabled; otherwise unauthenticated mode may work with lower rate limits). The token must match the project that built the app — a self-hoster's personal token does not work with the App Store build. See [Self-hosted deployment — Mobile Push Notifications](../deployment-self-hosted.md#mobile-push-notifications).
 
 **Requirement Level:** Services MAY support mobile push as an optional enhancement.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-hosters were hitting Expo `403` ("Insufficient permissions to send push notifications") while `POST /push-subscriptions` succeeded. The gap was documentation: `EXPO_ACCESS_TOKEN` must come from the **same Expo project as the mobile app**, not merely "any Expo account."

This updates the self-hosted deployment guide, `.env.example`, notifications spec, and development env table to explain:

- **App Store build** — personal Expo tokens do not work; need the official project's token or a custom EAS build.
- **Own EAS build** — own Expo account + APNs/FCM in EAS + matching `EXPO_ACCESS_TOKEN`.

## Test plan

- [x] Docs only — no code or test changes
- [x] Reviewed `deployment-self-hosted.md` Mobile Push section for accuracy against Expo push security behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-453b7087-9c56-4564-80b4-7c298fb3764e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-453b7087-9c56-4564-80b4-7c298fb3764e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

