### PR TITLE
docs(protonmail): drop hydroxide; recommend x86_64 mini PC for ARM users

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Tested a connector? [Open an issue](https://github.com/supersuit-tech/permission
 - [Openclaw Integration Guide](docs/agents.md) — how Openclaw connects to Permission Slip
 - [Creating Connectors](docs/creating-connectors.md) — build new built-in connectors
 - [Custom Connectors](docs/custom-connectors.md) — add connectors from external Git repos
-- [Proton Mail](docs/connectors/protonmail.md) — built-in Proton Mail via Bridge (x86_64) or hydroxide (ARM / Raspberry Pi) on self-hosted instances
+- [Proton Mail](docs/connectors/protonmail.md) — built-in Proton Mail via Proton Mail Bridge on self-hosted instances
 
 **Contributing**
 - [CONTRIBUTING.md](CONTRIBUTING.md) — workflow, code standards, PR process

--- a/docs/connectors/protonmail.md
+++ b/docs/connectors/protonmail.md
@@ -1,41 +1,30 @@
 # Proton Mail (built-in connector)
 
-Permission Slip includes a built-in **Proton Mail** connector that talks to your mailbox through a local IMAP/SMTP proxy. Two proxies are supported and the connector works the same way with either:
-
-- **[Proton Mail Bridge](https://proton.me/mail/bridge)** — official Proton product, recommended on x86_64 Linux, macOS, and Windows.
-- **[hydroxide](https://github.com/emersion/hydroxide)** — community-built open-source Go proxy, recommended on Raspberry Pi / ARM (Proton does not publish an ARM build of Bridge).
-
-Both expose IMAP on `127.0.0.1:1143` and SMTP on `127.0.0.1:1025` by default, so the connector's defaults work for either.
+Permission Slip includes a built-in **Proton Mail** connector that talks to your mailbox through [Proton Mail Bridge](https://proton.me/mail/bridge) — Proton's official local IMAP/SMTP proxy. Bridge exposes IMAP on `127.0.0.1:1143` and SMTP on `127.0.0.1:1025` by default, so the connector's defaults work out of the box.
 
 ## Why a local proxy is required
 
-Proton Mail does not offer a public Gmail-style API for third-party apps on free or paid mail plans. A local proxy runs on your machine, decrypts mail locally, and forwards IMAP/SMTP to Permission Slip. Every self-hoster who uses Proton must run one of these proxies on the same host (or one reachable on the LAN).
+Proton Mail does not offer a public Gmail-style API for third-party apps on free or paid mail plans. Bridge runs on your machine, decrypts mail locally, and forwards IMAP/SMTP to Permission Slip. Every self-hoster who uses Proton must run Bridge on the same host (or one reachable on the LAN).
 
-## Choosing between Bridge and hydroxide
+## Supported hosts
 
-| | Proton Mail Bridge | hydroxide |
-|---|---|---|
-| Maintained by | Proton (official) | Community ([emersion](https://github.com/emersion)) |
-| Architectures | x86_64 only (no ARM build published) | Anything Go cross-compiles for (incl. arm64, armhf) |
-| Linux setup | `.deb` / `.rpm` + `pass` keychain | `go build`, no keychain |
-| IMAP maturity | Production | Upstream tags IMAP as "work-in-progress" |
-| Recommended for | x86_64 Linux / macOS / Windows hosts | Raspberry Pi and other ARM boards |
+Bridge is officially distributed for **x86_64 Linux, macOS, and Windows**. Proton does not publish an ARM build, so Raspberry Pi and other ARM boards are not supported hosts for the Proton Mail connector.
+
+If you're currently self-hosting on ARM hardware, we recommend running Permission Slip (and Bridge) on a small **x86_64 mini PC** with the specs you need. Any model that fits your budget and footprint will work; the connector only requires that Bridge itself is supported on the host OS.
 
 ## What the connector supports
 
 | Action | Risk | Description |
 |--------|------|-------------|
-| `protonmail.send_email` | high | Send mail via SMTP through the proxy |
+| `protonmail.send_email` | high | Send mail via SMTP through Bridge |
 | `protonmail.read_inbox` | low | List recent messages in a folder |
 | `protonmail.search_emails` | low | Search by subject, sender, or date |
 | `protonmail.read_email` | low | Read one message by sequence number |
 | `protonmail.archive_email` | medium | Move messages to Archive (IMAP MOVE) |
 
-Calendar, Drive, Contacts, VPN, and Pass are **not** available through either proxy (no CalDAV/WebDAV for those products).
+Calendar, Drive, Contacts, VPN, and Pass are **not** available through Bridge (no CalDAV/WebDAV for those products).
 
-## Option A — Proton Mail Bridge (x86_64)
-
-> **Heads up:** Proton publishes Bridge only for x86_64 Linux, macOS, and Windows. If you're self-hosting on a Raspberry Pi or other ARM board, skip to [Option B (hydroxide)](#option-b--hydroxide-raspberry-pi--arm).
+## Install and run Bridge
 
 These steps assume a dedicated Linux user (example: `proton`) on the same host as Permission Slip.
 
@@ -101,92 +90,18 @@ systemctl --user status protonmail-bridge.service
 
 `enable-linger` keeps the user's systemd instance running after logout so Bridge stays up for Permission Slip.
 
-Skip ahead to [Configure credentials in Permission Slip](#configure-credentials-in-permission-slip).
-
-## Option B — hydroxide (Raspberry Pi / ARM)
-
-These steps assume a dedicated Linux user (example: `proton`) and a working Go toolchain. On Raspberry Pi OS / Debian:
-
-```bash
-sudo apt install golang git
-```
-
-### 1. Build and install hydroxide
-
-As the service user:
-
-```bash
-sudo useradd -m -s /bin/bash proton
-sudo -u proton bash
-
-# Builds for whatever architecture you're on, including arm64 and armhf.
-git clone https://github.com/emersion/hydroxide.git
-cd hydroxide
-go build ./cmd/hydroxide
-sudo install -m 0755 hydroxide /usr/local/bin/
-```
-
-### 2. Generate a bridge password
-
-```bash
-hydroxide auth your-username@proton.me
-```
-
-Hydroxide prints a **32-byte bridge password** at the end. **Copy it now** — it's not stored anywhere recoverable. This password is what you'll give Permission Slip; your real Proton password is not.
-
-If you have 2FA enabled, pass the code with `-tfa-code <code>`.
-
-### 3. Run hydroxide under systemd (user unit)
-
-```bash
-mkdir -p ~/.config/systemd/user
-cat > ~/.config/systemd/user/hydroxide.service << 'EOF'
-[Unit]
-Description=Hydroxide Proton Mail IMAP/SMTP proxy
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/hydroxide serve
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-EOF
-
-loginctl enable-linger proton
-systemctl --user daemon-reload
-systemctl --user enable --now hydroxide.service
-systemctl --user status hydroxide.service
-```
-
-`hydroxide serve` starts SMTP on `1025`, IMAP on `1143`, and CardDAV on `8080` (the last is unused by Permission Slip).
-
 ## Configure credentials in Permission Slip
 
-Once your proxy (Bridge or hydroxide) is running, add **Proton Mail** credentials (`custom` auth) in the UI:
+Once Bridge is running, add **Proton Mail** credentials (`custom` auth) in the UI:
 
 | Field | Value |
 |-------|--------|
-| `username` | Your Proton address (as shown in Bridge or `hydroxide auth`) |
+| `username` | Your Proton address (as shown in Bridge) |
 | `password` | The bridge password — **not** your Proton account password |
 | `imap_host` / `imap_port` | Optional; default `127.0.0.1` / `1143` |
 | `smtp_host` / `smtp_port` | Optional; default `127.0.0.1` / `1025` |
 
-Saving credentials runs a real **IMAP LOGIN** against your proxy. The proxy must be running at save time.
-
-## Compatibility notes (hydroxide)
-
-Permission Slip's connector was originally written against Bridge. The protocol surface used by each action matches what hydroxide implements:
-
-| Action | Hydroxide status |
-|---|---|
-| `send_email` | Hydroxide's SMTP server on `127.0.0.1:1025` accepts PLAIN auth — matches our client (`connectors/protonmail/send_email.go`). |
-| `read_inbox`, `read_email` | `SELECT INBOX` + `FETCH` are supported by hydroxide's IMAP backend. |
-| `search_emails` | Hydroxide implements `SearchMessages` covering subject / from / date criteria. |
-| `archive_email` | Hydroxide exposes Proton's `LabelArchive` as the IMAP mailbox `"Archive"` — matches the literal in our archive action. IMAP MOVE is supported via `MoveMessages`. |
-
-Upstream still flags hydroxide's IMAP as "work-in-progress". If you hit an action that misbehaves with hydroxide but works with Bridge, please [open an issue](https://github.com/supersuit-tech/permission-slip/issues).
+Saving credentials runs a real **IMAP LOGIN** against Bridge. Bridge must be running at save time.
 
 ## Migrating from `permission-slip-proton`
 
@@ -196,11 +111,10 @@ If you previously used the external [permission-slip-proton](https://github.com/
 
 | Symptom | What to check |
 |---------|----------------|
-| Credential validation fails immediately | Proxy running? `systemctl --user status protonmail-bridge` (Bridge) or `systemctl --user status hydroxide` |
-| Auth / LOGIN errors | Username must match the proxy; password must be the bridge password, not your Proton account password |
-| Connection refused on 1143/1025 | Another process using the port, or the proxy bound to a different interface |
+| Credential validation fails immediately | Bridge running? `systemctl --user status protonmail-bridge` |
+| Auth / LOGIN errors | Username must match the address in Bridge; password must be the bridge password, not your Proton account password |
+| Connection refused on 1143/1025 | Another process using the port, or Bridge bound to a different interface |
 | Login loop in Bridge CLI | Clock skew, 2FA, or `pass` store not initialized |
-| `hydroxide auth` fails | Network issue, 2FA required (use `hydroxide auth -tfa-code <code>`), or clock skew |
-| Archive action fails | Proton's Archive folder must exist; both Bridge and hydroxide expose it as `"Archive"` |
+| Archive action fails | Proton's Archive folder must exist; Bridge exposes it as `"Archive"` |
 
 For general self-hosted setup (Tailscale, Google, Slack), see [Self-hosted deployment](../deployment-self-hosted.md).

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -254,15 +254,14 @@ When a user connects Slack from Permission Slip, they'll complete Slack's OAuth 
 
 ---
 
-## Email: Proton Mail (Bridge or hydroxide)
+## Email: Proton Mail (Bridge)
 
-Gmail is covered by the [Google connector](#step-5-connect-google) (OAuth). **Proton Mail** is a built-in connector that uses a local IMAP/SMTP proxy on the same machine as Permission Slip — there is no cloud OAuth flow. Two proxies are supported:
+Gmail is covered by the [Google connector](#step-5-connect-google) (OAuth). **Proton Mail** is a built-in connector that uses [Proton Mail Bridge](https://proton.me/mail/bridge) — Proton's official local IMAP/SMTP proxy — on the same machine as Permission Slip. There is no cloud OAuth flow.
 
-- **[Proton Mail Bridge](https://proton.me/mail/bridge)** — recommended on x86_64 Linux / macOS / Windows.
-- **[hydroxide](https://github.com/emersion/hydroxide)** — recommended on Raspberry Pi / ARM (Bridge has no ARM build).
+Bridge runs on x86_64 Linux, macOS, and Windows. Proton does not publish an ARM build, so Raspberry Pi and other ARM boards are not supported hosts for the Proton Mail connector. If you're on ARM, we recommend running Permission Slip on a small x86_64 mini PC with the specs you need.
 
-1. Install and run your chosen proxy headless (systemd user unit). Full steps for both: **[Proton Mail connector guide](connectors/protonmail.md)**.
-2. In the Permission Slip UI, add **Proton Mail** credentials with your Proton address and the bridge password printed by Bridge or `hydroxide auth`.
+1. Install and run Bridge headless (systemd user unit). Full steps: **[Proton Mail connector guide](connectors/protonmail.md)**.
+2. In the Permission Slip UI, add **Proton Mail** credentials with your Proton address and the bridge password printed by Bridge.
 3. Grant agent permissions using the Proton templates (send, read inbox, search, read message, archive).
 
 The proxy must be running when you save credentials; validation performs a real IMAP LOGIN.


### PR DESCRIPTION
## Summary

- Removes hydroxide as a documented Proton Mail proxy option. Proton Mail Bridge is now the only supported local proxy for the built-in Proton Mail connector.
- For users on Raspberry Pi or other ARM hardware (where Proton does not publish a Bridge build), the docs now recommend running Permission Slip on a small x86_64 mini PC with the specs they need — no brand named.
- Trims the comparison table, "Option B (hydroxide)" install steps, compatibility notes, and hydroxide-specific troubleshooting rows from the connector guide; simplifies the email section in the self-hosted deployment guide; updates the README index entry.

## Why

Hydroxide is a third-party reimplementation of Proton's auth/IMAP/SMTP surface and is self-described upstream as "casually maintained," with the IMAP backend still flagged as work-in-progress. For a connector that handles user mail and credentials, a single supported path (official Proton Bridge) is a safer default to recommend than an "ARM = use hydroxide" branch.

## Files changed

- `docs/connectors/protonmail.md` — single-path Bridge guide; new "Supported hosts" section instead of the ARM-skip warning.
- `docs/deployment-self-hosted.md` — email section is Bridge-only.
- `README.md` — connector index line simplified.

## Test plan

- [ ] CI passes (docs-only change; no code paths affected).
- [ ] `grep -rn hydroxide docs/ README.md` returns no matches.
- [ ] Render `docs/connectors/protonmail.md` and `docs/deployment-self-hosted.md` and confirm the install flow reads cleanly as a single Bridge path.

https://claude.ai/code/session_0128YEBytfJed4FUxs91MCEp

---
_Generated by [Claude Code](https://claude.ai/code/session_0128YEBytfJed4FUxs91MCEp)_