### PR TITLE
Fix auto-approve checkbox when no action configuration exists

### DIFF
--- a/api/approvals_test.go
+++ b/api/approvals_test.go
@@ -254,10 +254,7 @@ func TestListApprovals_ResponseShape(t *testing.T) {
 // ── Pagination ───────────────────────────────────────────────────────────────
 
 func TestListApprovals_Pagination(t *testing.T) {
-	t.Parallel()
-
 	t.Run("LimitParam", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
@@ -292,7 +289,6 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 
 	t.Run("CursorPagination", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
@@ -386,7 +382,6 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 
 	t.Run("InvalidLimit", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
@@ -408,7 +403,6 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 
 	t.Run("InvalidCursor", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
@@ -434,7 +428,6 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 
 	t.Run("DefaultLimit", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
@@ -469,7 +462,6 @@ func TestListApprovals_Pagination(t *testing.T) {
 	})
 
 	t.Run("EmptyPage", func(t *testing.T) {
-		t.Parallel()
 		tx := testhelper.SetupTestDB(t)
 		uid := testhelper.GenerateUID(t)
 		testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -49,7 +49,7 @@ type createStandingApprovalRequest struct {
 	ActionType                  string          `json:"action_type" validate:"required"`
 	ActionVersion               string          `json:"action_version"`
 	Constraints                 json.RawMessage `json:"constraints"`
-	SourceActionConfigurationID *string         `json:"source_action_configuration_id" validate:"required"`
+	SourceActionConfigurationID *string         `json:"source_action_configuration_id"`
 	StartsAt                    *time.Time      `json:"starts_at"`
 	ExpiresAt                   *time.Time      `json:"expires_at"`
 }
@@ -239,34 +239,6 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		sourceConfigID := strings.TrimSpace(*req.SourceActionConfigurationID)
-		if sourceConfigID == "" || len(sourceConfigID) > maxActionConfigIDLength {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id must be between 1 and 128 characters"))
-			return
-		}
-
-		ac, err := db.GetActionConfigByID(r.Context(), deps.DB, sourceConfigID, profile.ID)
-		if err != nil {
-			log.Printf("[%s] CreateStandingApproval: load action config: %v", TraceID(r.Context()), err)
-			CaptureError(r.Context(), err)
-			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
-			return
-		}
-		if ac == nil {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id must reference an existing action configuration"))
-			return
-		}
-		if ac.AgentID != req.AgentID {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action configuration does not belong to the specified agent"))
-			return
-		}
-		if ac.ActionType != req.ActionType {
-			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_type must match the referenced action configuration"))
-			return
-		}
-
-		sourceConfigIDPtr := sourceConfigID
-
 		var constraintsBytes []byte
 		if len(req.Constraints) > 0 {
 			s := strings.TrimSpace(string(req.Constraints))
@@ -311,6 +283,11 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			defer db.RollbackTx(r.Context(), tx)
 		}
 
+		sourceConfigIDPtr, ok := resolveSourceActionConfigForStandingApproval(w, r, tx, profile.ID, req)
+		if !ok {
+			return
+		}
+
 		sa, err := db.CreateStandingApproval(r.Context(), tx, db.CreateStandingApprovalParams{
 			StandingApprovalID:          saID,
 			AgentID:                     req.AgentID,
@@ -345,6 +322,139 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 
 		RespondJSON(w, http.StatusCreated, toStandingApprovalResponse(*sa))
 	}
+}
+
+const autoApprovedFromRequestConfigName = "Auto-approved from request"
+
+// resolveSourceActionConfigForStandingApproval validates an explicit source config
+// or auto-creates/reactivates a backing action configuration when omitted.
+// Returns the config ID and true on success; false if an HTTP error was written.
+func resolveSourceActionConfigForStandingApproval(
+	w http.ResponseWriter,
+	r *http.Request,
+	tx db.DBTX,
+	userID string,
+	req createStandingApprovalRequest,
+) (*string, bool) {
+	if req.SourceActionConfigurationID != nil {
+		sourceConfigID := strings.TrimSpace(*req.SourceActionConfigurationID)
+		if sourceConfigID == "" {
+			// Empty string is treated as omitted — fall through to auto-create.
+		} else {
+			if len(sourceConfigID) > maxActionConfigIDLength {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id must be between 1 and 128 characters"))
+				return nil, false
+			}
+
+			ac, err := db.GetActionConfigByID(r.Context(), tx, sourceConfigID, userID)
+			if err != nil {
+				log.Printf("[%s] CreateStandingApproval: load action config: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+				return nil, false
+			}
+			if ac == nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "source_action_configuration_id must reference an existing action configuration"))
+				return nil, false
+			}
+			if ac.AgentID != req.AgentID {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action configuration does not belong to the specified agent"))
+				return nil, false
+			}
+			if ac.ActionType != req.ActionType {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "action_type must match the referenced action configuration"))
+				return nil, false
+			}
+			return &sourceConfigID, true
+		}
+	}
+
+	existing, err := db.FindLatestActionConfigForAgentActionType(r.Context(), tx, req.AgentID, userID, req.ActionType)
+	if err != nil {
+		log.Printf("[%s] CreateStandingApproval: find backing action config: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+		return nil, false
+	}
+	if existing != nil {
+		if existing.Status == "active" {
+			id := existing.ID
+			return &id, true
+		}
+		if existing.Status == "disabled" {
+			active := "active"
+			updated, err := db.UpdateActionConfig(r.Context(), tx, db.UpdateActionConfigParams{
+				ID:     existing.ID,
+				UserID: userID,
+				Status: &active,
+			})
+			if err != nil {
+				log.Printf("[%s] CreateStandingApproval: reactivate action config: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+				return nil, false
+			}
+			id := updated.ID
+			return &id, true
+		}
+	}
+
+	connectorIDPtr := connectorIDFromActionType(req.ActionType)
+	if connectorIDPtr == nil {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "Cannot auto-create action configuration: action type has no connector prefix"))
+		return nil, false
+	}
+	connectorID := *connectorIDPtr
+
+	exists, err := db.ConnectorActionExists(r.Context(), tx, connectorID, req.ActionType)
+	if err != nil {
+		log.Printf("[%s] CreateStandingApproval: check connector action: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+		return nil, false
+	}
+	if !exists {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Cannot auto-create action configuration: action type is not registered for connector"))
+		return nil, false
+	}
+
+	configID, err := generatePrefixedID("ac_", 16)
+	if err != nil {
+		log.Printf("[%s] CreateStandingApproval: generate action config ID: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+		return nil, false
+	}
+
+	ac, err := db.CreateActionConfig(r.Context(), tx, db.CreateActionConfigParams{
+		ID:          configID,
+		AgentID:     req.AgentID,
+		UserID:      userID,
+		ConnectorID: connectorID,
+		ActionType:  req.ActionType,
+		Parameters:  []byte("{}"),
+		Name:        autoApprovedFromRequestConfigName,
+	})
+	if err != nil {
+		var acErr *db.ActionConfigError
+		if errors.As(err, &acErr) {
+			switch acErr.Code {
+			case db.ActionConfigErrAgentNotFound:
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrAgentNotFound, "Agent not found"))
+				return nil, false
+			case db.ActionConfigErrInvalidRef:
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidReference, "Cannot auto-create action configuration: invalid connector or action type reference"))
+				return nil, false
+			}
+		}
+		log.Printf("[%s] CreateStandingApproval: create backing action config: %v", TraceID(r.Context()), err)
+		CaptureError(r.Context(), err)
+		RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create standing approval"))
+		return nil, false
+	}
+
+	id := ac.ID
+	return &id, true
 }
 
 func handleRevokeStandingApproval(deps *Deps) http.HandlerFunc {

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -295,7 +295,7 @@ func handleCreateStandingApproval(deps *Deps) http.HandlerFunc {
 			ActionType:                  req.ActionType,
 			ActionVersion:               req.ActionVersion,
 			Constraints:                 constraintsBytes,
-			SourceActionConfigurationID: &sourceConfigIDPtr,
+			SourceActionConfigurationID: sourceConfigIDPtr,
 			StartsAt:                    startsAt,
 			ExpiresAt:                   req.ExpiresAt,
 		})

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -1102,11 +1102,11 @@ func TestCreateStandingApproval_SourceActionConfigWrongAgent(t *testing.T) {
 // standingApprovalTestConnectorOnly inserts connector + action rows without an action_configuration.
 func standingApprovalTestConnectorOnly(t *testing.T, tx db.DBTX, actionType string) {
 	t.Helper()
-	safe := strings.ReplaceAll(strings.ReplaceAll(actionType, ".", "_"), "*", "wildcard")
-	connectorID := "tconn_" + safe
-	if len(connectorID) > 200 {
-		connectorID = connectorID[:200]
+	connectorIDPtr := connectorIDFromActionType(actionType)
+	if connectorIDPtr == nil {
+		t.Fatalf("action type %q has no connector prefix", actionType)
 	}
+	connectorID := *connectorIDPtr
 	testhelper.InsertConnector(t, tx, connectorID)
 	testhelper.InsertConnectorAction(t, tx, connectorID, actionType, actionType)
 }
@@ -1498,7 +1498,7 @@ func TestCreateStandingApproval_AutoCreateReactivatesDisabledConfig(t *testing.T
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
 	standingApprovalTestConnectorOnly(t, tx, "email.send")
 	acID := testhelper.GenerateID(t, "ac_")
-	testhelper.InsertActionConfigFull(t, tx, acID, agentID, uid, "tconn_email_send", "email.send", testhelper.ActionConfigOpts{
+	testhelper.InsertActionConfigFull(t, tx, acID, agentID, uid, "email", "email.send", testhelper.ActionConfigOpts{
 		Status: "disabled",
 	})
 

--- a/api/standing_approvals_test.go
+++ b/api/standing_approvals_test.go
@@ -1028,6 +1028,7 @@ func TestCreateStandingApproval_MissingSourceActionConfigurationID(t *testing.T)
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	standingApprovalTestConnectorOnly(t, tx, "email.send")
 
 	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -1042,8 +1043,30 @@ func TestCreateStandingApproval_MissingSourceActionConfigurationID(t *testing.T)
 	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp standingApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.SourceActionConfigurationID == nil || *resp.SourceActionConfigurationID == "" {
+		t.Fatal("expected auto-created source_action_configuration_id")
+	}
+
+	configs, err := db.ListActionConfigsByAgent(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("ListActionConfigsByAgent: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 auto-created action config, got %d", len(configs))
+	}
+	if configs[0].Status != "active" {
+		t.Errorf("expected auto-created config status active, got %q", configs[0].Status)
+	}
+	if configs[0].Name != autoApprovedFromRequestConfigName {
+		t.Errorf("expected config name %q, got %q", autoApprovedFromRequestConfigName, configs[0].Name)
 	}
 }
 
@@ -1076,11 +1099,24 @@ func TestCreateStandingApproval_SourceActionConfigWrongAgent(t *testing.T) {
 	}
 }
 
+// standingApprovalTestConnectorOnly inserts connector + action rows without an action_configuration.
+func standingApprovalTestConnectorOnly(t *testing.T, tx db.DBTX, actionType string) {
+	t.Helper()
+	safe := strings.ReplaceAll(strings.ReplaceAll(actionType, ".", "_"), "*", "wildcard")
+	connectorID := "tconn_" + safe
+	if len(connectorID) > 200 {
+		connectorID = connectorID[:200]
+	}
+	testhelper.InsertConnector(t, tx, connectorID)
+	testhelper.InsertConnectorAction(t, tx, connectorID, actionType, actionType)
+}
+
 func TestCreateStandingApproval_SourceActionConfigIDEmpty(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	standingApprovalTestConnectorOnly(t, tx, "email.send")
 
 	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
 	router := NewRouter(deps)
@@ -1099,8 +1135,8 @@ func TestCreateStandingApproval_SourceActionConfigIDEmpty(t *testing.T) {
 
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -1411,5 +1447,123 @@ func TestCreateStandingApproval_BareStringPatternAutoWrapped(t *testing.T) {
 	bodyConstraint, ok := constraintsMap["body"].(string)
 	if !ok || bodyConstraint != "*" {
 		t.Errorf("expected body constraint to remain \"*\", got %v", constraintsMap["body"])
+	}
+}
+
+func TestCreateStandingApproval_AutoCreateReusesActiveConfig(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	acID := standingApprovalTestConfigID(t, tx, agentID, uid, "email.send")
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "email.send",
+		"constraints": {"to": "user@example.com"},
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp standingApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.SourceActionConfigurationID == nil || *resp.SourceActionConfigurationID != acID {
+		t.Errorf("expected reused config %q, got %v", acID, resp.SourceActionConfigurationID)
+	}
+
+	configs, err := db.ListActionConfigsByAgent(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("ListActionConfigsByAgent: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 action config (no duplicate), got %d", len(configs))
+	}
+}
+
+func TestCreateStandingApproval_AutoCreateReactivatesDisabledConfig(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	standingApprovalTestConnectorOnly(t, tx, "email.send")
+	acID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, acID, agentID, uid, "tconn_email_send", "email.send", testhelper.ActionConfigOpts{
+		Status: "disabled",
+	})
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "email.send",
+		"constraints": {"to": "user@example.com"},
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp standingApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.SourceActionConfigurationID == nil || *resp.SourceActionConfigurationID != acID {
+		t.Errorf("expected reactivated config %q, got %v", acID, resp.SourceActionConfigurationID)
+	}
+
+	ac, err := db.GetActionConfigByID(t.Context(), tx, acID, uid)
+	if err != nil {
+		t.Fatalf("GetActionConfigByID: %v", err)
+	}
+	if ac == nil || ac.Status != "active" {
+		t.Errorf("expected config reactivated to active, got %+v", ac)
+	}
+
+	configs, err := db.ListActionConfigsByAgent(t.Context(), tx, agentID, uid)
+	if err != nil {
+		t.Fatalf("ListActionConfigsByAgent: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 action config (no duplicate), got %d", len(configs))
+	}
+}
+
+func TestCreateStandingApproval_AutoCreateUnderivableConnector(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`{
+		"agent_id": %d,
+		"action_type": "malformed_action_type",
+		"constraints": {"to": "user@example.com"},
+		"expires_at": "%s"
+	}`, agentID, expiresAt)
+	r := authenticatedJSONRequest(t, http.MethodPost, "/standing-approvals/create", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/db/action_configurations.go
+++ b/db/action_configurations.go
@@ -1,11 +1,10 @@
 package db
 
 import (
-	"database/sql"
 	"context"
+	"database/sql"
 	"errors"
 	"time"
-
 )
 
 // ActionConfiguration represents a row from the action_configurations table.
@@ -257,6 +256,29 @@ func DeleteActionConfig(ctx context.Context, db DBTX, configID, userID string) (
 // execution time, but standing approvals still gate actual execution
 // per-action-type.
 const WildcardActionType = "*"
+
+// FindLatestActionConfigForAgentActionType returns the best matching action
+// configuration for the given agent, user, and action type. Active configs
+// are preferred over disabled; among equal status, the newest wins.
+func FindLatestActionConfigForAgentActionType(ctx context.Context, db DBTX, agentID int64, userID, actionType string) (*ActionConfiguration, error) {
+	row := db.QueryRow(ctx,
+		`SELECT `+actionConfigColumns+`
+		 FROM action_configurations
+		 WHERE agent_id = $1 AND user_id = $2 AND action_type = $3
+		 ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'disabled' THEN 1 ELSE 2 END,
+		          created_at DESC
+		 LIMIT 1`,
+		agentID, userID, actionType,
+	)
+	ac, err := scanActionConfig(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ac, nil
+}
 
 // ConnectorActionExists checks whether a (connector_id, action_type) pair
 // exists in the connector_actions table. Used to validate non-wildcard

--- a/db/approvals_test.go
+++ b/db/approvals_test.go
@@ -115,7 +115,6 @@ func TestRequestIdCascadeDeleteOnAgentDelete(t *testing.T) {
 }
 
 func TestListApprovalsByApproverPaginated(t *testing.T) {
-	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
@@ -189,7 +188,6 @@ func TestListApprovalsByApproverPaginated(t *testing.T) {
 }
 
 func TestListApprovalsByApproverPaginated_DuplicateTimestamps(t *testing.T) {
-	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
@@ -246,7 +244,6 @@ func TestListApprovalsByApproverPaginated_DuplicateTimestamps(t *testing.T) {
 }
 
 func TestListApprovalsByApproverPaginated_StatusFilters(t *testing.T) {
-	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -140,7 +140,7 @@ export function ReviewApprovalDialog({
   const isBusy = pendingAction !== null || isDenying;
 
   const { standingApprovals, isLoading: standingApprovalsLoading } = useStandingApprovals();
-  const { configs, isFetched: configsFetched } = useActionConfigs(approval.agent_id);
+  const { configs } = useActionConfigs(approval.agent_id);
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
   const hasExistingStandingApproval = useMemo(
@@ -188,26 +188,20 @@ export function ReviewApprovalDialog({
       setApproveResult(result);
 
       if (autoApproveFuture && result.execution_status !== "error") {
-        if (!configsFetched || !matchingActionConfig) {
-          toast.error(
-            "Request approved, but no action configuration was found to enable auto-approval.",
+        try {
+          await createStandingApproval(
+            buildCreateStandingApprovalFromApproval(
+              approval,
+              matchingActionConfig?.id,
+            ),
           );
-        } else {
-          try {
-            await createStandingApproval(
-              buildCreateStandingApprovalFromApproval(
-                approval,
-                matchingActionConfig.id,
-              ),
-            );
-            setStandingApprovalCreated(true);
-          } catch (err) {
-            toast.error(
-              err instanceof Error
-                ? err.message
-                : "Request approved, but failed to create auto-approval rule.",
-            );
-          }
+          setStandingApprovalCreated(true);
+        } catch (err) {
+          toast.error(
+            err instanceof Error
+              ? err.message
+              : "Request approved, but failed to create auto-approval rule.",
+          );
         }
       }
     } catch {
@@ -219,7 +213,6 @@ export function ReviewApprovalDialog({
     approveApproval,
     approval,
     autoApproveFuture,
-    configsFetched,
     matchingActionConfig,
     createStandingApproval,
   ]);

--- a/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/ReviewApprovalDialog.test.tsx
@@ -233,6 +233,66 @@ describe("ReviewApprovalDialog — auto-approve future requests", () => {
     ).toBeInTheDocument();
   });
 
+  it("creates standing approval without config id when no action configuration exists", async () => {
+    setupMocks({ actionConfigs: [] });
+    mockApproveSuccess();
+    mockPost.mockResolvedValueOnce({
+      data: {
+        standing_approval_id: "sa_new",
+        agent_id: 1,
+        action_type: "email.send",
+        status: "active",
+      },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ReviewApprovalDialog
+        approval={makeApproval()}
+        agentDisplayName="Test Bot"
+        open={true}
+        onOpenChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    await settleAuthHydration();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Auto-approve all future requests like this"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByLabelText("Auto-approve all future requests like this"),
+    );
+    await user.click(screen.getByText("Approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Action Executed Successfully")).toBeInTheDocument();
+    });
+
+    const createCall = mockPost.mock.calls.find(
+      (call) => call[0] === "/v1/standing-approvals/create",
+    );
+    expect(createCall).toBeDefined();
+    expect(createCall?.[1]?.body).toMatchObject({
+      agent_id: 1,
+      action_type: "email.send",
+      constraints: {
+        recipient: "user@example.com",
+        subject: "Hello",
+      },
+      expires_at: null,
+    });
+    expect(createCall?.[1]?.body).not.toHaveProperty("source_action_configuration_id");
+
+    expect(
+      screen.getByText("Future matching requests will be auto-approved."),
+    ).toBeInTheDocument();
+  });
+
   it("standing approval failure does not block approve from succeeding", async () => {
     setupMocks();
     mockApproveSuccess();

--- a/frontend/src/pages/dashboard/standingApprovalFromApproval.ts
+++ b/frontend/src/pages/dashboard/standingApprovalFromApproval.ts
@@ -31,7 +31,7 @@ export function standingApprovalConstraintsForCreate(
 
 export function buildCreateStandingApprovalFromApproval(
   approval: ApprovalSummary,
-  sourceActionConfigurationId: string,
+  sourceActionConfigurationId?: string,
 ): CreateStandingApprovalRequest {
   const params = approval.action.parameters as Record<string, unknown>;
   const version =
@@ -39,12 +39,17 @@ export function buildCreateStandingApprovalFromApproval(
       ? approval.action.version
       : "1";
 
-  return {
+  const request: CreateStandingApprovalRequest = {
     agent_id: approval.agent_id,
     action_type: approval.action.type,
     action_version: version,
     constraints: standingApprovalConstraintsForCreate(params),
-    source_action_configuration_id: sourceActionConfigurationId,
     expires_at: null,
   };
+
+  if (sourceActionConfigurationId !== undefined) {
+    request.source_action_configuration_id = sourceActionConfigurationId;
+  }
+
+  return request;
 }

--- a/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalDetailScreen.tsx
@@ -82,7 +82,7 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
   const { standingApprovals, isLoading: standingApprovalsLoading } =
     useStandingApprovals();
   const { createStandingApproval } = useCreateStandingApproval();
-  const { configs, isFetched: configsFetched } = useActionConfigs(
+  const { configs } = useActionConfigs(
     approval.agent_id,
   );
 
@@ -201,27 +201,20 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
       if (autoApproveFuture) {
-        if (!configsFetched || !matchingActionConfig) {
-          Alert.alert(
-            "Auto-approval not set up",
-            "Request approved, but no action configuration was found to enable auto-approval.",
+        try {
+          await createStandingApproval(
+            buildCreateStandingApprovalFromApproval(
+              approval,
+              matchingActionConfig?.id,
+            ),
           );
-        } else {
-          try {
-            await createStandingApproval(
-              buildCreateStandingApprovalFromApproval(
-                approval,
-                matchingActionConfig.id,
-              ),
-            );
-            setStandingApprovalCreated(true);
-          } catch (err) {
-            const message =
-              err instanceof Error
-                ? err.message
-                : "Failed to create auto-approval rule.";
-            Alert.alert("Auto-approval failed", message);
-          }
+          setStandingApprovalCreated(true);
+        } catch (err) {
+          const message =
+            err instanceof Error
+              ? err.message
+              : "Failed to create auto-approval rule.";
+          Alert.alert("Auto-approval failed", message);
         }
       }
     } catch (err) {
@@ -234,7 +227,6 @@ export default function ApprovalDetailScreen({ route, navigation }: Props) {
     approveApproval,
     approval,
     autoApproveFuture,
-    configsFetched,
     matchingActionConfig,
     createStandingApproval,
   ]);

--- a/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
+++ b/mobile/src/screens/approvals/__tests__/ApprovalDetailScreen.test.tsx
@@ -9,6 +9,17 @@ import { makeApproval, MOCK_AGENTS, mockGetAgentDisplayName } from "../testFixtu
 const mockApproveApproval = jest.fn();
 const mockDenyApproval = jest.fn();
 const mockCreateStandingApproval = jest.fn();
+let mockActionConfigs = [
+  {
+    id: "ac_config1",
+    agent_id: 42,
+    connector_id: "email",
+    action_type: "email.send",
+    status: "active",
+    name: "Send",
+    parameters: {},
+  },
+];
 
 jest.mock("../../../hooks/useApproveApproval", () => ({
   useApproveApproval: () => ({
@@ -44,17 +55,7 @@ jest.mock("../../../hooks/useCreateStandingApproval", () => ({
 
 jest.mock("../../../hooks/useActionConfigs", () => ({
   useActionConfigs: () => ({
-    configs: [
-      {
-        id: "ac_config1",
-        agent_id: 42,
-        connector_id: "email",
-        action_type: "email.send",
-        status: "active",
-        name: "Send",
-        parameters: {},
-      },
-    ],
+    configs: mockActionConfigs,
     isLoading: false,
     isFetched: true,
   }),
@@ -116,6 +117,17 @@ describe("ApprovalDetailScreen", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
+    mockActionConfigs = [
+      {
+        id: "ac_config1",
+        agent_id: 42,
+        connector_id: "email",
+        action_type: "email.send",
+        status: "active",
+        name: "Send",
+        parameters: {},
+      },
+    ];
   });
 
   afterEach(async () => {
@@ -537,6 +549,44 @@ describe("ApprovalDetailScreen", () => {
         action_type: "email.send",
         source_action_configuration_id: "ac_config1",
         expires_at: null,
+      }),
+    );
+    expect(hasTestId(renderer, "standing-approval-success")).toBe(true);
+  });
+
+  it("creates standing approval without config id when no action configuration exists", async () => {
+    mockActionConfigs = [];
+    mockApproveApproval.mockResolvedValueOnce({
+      approval_id: "appr_test123",
+      status: "approved",
+      approved_at: new Date().toISOString(),
+    });
+    mockCreateStandingApproval.mockResolvedValueOnce({
+      standing_approval_id: "sa_new",
+    });
+
+    const approval = makeApproval();
+    await act(async () => {
+      renderer = renderDetail(approval);
+    });
+
+    const checkbox = findFirstByTestId(renderer, "auto-approve-checkbox");
+    await act(async () => {
+      checkbox?.props.onPress();
+    });
+
+    const approveButton = findFirstByTestId(renderer, "approve-button");
+    await act(async () => {
+      approveButton?.props.onPress();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockCreateStandingApproval).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        source_action_configuration_id: expect.anything(),
       }),
     );
     expect(hasTestId(renderer, "standing-approval-success")).toBe(true);

--- a/mobile/src/screens/approvals/standingApprovalFromApproval.ts
+++ b/mobile/src/screens/approvals/standingApprovalFromApproval.ts
@@ -26,7 +26,7 @@ function standingApprovalConstraintsForCreate(
 
 export function buildCreateStandingApprovalFromApproval(
   approval: ApprovalSummary,
-  sourceActionConfigurationId: string,
+  sourceActionConfigurationId?: string,
 ): CreateStandingApprovalRequest {
   const params = approval.action.parameters as Record<string, unknown>;
   const version =
@@ -34,12 +34,17 @@ export function buildCreateStandingApprovalFromApproval(
       ? approval.action.version
       : "1";
 
-  return {
+  const request: CreateStandingApprovalRequest = {
     agent_id: approval.agent_id,
     action_type: approval.action.type,
     action_version: version,
     constraints: standingApprovalConstraintsForCreate(params),
-    source_action_configuration_id: sourceActionConfigurationId,
     expires_at: null,
   };
+
+  if (sourceActionConfigurationId !== undefined) {
+    request.source_action_configuration_id = sourceActionConfigurationId;
+  }
+
+  return request;
 }

--- a/spec/openapi/components/schemas/standing_approvals.yaml
+++ b/spec/openapi/components/schemas/standing_approvals.yaml
@@ -240,7 +240,6 @@ CreateStandingApprovalRequest:
     - agent_id
     - action_type
     - constraints
-    - source_action_configuration_id
   properties:
     agent_id:
       type: integer
@@ -282,9 +281,13 @@ CreateStandingApprovalRequest:
       minLength: 1
       maxLength: 128
       description: |
-        Action configuration this standing approval is created from. Must exist,
-        belong to the same `agent_id`, and have the same `action_type` as the request.
-        Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
+        Action configuration this standing approval is created from. When omitted,
+        the backend auto-creates or reactivates a backing configuration for the
+        agent and action type.
+
+        When provided, the configuration must exist, belong to the same `agent_id`,
+        and have the same `action_type` as the request. Expected format: `ac_` prefix
+        followed by 32 hex characters (e.g.,
         `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
         enforce the pattern — only non-empty and max 128 characters.
       example: "ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -8080,7 +8080,6 @@ components:
         - agent_id
         - action_type
         - constraints
-        - source_action_configuration_id
       properties:
         agent_id:
           type: integer
@@ -8118,9 +8117,13 @@ components:
           minLength: 1
           maxLength: 128
           description: |
-            Action configuration this standing approval is created from. Must exist,
-            belong to the same `agent_id`, and have the same `action_type` as the request.
-            Expected format: `ac_` prefix followed by 32 hex characters (e.g.,
+            Action configuration this standing approval is created from. When omitted,
+            the backend auto-creates or reactivates a backing configuration for the
+            agent and action type.
+
+            When provided, the configuration must exist, belong to the same `agent_id`,
+            and have the same `action_type` as the request. Expected format: `ac_` prefix
+            followed by 32 hex characters (e.g.,
             `ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`), but the backend does not
             enforce the pattern — only non-empty and max 128 characters.
           example: ac_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the "Auto-approval not set up" dead-end when users tick **Auto-approve all future requests like this** during approval but no active `action_configuration` exists for that agent + action type.

Closes #1284

## Changes

**Backend**
- Make `source_action_configuration_id` optional on `POST /standing-approvals/create`
- When omitted, auto-create or reactivate a backing `action_configuration` in the same transaction (reuse active, reactivate disabled, create new with `{}` parameters)
- Return `400` when the connector cannot be derived or the action type is not registered

**Clients (web + mobile)**
- Omit `source_action_configuration_id` when no active matching config is found; backend handles auto-create
- Still pass the config id when an active match exists (avoids extra lookup)

**Spec**
- Updated OpenAPI schema and regenerated bundled spec

## Test plan

- [x] Frontend: `ReviewApprovalDialog` tests pass (including no-config opt-in path)
- [x] Mobile: `ApprovalDetailScreen` tests pass (including no-config opt-in path)
- [ ] Backend: `api/standing_approvals_test.go` (CI — not run locally due to sandbox Go 1.25 constraint)
- [ ] Manual: approve a request with auto-approve checked when no action config exists; confirm success banner and standing approval created

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0791f4c2-844d-4915-b44e-24695ae87e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0791f4c2-844d-4915-b44e-24695ae87e8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

