### PR TITLE
docs(protonmail): document hydroxide for ARM / Raspberry Pi self-hosters

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Tested a connector? [Open an issue](https://github.com/supersuit-tech/permission
 - [Openclaw Integration Guide](docs/agents.md) — how Openclaw connects to Permission Slip
 - [Creating Connectors](docs/creating-connectors.md) — build new built-in connectors
 - [Custom Connectors](docs/custom-connectors.md) — add connectors from external Git repos
-- [Proton Mail (Bridge)](docs/connectors/protonmail.md) — built-in Proton Mail via Proton Mail Bridge on self-hosted instances
+- [Proton Mail](docs/connectors/protonmail.md) — built-in Proton Mail via Bridge (x86_64) or hydroxide (ARM / Raspberry Pi) on self-hosted instances
 
 **Contributing**
 - [CONTRIBUTING.md](CONTRIBUTING.md) — workflow, code standards, PR process

--- a/connectors/protonmail/archive_email.go
+++ b/connectors/protonmail/archive_email.go
@@ -10,12 +10,12 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
-// archiveMailbox is the IMAP folder that Proton Mail Bridge exposes for
-// archived messages. Proton Bridge maps the "Archive" label to this folder.
+// archiveMailbox is the IMAP folder that both Proton Mail Bridge and hydroxide
+// expose for Proton's Archive system label (LabelArchive in hydroxide's source).
 const archiveMailbox = "Archive"
 
 // archiveEmailAction moves one or more emails to the Archive folder via IMAP
-// MOVE (RFC 6851). Proton Mail Bridge supports MOVE natively.
+// MOVE (RFC 6851). Both Bridge and hydroxide support MOVE.
 type archiveEmailAction struct {
 	conn *ProtonMailConnector
 }
@@ -143,7 +143,7 @@ func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionR
 		// Provide a helpful hint if the Archive folder doesn't exist.
 		if strings.Contains(err.Error(), "TRYCREATE") || strings.Contains(err.Error(), "Mailbox doesn't exist") {
 			return nil, &connectors.ExternalError{
-				Message: fmt.Sprintf("Archive folder not found on server — the mailbox %q may not exist. Ensure Proton Mail Bridge is configured correctly: %v", archiveMailbox, err),
+				Message: fmt.Sprintf("Archive folder not found on server — the mailbox %q may not exist. Ensure your local Proton IMAP/SMTP proxy (Bridge or hydroxide) is configured correctly and exposes an Archive folder: %v", archiveMailbox, err),
 			}
 		}
 		return nil, imapErr

--- a/connectors/protonmail/imap_helpers.go
+++ b/connectors/protonmail/imap_helpers.go
@@ -15,15 +15,16 @@ import (
 // imapDial establishes a raw IMAP connection. It is a package-level variable
 // so tests can replace it without needing a running server.
 //
-// For localhost (Proton Mail Bridge), it dials without TLS since Bridge handles
-// encryption internally. For remote hosts, it uses implicit TLS (port 993 style)
+// For localhost (Proton Mail Bridge or hydroxide), it dials without TLS — both
+// proxies handle Proton-side encryption internally and expose plain IMAP on the
+// loopback interface. For remote hosts, it uses implicit TLS (port 993 style)
 // to protect credentials in transit.
 var imapDial = func(addr string, timeout time.Duration) (*imapclient.Client, error) {
 	host, _, _ := net.SplitHostPort(addr)
 	dialer := &net.Dialer{Timeout: timeout}
 
 	if isLocalhost(host) {
-		// Proton Mail Bridge on localhost uses plain IMAP (no TLS).
+		// The Proton local proxy (Bridge or hydroxide) uses plain IMAP on loopback.
 		conn, err := dialer.Dial("tcp", addr)
 		if err != nil {
 			return nil, err

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -14,13 +14,13 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 	return &connectors.ConnectorManifest{
 		ID:          "protonmail",
 		Name:        "Proton Mail",
-		Description: "Send and read emails through Proton Mail via IMAP/SMTP Bridge. Requires Proton Mail Bridge running locally.",
+		Description: "Send and read emails through Proton Mail via a local IMAP/SMTP proxy (Proton Mail Bridge on x86_64, or hydroxide on ARM/Raspberry Pi). The proxy must be running on the same host as Permission Slip.",
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{
 				ActionType:  "protonmail.send_email",
 				Name:        "Send Email",
-				Description: "Send an email via SMTP through Proton Mail Bridge",
+				Description: "Send an email via SMTP through the local Proton IMAP/SMTP proxy",
 				RiskLevel:   "high",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -193,7 +193,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				Service:         "protonmail",
 				AuthType:        "custom",
-				InstructionsURL: "https://proton.me/support/bridge",
+				InstructionsURL: "https://github.com/supersuit-tech/permission-slip/blob/main/docs/connectors/protonmail.md",
 			},
 		},
 		Templates: protonmailTemplates(),

--- a/connectors/protonmail/manifest_templates.go
+++ b/connectors/protonmail/manifest_templates.go
@@ -12,7 +12,7 @@ func protonmailTemplates() []connectors.ManifestTemplate {
 			ID:          "tpl_protonmail_send",
 			ActionType:  "protonmail.send_email",
 			Name:        "Send emails from your Proton Mail account",
-			Description: "Agent can send emails on your behalf via Proton Mail Bridge.",
+			Description: "Agent can send emails on your behalf via your local Proton IMAP/SMTP proxy.",
 			Parameters:  json.RawMessage(`{"to":"*","subject":"*","body":"*"}`),
 		},
 		{

--- a/connectors/protonmail/protonmail.go
+++ b/connectors/protonmail/protonmail.go
@@ -1,5 +1,7 @@
 // Package protonmail implements the built-in Proton Mail connector for Permission
-// Slip. It uses IMAP/SMTP against a locally running Proton Mail Bridge instance.
+// Slip. It speaks IMAP/SMTP to a locally running Proton proxy — either Proton
+// Mail Bridge (official, x86_64) or hydroxide (open-source, ARM-friendly). Both
+// expose the same loopback IMAP/SMTP surface that this connector targets.
 //
 // Actions: send_email (SMTP), read_inbox, search_emails, read_email, archive_email (IMAP).
 package protonmail
@@ -30,7 +32,7 @@ const (
 )
 
 // validateIMAPConn is the IMAP dial+login used by ValidateCredentials. Tests may
-// replace it to avoid requiring a running Bridge.
+// replace it to avoid requiring a running local Proton proxy.
 var validateIMAPConn = connectIMAP
 
 // ProtonMailConnector owns the shared configuration for all Proton Mail actions.
@@ -59,8 +61,9 @@ func (c *ProtonMailConnector) Actions() map[string]connectors.Action {
 	}
 }
 
-// ValidateCredentials checks credential shape and verifies Bridge is reachable
-// with a real IMAP LOGIN. Bridge must be running when credentials are saved.
+// ValidateCredentials checks credential shape and verifies the local Proton
+// proxy is reachable with a real IMAP LOGIN. The proxy (Bridge or hydroxide)
+// must be running when credentials are saved.
 func (c *ProtonMailConnector) ValidateCredentials(ctx context.Context, creds connectors.Credentials) error {
 	if err := validateCredentialShape(creds); err != nil {
 		return err
@@ -101,8 +104,8 @@ func validateCredentialShape(creds connectors.Credentials) error {
 	return nil
 }
 
-// smtpConfig extracts SMTP connection settings from credentials, using defaults
-// for Proton Mail Bridge when not specified.
+// smtpConfig extracts SMTP connection settings from credentials, using the
+// loopback defaults shared by Proton Mail Bridge and hydroxide.
 func smtpConfig(creds connectors.Credentials) (host, port, username, password string) {
 	host, _ = creds.Get(credKeySMTPHost)
 	if host == "" {
@@ -117,8 +120,8 @@ func smtpConfig(creds connectors.Credentials) (host, port, username, password st
 	return host, port, username, password
 }
 
-// imapConfig extracts IMAP connection settings from credentials, using defaults
-// for Proton Mail Bridge when not specified.
+// imapConfig extracts IMAP connection settings from credentials, using the
+// loopback defaults shared by Proton Mail Bridge and hydroxide.
 func imapConfig(creds connectors.Credentials) (host, port, username, password string) {
 	host, _ = creds.Get(credKeyIMAPHost)
 	if host == "" {

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -135,7 +135,7 @@ func TestProtonMailConnector_ValidateCredentials(t *testing.T) {
 	}
 }
 
-func TestProtonMailConnector_ValidateCredentials_bridgeUnreachable(t *testing.T) {
+func TestProtonMailConnector_ValidateCredentials_proxyUnreachable(t *testing.T) {
 	t.Parallel()
 
 	old := validateIMAPConn
@@ -145,7 +145,7 @@ func TestProtonMailConnector_ValidateCredentials_bridgeUnreachable(t *testing.T)
 	c := New()
 	err := c.ValidateCredentials(t.Context(), validCreds())
 	if err == nil {
-		t.Fatal("expected error when Proton Bridge is not running")
+		t.Fatal("expected error when the local Proton proxy (Bridge or hydroxide) is not running")
 	}
 	if connectors.IsValidationError(err) {
 		t.Fatalf("expected connection/auth error, got validation error: %v", err)

--- a/connectors/protonmail/send_email.go
+++ b/connectors/protonmail/send_email.go
@@ -13,9 +13,9 @@ import (
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
-// sendEmailAction sends an email via SMTP through Proton Mail Bridge.
-// The sendFunc field allows tests to inject a mock SMTP sender without
-// requiring a running Bridge instance.
+// sendEmailAction sends an email via SMTP through the local Proton proxy
+// (Bridge or hydroxide). The sendFunc field allows tests to inject a mock
+// SMTP sender without requiring a running proxy instance.
 type sendEmailAction struct {
 	conn     *ProtonMailConnector
 	sendFunc func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
@@ -149,7 +149,8 @@ func buildMessage(from string, params sendEmailParams) []byte {
 
 // sendMailTLS establishes a plain TCP connection, upgrades to TLS via STARTTLS
 // if the server advertises it, then authenticates and sends the message. This
-// matches Proton Mail Bridge's default behavior on port 1025.
+// matches the default behavior of both Proton Mail Bridge and hydroxide on
+// port 1025 — Bridge advertises STARTTLS, hydroxide does not, and both work.
 func sendMailTLS(ctx context.Context, addr, host string, auth smtp.Auth, from string, to []string, msg []byte) error {
 	// Use a dialer with context deadline if set.
 	dialer := &net.Dialer{}
@@ -172,7 +173,8 @@ func sendMailTLS(ctx context.Context, addr, host string, auth smtp.Auth, from st
 	}
 	defer client.Close()
 
-	// Try STARTTLS — Proton Mail Bridge supports it.
+	// Try STARTTLS — Bridge advertises it; hydroxide does not (and this block
+	// is a no-op when the proxy doesn't advertise the extension).
 	if ok, _ := client.Extension("STARTTLS"); ok {
 		tlsConfig := &tls.Config{ServerName: host}
 		if err := client.StartTLS(tlsConfig); err != nil {

--- a/docs/connectors/protonmail.md
+++ b/docs/connectors/protonmail.md
@@ -1,37 +1,52 @@
 # Proton Mail (built-in connector)
 
-Permission Slip includes a built-in **Proton Mail** connector that talks to your mailbox through [Proton Mail Bridge](https://proton.me/mail/bridge). Bridge exposes standard IMAP and SMTP on localhost so agents can send and read mail without a separate external connector binary.
+Permission Slip includes a built-in **Proton Mail** connector that talks to your mailbox through a local IMAP/SMTP proxy. Two proxies are supported and the connector works the same way with either:
 
-## Why Bridge is required
+- **[Proton Mail Bridge](https://proton.me/mail/bridge)** — official Proton product, recommended on x86_64 Linux, macOS, and Windows.
+- **[hydroxide](https://github.com/emersion/hydroxide)** — community-built open-source Go proxy, recommended on Raspberry Pi / ARM (Proton does not publish an ARM build of Bridge).
 
-Proton Mail does not offer a public Gmail-style API for third-party apps on free or paid mail plans. Bridge runs on your machine (or your self-hosted server), decrypts mail locally, and forwards IMAP/SMTP to Permission Slip. Every self-hoster who uses Proton must run Bridge anyway; host and ports are usually `127.0.0.1` with Bridge’s default ports.
+Both expose IMAP on `127.0.0.1:1143` and SMTP on `127.0.0.1:1025` by default, so the connector's defaults work for either.
+
+## Why a local proxy is required
+
+Proton Mail does not offer a public Gmail-style API for third-party apps on free or paid mail plans. A local proxy runs on your machine, decrypts mail locally, and forwards IMAP/SMTP to Permission Slip. Every self-hoster who uses Proton must run one of these proxies on the same host (or one reachable on the LAN).
+
+## Choosing between Bridge and hydroxide
+
+| | Proton Mail Bridge | hydroxide |
+|---|---|---|
+| Maintained by | Proton (official) | Community ([emersion](https://github.com/emersion)) |
+| Architectures | x86_64 only (no ARM build published) | Anything Go cross-compiles for (incl. arm64, armhf) |
+| Linux setup | `.deb` / `.rpm` + `pass` keychain | `go build`, no keychain |
+| IMAP maturity | Production | Upstream tags IMAP as "work-in-progress" |
+| Recommended for | x86_64 Linux / macOS / Windows hosts | Raspberry Pi and other ARM boards |
 
 ## What the connector supports
 
 | Action | Risk | Description |
 |--------|------|-------------|
-| `protonmail.send_email` | high | Send mail via SMTP through Bridge |
+| `protonmail.send_email` | high | Send mail via SMTP through the proxy |
 | `protonmail.read_inbox` | low | List recent messages in a folder |
 | `protonmail.search_emails` | low | Search by subject, sender, or date |
 | `protonmail.read_email` | low | Read one message by sequence number |
 | `protonmail.archive_email` | medium | Move messages to Archive (IMAP MOVE) |
 
-Calendar, Drive, Contacts, VPN, and Pass are **not** available through Bridge (no CalDAV/WebDAV for those products).
+Calendar, Drive, Contacts, VPN, and Pass are **not** available through either proxy (no CalDAV/WebDAV for those products).
 
-## Headless Bridge on a Raspberry Pi or Linux server
+## Option A — Proton Mail Bridge (x86_64)
+
+> **Heads up:** Proton publishes Bridge only for x86_64 Linux, macOS, and Windows. If you're self-hosting on a Raspberry Pi or other ARM board, skip to [Option B (hydroxide)](#option-b--hydroxide-raspberry-pi--arm).
 
 These steps assume a dedicated Linux user (example: `proton`) on the same host as Permission Slip.
 
 ### 1. Install Bridge
 
-On Debian/Ubuntu (including Raspberry Pi OS):
+On Debian/Ubuntu (x86_64):
 
 ```bash
-# Get Official package — see https://proton.me/mail/bridge for other distros
+# Download the official package from https://proton.me/mail/bridge
 sudo apt install ./protonmail-bridge_*.deb
 ```
-
-Use the ARM build on a Pi when applicable.
 
 ### 2. Create a service user
 
@@ -58,7 +73,7 @@ Still as `proton`:
 protonmail-bridge --cli
 ```
 
-In the CLI: log in with your Proton account, complete 2FA, and let Bridge finish syncing. Then note the **Bridge-generated password** and IMAP/SMTP ports (defaults are often IMAP `127.0.0.1:1143`, SMTP `127.0.0.1:1025`).
+In the CLI: log in with your Proton account, complete 2FA, and let Bridge finish syncing. Then note the **Bridge-generated password** and IMAP/SMTP ports (defaults are usually IMAP `127.0.0.1:1143`, SMTP `127.0.0.1:1025`).
 
 ### 5. Run Bridge under systemd (user unit)
 
@@ -84,20 +99,94 @@ systemctl --user enable --now protonmail-bridge.service
 systemctl --user status protonmail-bridge.service
 ```
 
-`enable-linger` keeps the user’s systemd instance running after logout so Bridge stays up for Permission Slip.
+`enable-linger` keeps the user's systemd instance running after logout so Bridge stays up for Permission Slip.
 
-### 6. Configure credentials in Permission Slip
+Skip ahead to [Configure credentials in Permission Slip](#configure-credentials-in-permission-slip).
 
-In the UI, add **Proton Mail** credentials (`custom` auth):
+## Option B — hydroxide (Raspberry Pi / ARM)
+
+These steps assume a dedicated Linux user (example: `proton`) and a working Go toolchain. On Raspberry Pi OS / Debian:
+
+```bash
+sudo apt install golang git
+```
+
+### 1. Build and install hydroxide
+
+As the service user:
+
+```bash
+sudo useradd -m -s /bin/bash proton
+sudo -u proton bash
+
+# Builds for whatever architecture you're on, including arm64 and armhf.
+git clone https://github.com/emersion/hydroxide.git
+cd hydroxide
+go build ./cmd/hydroxide
+sudo install -m 0755 hydroxide /usr/local/bin/
+```
+
+### 2. Generate a bridge password
+
+```bash
+hydroxide auth your-username@proton.me
+```
+
+Hydroxide prints a **32-byte bridge password** at the end. **Copy it now** — it's not stored anywhere recoverable. This password is what you'll give Permission Slip; your real Proton password is not.
+
+If you have 2FA enabled, pass the code with `-tfa-code <code>`.
+
+### 3. Run hydroxide under systemd (user unit)
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/hydroxide.service << 'EOF'
+[Unit]
+Description=Hydroxide Proton Mail IMAP/SMTP proxy
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/hydroxide serve
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+loginctl enable-linger proton
+systemctl --user daemon-reload
+systemctl --user enable --now hydroxide.service
+systemctl --user status hydroxide.service
+```
+
+`hydroxide serve` starts SMTP on `1025`, IMAP on `1143`, and CardDAV on `8080` (the last is unused by Permission Slip).
+
+## Configure credentials in Permission Slip
+
+Once your proxy (Bridge or hydroxide) is running, add **Proton Mail** credentials (`custom` auth) in the UI:
 
 | Field | Value |
 |-------|--------|
-| `username` | Your Proton address (as shown in Bridge) |
-| `password` | Bridge-generated password (not your Proton account password) |
+| `username` | Your Proton address (as shown in Bridge or `hydroxide auth`) |
+| `password` | The bridge password — **not** your Proton account password |
 | `imap_host` / `imap_port` | Optional; default `127.0.0.1` / `1143` |
 | `smtp_host` / `smtp_port` | Optional; default `127.0.0.1` / `1025` |
 
-Saving credentials runs a real **IMAP LOGIN** against Bridge. Bridge must be running at save time.
+Saving credentials runs a real **IMAP LOGIN** against your proxy. The proxy must be running at save time.
+
+## Compatibility notes (hydroxide)
+
+Permission Slip's connector was originally written against Bridge. The protocol surface used by each action matches what hydroxide implements:
+
+| Action | Hydroxide status |
+|---|---|
+| `send_email` | Hydroxide's SMTP server on `127.0.0.1:1025` accepts PLAIN auth — matches our client (`connectors/protonmail/send_email.go`). |
+| `read_inbox`, `read_email` | `SELECT INBOX` + `FETCH` are supported by hydroxide's IMAP backend. |
+| `search_emails` | Hydroxide implements `SearchMessages` covering subject / from / date criteria. |
+| `archive_email` | Hydroxide exposes Proton's `LabelArchive` as the IMAP mailbox `"Archive"` — matches the literal in our archive action. IMAP MOVE is supported via `MoveMessages`. |
+
+Upstream still flags hydroxide's IMAP as "work-in-progress". If you hit an action that misbehaves with hydroxide but works with Bridge, please [open an issue](https://github.com/supersuit-tech/permission-slip/issues).
 
 ## Migrating from `permission-slip-proton`
 
@@ -107,10 +196,11 @@ If you previously used the external [permission-slip-proton](https://github.com/
 
 | Symptom | What to check |
 |---------|----------------|
-| Credential validation fails immediately | Bridge service running? `systemctl --user status protonmail-bridge` as the `proton` user |
-| Auth / LOGIN errors | Username must match Bridge; password must be the Bridge-generated password |
-| Connection refused on 1143/1025 | Another process using the port, or Bridge bound to a different interface |
+| Credential validation fails immediately | Proxy running? `systemctl --user status protonmail-bridge` (Bridge) or `systemctl --user status hydroxide` |
+| Auth / LOGIN errors | Username must match the proxy; password must be the bridge password, not your Proton account password |
+| Connection refused on 1143/1025 | Another process using the port, or the proxy bound to a different interface |
 | Login loop in Bridge CLI | Clock skew, 2FA, or `pass` store not initialized |
-| Archive action fails | Proton’s Archive folder must exist; Bridge must support IMAP MOVE |
+| `hydroxide auth` fails | Network issue, 2FA required (use `hydroxide auth -tfa-code <code>`), or clock skew |
+| Archive action fails | Proton's Archive folder must exist; both Bridge and hydroxide expose it as `"Archive"` |
 
 For general self-hosted setup (Tailscale, Google, Slack), see [Self-hosted deployment](../deployment-self-hosted.md).

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -254,15 +254,18 @@ When a user connects Slack from Permission Slip, they'll complete Slack's OAuth 
 
 ---
 
-## Email: Proton Mail (Bridge)
+## Email: Proton Mail (Bridge or hydroxide)
 
-Gmail is covered by the [Google connector](#step-5-connect-google) (OAuth). **Proton Mail** is a built-in connector that uses [Proton Mail Bridge](https://proton.me/mail/bridge) on the same machine as Permission Slip — there is no cloud OAuth flow.
+Gmail is covered by the [Google connector](#step-5-connect-google) (OAuth). **Proton Mail** is a built-in connector that uses a local IMAP/SMTP proxy on the same machine as Permission Slip — there is no cloud OAuth flow. Two proxies are supported:
 
-1. Install and run Bridge headless (systemd user unit, `pass` keychain, login). Full steps: **[Proton Mail connector guide](connectors/protonmail.md)**.
-2. In the Permission Slip UI, add **Proton Mail** credentials with your Bridge username and Bridge-generated password.
+- **[Proton Mail Bridge](https://proton.me/mail/bridge)** — recommended on x86_64 Linux / macOS / Windows.
+- **[hydroxide](https://github.com/emersion/hydroxide)** — recommended on Raspberry Pi / ARM (Bridge has no ARM build).
+
+1. Install and run your chosen proxy headless (systemd user unit). Full steps for both: **[Proton Mail connector guide](connectors/protonmail.md)**.
+2. In the Permission Slip UI, add **Proton Mail** credentials with your Proton address and the bridge password printed by Bridge or `hydroxide auth`.
 3. Grant agent permissions using the Proton templates (send, read inbox, search, read message, archive).
 
-Bridge must be running when you save credentials; validation performs a real IMAP LOGIN.
+The proxy must be running when you save credentials; validation performs a real IMAP LOGIN.
 
 ---
 


### PR DESCRIPTION
## Summary

Proton Mail Bridge has no ARM build, so our self-hosting docs (which recommend a Raspberry Pi 5) were broken for Pi users. This PR splits the Proton Mail connector guide into two parallel setup paths and neutralises Bridge-only wording in the connector's user-visible strings.

- **`docs/connectors/protonmail.md`** — major rewrite. Two setup paths: **Option A — Proton Mail Bridge** (x86_64, unchanged steps with a clear "no ARM build" callout), and **Option B — hydroxide** (Raspberry Pi / ARM, new step-by-step including `go build`, `hydroxide auth`, and a systemd user unit). Adds a "Choosing between Bridge and hydroxide" comparison table and a "Compatibility notes (hydroxide)" section documenting the per-action verification.
- **`docs/deployment-self-hosted.md`** — Email section updated to mention both proxies.
- **`README.md`** — link blurb updated.
- **`connectors/protonmail/manifest.go`** — connector `Description`, send-email action description, and `InstructionsURL` are now neutral and point at our own docs page instead of `proton.me/support/bridge`.
- **`connectors/protonmail/*.go`** — comments and the archive action's user-visible error string updated to reference "the local Proton IMAP/SMTP proxy (Bridge or hydroxide)" instead of Bridge exclusively.
- **`connectors/protonmail/protonmail_test.go`** — `TestProtonMailConnector_ValidateCredentials_bridgeUnreachable` renamed to `…_proxyUnreachable`.

**No connector logic changes.** Hydroxide's IMAP/SMTP loopback surface matches Bridge's defaults (ports `1143` / `1025`), and a source-level review of hydroxide confirms it exposes Proton's `LabelArchive` as the IMAP mailbox `"Archive"` — exactly what `archive_email.go` targets.

### Why this approach (vs. switching the default to hydroxide everywhere)

Bridge is the official Proton product and is still the right recommendation on x86_64; flipping the default would churn working setups and adopt an upstream-flagged "work-in-progress" IMAP backend universally. The split keeps Bridge for the architectures Proton supports and uses hydroxide only where Bridge can't run.

## Test plan

- [ ] CI: `make test-backend` (cannot run locally — see `CLAUDE.md` Go 1.25 sandbox limitation; `gofmt -l` ran clean on every changed Go file)
- [ ] CI: `make test-frontend` (no frontend changes, but the manifest's new `Description` and `InstructionsURL` propagate to the UI via the generated OpenAPI types)
- [ ] Manual on a Raspberry Pi: install hydroxide per the new Option B, configure credentials in the UI, then run each of the 5 actions through an agent (send_email, read_inbox, search_emails, read_email, archive_email)
- [ ] Spot-check that Bridge users on x86_64 still see correct instructions (Option A is unchanged apart from the "no ARM build" note)

https://claude.ai/code/session_01QVph6gJjjshgNpqQNmboe8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVph6gJjjshgNpqQNmboe8)_