### PR TITLE
Prevent infinite agent loops on denied approvals

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -40,9 +40,14 @@ type agentRequestApprovalResponse struct {
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	CreatedAt   *time.Time `json:"created_at,omitempty"`
 
-	// ── Common field ──
+	// ── Common fields ──
 	// "pending" = awaiting human approval; "approved" = auto-approved via standing approval.
 	Status string `json:"status"`
+
+	// terminal is true when the approval lifecycle is complete (approved, denied, etc.).
+	Terminal bool `json:"terminal"`
+	// retryable is false for all approval outcomes — agents must not blindly re-request.
+	Retryable bool `json:"retryable"`
 
 	// ── Auto-approved fields (status="approved") ──
 	// Present only when a standing approval matched and the action was
@@ -247,6 +252,18 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
+		actionFingerprint := db.ComputeActionFingerprint(agent.AgentID, agent.ApproverID, req.Action)
+		cooldownSince := time.Now().UTC().Add(-approvalDenialCooldown(deps))
+		if recentDenied, err := db.FindRecentDeniedApproval(r.Context(), deps.DB, agent.AgentID, agent.ApproverID, actionFingerprint, cooldownSince); err != nil {
+			log.Printf("[%s] AgentRequestApproval: recent denial lookup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create approval"))
+			return
+		} else if recentDenied != nil {
+			respondRecentlyDeniedApproval(w, r, recentDenied)
+			return
+		}
+
 		// Compute expiration.
 		expiresAt := time.Now().UTC().Add(db.DefaultApprovalTTL)
 		if req.ExpiresIn != nil {
@@ -303,13 +320,14 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 		)
 
 		approval, err := db.InsertApproval(r.Context(), deps.DB, db.InsertApprovalParams{
-			ApprovalID:      approvalID,
-			AgentID:         agent.AgentID,
-			ApproverID:      agent.ApproverID,
-			Action:          req.Action,
-			Context:         contextForStore,
-			ResourceDetails: resourceDetails,
-			ExpiresAt:       expiresAt,
+			ApprovalID:        approvalID,
+			AgentID:           agent.AgentID,
+			ApproverID:        agent.ApproverID,
+			Action:            req.Action,
+			Context:           contextForStore,
+			ResourceDetails:   resourceDetails,
+			ActionFingerprint: actionFingerprint,
+			ExpiresAt:         expiresAt,
 		}, req.RequestID)
 		if err != nil {
 			var apprErr *db.ApprovalError
@@ -343,6 +361,8 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 			ApprovalID:  approval.ApprovalID,
 			ApprovalURL: approvalURL,
 			Status:      approval.Status,
+			Terminal:    false,
+			Retryable:   false,
 			ExpiresAt:   &approval.ExpiresAt,
 			CreatedAt:   &approval.CreatedAt,
 		})
@@ -391,6 +411,9 @@ func handleAgentCancelApproval(deps *Deps) http.HandlerFunc {
 type agentApprovalStatusResponse struct {
 	ApprovalID      string           `json:"approval_id"`
 	Status          string           `json:"status"`
+	Terminal        bool             `json:"terminal"`
+	Retryable       bool             `json:"retryable"`
+	Reason          *string          `json:"reason,omitempty"`
 	ExecutionStatus *string          `json:"execution_status,omitempty"`
 	ExecutionResult *json.RawMessage `json:"execution_result,omitempty"`
 	ExpiresAt       time.Time        `json:"expires_at"`
@@ -419,21 +442,7 @@ func handleAgentApprovalStatus(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		resp := agentApprovalStatusResponse{
-			ApprovalID: appr.ApprovalID,
-			Status:     resolvedApprovalStatus(*appr),
-			ExpiresAt:  appr.ExpiresAt,
-			CreatedAt:  appr.CreatedAt,
-		}
-		if appr.ExecutionStatus != nil {
-			resp.ExecutionStatus = appr.ExecutionStatus
-		}
-		if len(appr.ExecutionResult) > 0 {
-			raw := json.RawMessage(appr.ExecutionResult)
-			resp.ExecutionResult = &raw
-		}
-
-		RespondJSON(w, http.StatusOK, resp)
+		respondAgentApprovalStatus(w, r, appr)
 	}
 }
 
@@ -442,6 +451,13 @@ func handleAgentApprovalStatus(deps *Deps) http.HandlerFunc {
 // handleAgentApprovalError is an alias for the shared handleApprovalError
 // in approvals.go. Both dashboard and agent endpoints use the same mapping.
 var handleAgentApprovalError = handleApprovalError
+
+func approvalDenialCooldown(deps *Deps) time.Duration {
+	if deps.ApprovalDenialCooldown > 0 {
+		return deps.ApprovalDenialCooldown
+	}
+	return db.DefaultDenialCooldown
+}
 
 // resolveCredentialsForResolver is a best-effort credential resolver for the
 // ResourceDetailResolver call. It mirrors the credential resolution logic from

--- a/api/agent_approvals_test.go
+++ b/api/agent_approvals_test.go
@@ -64,6 +64,12 @@ func TestAgentRequestApproval_Success(t *testing.T) {
 	if resp.Status != "pending" {
 		t.Errorf("expected status 'pending', got %q", resp.Status)
 	}
+	if resp.Terminal {
+		t.Error("expected terminal=false for pending approval")
+	}
+	if resp.Retryable {
+		t.Error("expected retryable=false for pending approval")
+	}
 	if resp.ExpiresAt.IsZero() {
 		t.Error("expected expires_at to be set")
 	}
@@ -727,6 +733,12 @@ func TestAgentApprovalStatus_Pending(t *testing.T) {
 	if statusResp.Status != "pending" {
 		t.Errorf("expected status 'pending', got %q", statusResp.Status)
 	}
+	if statusResp.Terminal {
+		t.Error("expected terminal=false for pending status")
+	}
+	if statusResp.Retryable {
+		t.Error("expected retryable=false for pending status")
+	}
 	if statusResp.ExecutionStatus != nil {
 		t.Errorf("expected nil execution_status for pending approval, got %v", *statusResp.ExecutionStatus)
 	}
@@ -776,6 +788,12 @@ func TestAgentApprovalStatus_ApprovedWithExecution(t *testing.T) {
 	if statusResp.Status != "approved" {
 		t.Errorf("expected status 'approved', got %q", statusResp.Status)
 	}
+	if !statusResp.Terminal {
+		t.Error("expected terminal=true for approved status")
+	}
+	if statusResp.Retryable {
+		t.Error("expected retryable=false for approved status")
+	}
 	if statusResp.ExecutionStatus == nil || *statusResp.ExecutionStatus != "success" {
 		t.Errorf("expected execution_status 'success', got %v", statusResp.ExecutionStatus)
 	}
@@ -821,7 +839,7 @@ func TestAgentApprovalStatus_Denied(t *testing.T) {
 	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
 
 	approvalID := "appr_status_denied"
-	testhelper.InsertApprovalWithStatus(t, tx, approvalID, agentID, uid, "denied")
+	testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "denied")
 
 	deps := testDepsForDB(t, tx)
 	router := NewRouter(deps)
@@ -830,22 +848,207 @@ func TestAgentApprovalStatus_Denied(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status: expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: expected 409, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var statusResp agentApprovalStatusResponse
-	if err := json.Unmarshal(w.Body.Bytes(), &statusResp); err != nil {
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if statusResp.Status != "denied" {
-		t.Errorf("expected status 'denied', got %q", statusResp.Status)
+	if errResp.Error.Code != ErrApprovalDenied {
+		t.Errorf("expected error code %q, got %q", ErrApprovalDenied, errResp.Error.Code)
 	}
-	if statusResp.ExecutionStatus != nil {
-		t.Errorf("expected nil execution_status for denied approval, got %v", *statusResp.ExecutionStatus)
+	if errResp.Error.Retryable {
+		t.Error("expected retryable=false for denied approval")
 	}
-	if statusResp.ExecutionResult != nil {
-		t.Error("expected nil execution_result for denied approval")
+	if errResp.Error.Details["status"] != "denied" {
+		t.Errorf("expected details.status denied, got %v", errResp.Error.Details["status"])
+	}
+}
+
+func TestAgentApprovalStatus_DeniedWithReason(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	approvalID := "appr_status_denied_reason"
+	action := []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`)
+	fingerprint := db.ComputeActionFingerprint(agentID, uid, action)
+	_, err = tx.Exec(context.Background(),
+		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, status, action_fingerprint, expires_at, denied_at, denial_reason)
+		 VALUES ($1, $2, $3, $4, '{"description":"test"}', 'denied', $5, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+1 hour'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), $6)`,
+		approvalID, agentID, uid, action, fingerprint, "Recipient not authorized",
+	)
+	if err != nil {
+		t.Fatalf("insert denied approval: %v", err)
+	}
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	r := signedJSONRequest(t, http.MethodGet, "/approvals/"+approvalID+"/status", "", privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Details["reason"] != "Recipient not authorized" {
+		t.Errorf("expected denial reason in details, got %v", errResp.Error.Details["reason"])
+	}
+}
+
+func TestAgentApprovalStatus_Expired(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	approvalID := "appr_status_expired"
+	testhelper.InsertApprovalWithExpiresAt(t, tx, approvalID, agentID, uid, time.Now().Add(-time.Hour))
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	r := signedJSONRequest(t, http.MethodGet, "/approvals/"+approvalID+"/status", "", privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("status: expected 410, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Code != ErrApprovalExpired {
+		t.Errorf("expected error code %q, got %q", ErrApprovalExpired, errResp.Error.Code)
+	}
+}
+
+func TestAgentApprovalStatus_Cancelled(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	approvalID := "appr_status_cancelled"
+	testhelper.InsertResolvedApproval(t, tx, approvalID, agentID, uid, "cancelled")
+
+	deps := testDepsForDB(t, tx)
+	router := NewRouter(deps)
+
+	r := signedJSONRequest(t, http.MethodGet, "/approvals/"+approvalID+"/status", "", privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status: expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if errResp.Error.Code != ErrApprovalCancelled {
+		t.Errorf("expected error code %q, got %q", ErrApprovalCancelled, errResp.Error.Code)
+	}
+}
+
+func TestAgentRequestApproval_RecentlyDeniedShortCircuited(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	deps := &Deps{
+		DB:                     tx,
+		JWTSigningSecret:       testJWTSecret,
+		ApprovalDenialCooldown: time.Hour,
+	}
+	router := NewRouter(deps)
+
+	reqBody := `{"request_id":"req_dedup_1","action":{"type":"email.send","parameters":{"to":"alice@example.com"}},"context":{"description":"Send email"}}`
+	r1 := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w1 := httptest.NewRecorder()
+	router.ServeHTTP(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("request: expected 200, got %d: %s", w1.Code, w1.Body.String())
+	}
+	var createResp agentRequestApprovalResponse
+	if err := json.Unmarshal(w1.Body.Bytes(), &createResp); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+
+	denyBody := `{"reason":"Not authorized"}`
+	rDeny := authenticatedJSONRequest(t, http.MethodPost, "/approvals/"+createResp.ApprovalID+"/deny", uid, denyBody)
+	wDeny := httptest.NewRecorder()
+	router.ServeHTTP(wDeny, rDeny)
+	if wDeny.Code != http.StatusOK {
+		t.Fatalf("deny: expected 200, got %d: %s", wDeny.Code, wDeny.Body.String())
+	}
+
+	reqBody2 := `{"request_id":"req_dedup_2","action":{"type":"email.send","parameters":{"to":"alice@example.com"}},"context":{"description":"Send email"}}`
+	r2 := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody2, privKey, agentID)
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, r2)
+
+	if w2.Code != http.StatusConflict {
+		t.Fatalf("re-request: expected 409, got %d: %s", w2.Code, w2.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if errResp.Error.Code != ErrApprovalRecentlyDenied {
+		t.Errorf("expected error code %q, got %q", ErrApprovalRecentlyDenied, errResp.Error.Code)
+	}
+	if errResp.Error.Details["approval_id"] != createResp.ApprovalID {
+		t.Errorf("expected original approval_id in details, got %v", errResp.Error.Details["approval_id"])
+	}
+
+	var pendingCount int
+	if err := tx.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM approvals WHERE agent_id = $1 AND status = 'pending'`,
+		agentID,
+	).Scan(&pendingCount); err != nil {
+		t.Fatalf("count pending approvals: %v", err)
+	}
+	if pendingCount != 0 {
+		t.Errorf("expected 0 pending approvals after dedup short-circuit, got %d", pendingCount)
 	}
 }
 

--- a/api/approval_agent_status.go
+++ b/api/approval_agent_status.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// approvalStateFlags describes whether an approval status is terminal and
+// whether an agent should retry the request.
+func approvalStateFlags(status string) (terminal, retryable bool) {
+	switch status {
+	case "pending":
+		return false, false
+	case "approved":
+		return true, false
+	case "denied", "cancelled", "expired":
+		return true, false
+	default:
+		return true, false
+	}
+}
+
+func respondAgentApprovalStatus(w http.ResponseWriter, r *http.Request, appr *db.Approval) {
+	status := resolvedApprovalStatus(*appr)
+
+	switch status {
+	case "denied":
+		resp := Conflict(ErrApprovalDenied, "Approval was denied by the approver")
+		resp.Error.Details = terminalApprovalErrorDetails(appr, status)
+		RespondError(w, r, http.StatusConflict, resp)
+		return
+	case "expired":
+		resp := Gone(ErrApprovalExpired, "Approval has expired")
+		resp.Error.Details = terminalApprovalErrorDetails(appr, status)
+		RespondError(w, r, http.StatusGone, resp)
+		return
+	case "cancelled":
+		resp := Conflict(ErrApprovalCancelled, "Approval was cancelled")
+		resp.Error.Details = terminalApprovalErrorDetails(appr, status)
+		RespondError(w, r, http.StatusConflict, resp)
+		return
+	}
+
+	terminal, retryable := approvalStateFlags(status)
+	resp := buildAgentApprovalStatusResponse(appr, status, terminal, retryable)
+	RespondJSON(w, http.StatusOK, resp)
+}
+
+func respondRecentlyDeniedApproval(w http.ResponseWriter, r *http.Request, appr *db.Approval) {
+	resp := Conflict(ErrApprovalRecentlyDenied, "This action was recently denied; do not retry without user intervention")
+	resp.Error.Details = terminalApprovalErrorDetails(appr, "denied")
+	RespondError(w, r, http.StatusConflict, resp)
+}
+
+func terminalApprovalErrorDetails(appr *db.Approval, status string) map[string]any {
+	details := map[string]any{
+		"approval_id": appr.ApprovalID,
+		"status":      status,
+		"terminal":    true,
+		"retryable":   false,
+	}
+	if appr.DenialReason != nil && *appr.DenialReason != "" {
+		details["reason"] = *appr.DenialReason
+	}
+	if appr.DeniedAt != nil {
+		details["denied_at"] = appr.DeniedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if appr.CancelledAt != nil {
+		details["cancelled_at"] = appr.CancelledAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !appr.ExpiresAt.IsZero() {
+		details["expires_at"] = appr.ExpiresAt.UTC().Format(time.RFC3339Nano)
+	}
+	return details
+}
+
+func buildAgentApprovalStatusResponse(appr *db.Approval, status string, terminal, retryable bool) agentApprovalStatusResponse {
+	resp := agentApprovalStatusResponse{
+		ApprovalID: appr.ApprovalID,
+		Status:     status,
+		Terminal:   terminal,
+		Retryable:  retryable,
+		ExpiresAt:  appr.ExpiresAt,
+		CreatedAt:  appr.CreatedAt,
+	}
+	if appr.DenialReason != nil && *appr.DenialReason != "" {
+		resp.Reason = appr.DenialReason
+	}
+	if appr.ExecutionStatus != nil {
+		resp.ExecutionStatus = appr.ExecutionStatus
+	}
+	if len(appr.ExecutionResult) > 0 {
+		raw := json.RawMessage(appr.ExecutionResult)
+		resp.ExecutionResult = &raw
+	}
+	return resp
+}

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -311,7 +311,7 @@ func handleDenyApproval(deps *Deps) http.HandlerFunc {
 		}
 
 		var req denyApprovalRequest
-		if r.ContentLength > 0 {
+		if ct := r.Header.Get("Content-Type"); strings.HasPrefix(ct, "application/json") {
 			if !DecodeJSONOrReject(w, r, &req) {
 				return
 			}

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -49,6 +49,11 @@ type denyResponse struct {
 	ApprovalID string    `json:"approval_id"`
 	Status     string    `json:"status"`
 	DeniedAt   time.Time `json:"denied_at"`
+	Reason     *string   `json:"reason,omitempty"`
+}
+
+type denyApprovalRequest struct {
+	Reason string `json:"reason,omitempty" validate:"omitempty,max=500"`
 }
 
 // approvalDetailResponse includes execution details for the activity feed
@@ -305,7 +310,18 @@ func handleDenyApproval(deps *Deps) http.HandlerFunc {
 			return
 		}
 
-		appr, agentMeta, err := db.DenyApproval(r.Context(), deps.DB, approvalID, profile.ID)
+		var req denyApprovalRequest
+		if r.ContentLength > 0 {
+			if !DecodeJSONOrReject(w, r, &req) {
+				return
+			}
+			if !ValidateRequest(w, r, &req) {
+				return
+			}
+		}
+		reason := strings.TrimSpace(req.Reason)
+
+		appr, agentMeta, err := db.DenyApproval(r.Context(), deps.DB, approvalID, profile.ID, reason)
 		if err != nil {
 			if handleApprovalError(w, r, err) {
 				return
@@ -325,6 +341,7 @@ func handleDenyApproval(deps *Deps) http.HandlerFunc {
 			ApprovalID: appr.ApprovalID,
 			Status:     appr.Status,
 			DeniedAt:   *appr.DeniedAt,
+			Reason:     appr.DenialReason,
 		})
 	}
 }

--- a/api/approvals_test.go
+++ b/api/approvals_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
 
@@ -708,6 +710,43 @@ func TestDenyApproval_Success(t *testing.T) {
 	}
 	if resp.DeniedAt.IsZero() {
 		t.Error("expected denied_at to be set")
+	}
+}
+
+func TestDenyApproval_WithReason(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	apprID := testhelper.GenerateID(t, "appr_")
+	agentID := testhelper.InsertUserWithAgent(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertApproval(t, tx, apprID, agentID, uid)
+
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	r := authenticatedJSONRequest(t, http.MethodPost, "/approvals/"+apprID+"/deny", uid, `{"reason":"Not authorized for this recipient"}`)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp denyResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Reason == nil || *resp.Reason != "Not authorized for this recipient" {
+		t.Errorf("expected denial reason in response, got %v", resp.Reason)
+	}
+
+	appr, err := db.GetApprovalByIDAndApprover(context.Background(), tx, apprID, uid)
+	if err != nil {
+		t.Fatalf("get approval: %v", err)
+	}
+	if appr == nil || appr.DenialReason == nil || *appr.DenialReason != "Not authorized for this recipient" {
+		t.Errorf("expected denial reason persisted on approval, got %+v", appr)
 	}
 }
 

--- a/api/error_codes.go
+++ b/api/error_codes.go
@@ -34,6 +34,8 @@ const (
 	ErrRegistrationExpired          ErrorCode = "registration_expired"
 	ErrVerificationLocked           ErrorCode = "verification_locked"
 	ErrApprovalExpired              ErrorCode = "approval_expired"
+	ErrApprovalCancelled            ErrorCode = "approval_cancelled"
+	ErrApprovalRecentlyDenied       ErrorCode = "approval_recently_denied"
 	ErrRateLimited                  ErrorCode = "rate_limited"
 	ErrInternalError                ErrorCode = "internal_error"
 	ErrInternalPanic                ErrorCode = "internal_panic"

--- a/api/router.go
+++ b/api/router.go
@@ -15,28 +15,29 @@ import (
 
 // Deps holds shared dependencies for API route handlers.
 type Deps struct {
-	DB                   db.DBTX                 // nil when running without a database
-	Vault                vault.VaultStore        // credential secret encryption; nil returns 503 on credential endpoints
-	JWTSigningSecret     string                  // HMAC-SHA256 secret for HS256 access JWTs (min 32 bytes; set JWT_SIGNING_SECRET)
-	BaseURL              string                  // Public base URL (e.g. "https://your-server.example.com"); used to construct invite URLs
-	InviteHMACKey        string                  // HMAC key for hashing short codes (invite codes, confirmation codes); if empty, falls back to plain SHA-256
-	Notifier             *notify.Dispatcher      // notification fan-out; nil means notifications are disabled
-	Stripe               *pstripe.Client         // Stripe API for saved payment methods; nil when STRIPE_SECRET_KEY is unset
-	Connectors           *connectors.Registry    // connector execution registry; nil means no connectors are available
-	OAuthProviders       *oauth.Registry         // OAuth provider registry; nil means OAuth is not available
-	OAuthRedirectBaseURL string                  // Public base URL for OAuth callbacks; falls back to BaseURL
-	OAuthStateSecret     string                  // HMAC-SHA256 secret for signing OAuth CSRF state tokens; if empty, falls back to JWTSigningSecret
-	DevMode              bool                    // true when MODE=development; disables rate limiting
-	RateLimiter          *RateLimiter            // pre-auth rate limiter (per-IP + global); nil disables
-	AuthRateLimiter      *RateLimiter            // rate limiter for /api/auth/* (signup/login); nil disables
-	AgentRateLimiter     *RateLimiter            // post-auth rate limiter (per verified agent); nil disables
-	VerifyRateLimiter    *RateLimiter            // per-IP rate limiter for POST /agents/{id}/verify; nil disables
-	TrustedProxyHeader   string                  // header to read client IP from behind a reverse proxy (e.g. "Fly-Client-IP"); empty uses RemoteAddr
-	AllowedOrigins       []string                // allowed CORS origins; empty means cross-origin requests are blocked
-	Logger               *slog.Logger            // structured logger for request logging; if nil, request logging is skipped
-	ApprovalEvents       *ApprovalEventBroker    // SSE broker for real-time approval notifications; nil disables SSE
-	SlackSigningSecret   string                  // Slack signing secret for verifying Events API webhook signatures; empty disables Slack events
-	EventBroker          *connectors.EventBroker // connector event dispatch; nil means inbound events are accepted but not processed
+	DB                     db.DBTX                 // nil when running without a database
+	Vault                  vault.VaultStore        // credential secret encryption; nil returns 503 on credential endpoints
+	JWTSigningSecret       string                  // HMAC-SHA256 secret for HS256 access JWTs (min 32 bytes; set JWT_SIGNING_SECRET)
+	BaseURL                string                  // Public base URL (e.g. "https://your-server.example.com"); used to construct invite URLs
+	InviteHMACKey          string                  // HMAC key for hashing short codes (invite codes, confirmation codes); if empty, falls back to plain SHA-256
+	Notifier               *notify.Dispatcher      // notification fan-out; nil means notifications are disabled
+	Stripe                 *pstripe.Client         // Stripe API for saved payment methods; nil when STRIPE_SECRET_KEY is unset
+	Connectors             *connectors.Registry    // connector execution registry; nil means no connectors are available
+	OAuthProviders         *oauth.Registry         // OAuth provider registry; nil means OAuth is not available
+	OAuthRedirectBaseURL   string                  // Public base URL for OAuth callbacks; falls back to BaseURL
+	OAuthStateSecret       string                  // HMAC-SHA256 secret for signing OAuth CSRF state tokens; if empty, falls back to JWTSigningSecret
+	DevMode                bool                    // true when MODE=development; disables rate limiting
+	RateLimiter            *RateLimiter            // pre-auth rate limiter (per-IP + global); nil disables
+	AuthRateLimiter        *RateLimiter            // rate limiter for /api/auth/* (signup/login); nil disables
+	AgentRateLimiter       *RateLimiter            // post-auth rate limiter (per verified agent); nil disables
+	VerifyRateLimiter      *RateLimiter            // per-IP rate limiter for POST /agents/{id}/verify; nil disables
+	TrustedProxyHeader     string                  // header to read client IP from behind a reverse proxy (e.g. "Fly-Client-IP"); empty uses RemoteAddr
+	AllowedOrigins         []string                // allowed CORS origins; empty means cross-origin requests are blocked
+	Logger                 *slog.Logger            // structured logger for request logging; if nil, request logging is skipped
+	ApprovalEvents         *ApprovalEventBroker    // SSE broker for real-time approval notifications; nil disables SSE
+	ApprovalDenialCooldown time.Duration           // window for short-circuiting re-requests of recently denied actions; zero uses db.DefaultDenialCooldown
+	SlackSigningSecret     string                  // Slack signing secret for verifying Events API webhook signatures; empty disables Slack events
+	EventBroker            *connectors.EventBroker // connector event dispatch; nil means inbound events are accepted but not processed
 }
 
 // NewRouter returns an http.Handler that serves all /api/v1/ routes.

--- a/api/router.go
+++ b/api/router.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
 	"github.com/supersuit-tech/permission-slip/connectors"

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -57,6 +57,7 @@ func authenticatedJSONRequest(t *testing.T, method, path, userID, body string) *
 	t.Helper()
 	r := authenticatedRequest(t, method, path, userID)
 	r.Body = io.NopCloser(strings.NewReader(body))
+	r.ContentLength = int64(len(body))
 	r.Header.Set("Content-Type", "application/json")
 	return r
 }

--- a/api/standing_approval_match.go
+++ b/api/standing_approval_match.go
@@ -127,6 +127,8 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 
 	RespondJSON(w, http.StatusOK, agentRequestApprovalResponse{
 		Status:             "approved",
+		Terminal:           true,
+		Retryable:          false,
 		Result:             actionResultPtr,
 		StandingApprovalID: sa.StandingApprovalID,
 	})

--- a/db/agent_approvals.go
+++ b/db/agent_approvals.go
@@ -48,13 +48,14 @@ func ApprovalTTLFromEnv(logger *slog.Logger) time.Duration {
 
 // InsertApprovalParams holds the parameters for creating a new approval.
 type InsertApprovalParams struct {
-	ApprovalID      string
-	AgentID         int64
-	ApproverID      string
-	Action          []byte // raw JSONB
-	Context         []byte // raw JSONB
-	ResourceDetails []byte // raw JSONB — human-readable resource metadata (optional)
-	ExpiresAt       time.Time
+	ApprovalID        string
+	AgentID           int64
+	ApproverID        string
+	Action            []byte // raw JSONB
+	Context           []byte // raw JSONB
+	ResourceDetails   []byte // raw JSONB — human-readable resource metadata (optional)
+	ActionFingerprint string
+	ExpiresAt         time.Time
 }
 
 // InsertApproval creates a new pending approval row. It also inserts the
@@ -85,10 +86,10 @@ func InsertApproval(ctx context.Context, d DBTX, p InsertApprovalParams, request
 	}
 
 	row := tx.QueryRow(ctx,
-		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, resource_details, status, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7)
+		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, resource_details, action_fingerprint, status, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), 'pending', $8)
 		 RETURNING `+approvalColumns,
-		p.ApprovalID, p.AgentID, p.ApproverID, p.Action, p.Context, p.ResourceDetails, TimestampForSQLite(p.ExpiresAt),
+		p.ApprovalID, p.AgentID, p.ApproverID, p.Action, p.Context, p.ResourceDetails, p.ActionFingerprint, TimestampForSQLite(p.ExpiresAt),
 	)
 	appr, err := scanApproval(row)
 	if err != nil {

--- a/db/approval_dedup.go
+++ b/db/approval_dedup.go
@@ -1,0 +1,87 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// DefaultDenialCooldown is the default window during which a recently denied
+// action fingerprint is short-circuited instead of creating a new approval.
+var DefaultDenialCooldown = 10 * time.Minute
+
+// DenialCooldownFromEnv reads APPROVAL_DENIAL_COOLDOWN and returns a duration
+// clamped to [1m, 24h]. Unset, unparseable, or out-of-bounds values fall back
+// to DefaultDenialCooldown.
+func DenialCooldownFromEnv(logger *slog.Logger) time.Duration {
+	const minCooldown = time.Minute
+	const maxCooldown = 24 * time.Hour
+
+	v := os.Getenv("APPROVAL_DENIAL_COOLDOWN")
+	if v == "" {
+		return DefaultDenialCooldown
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("invalid APPROVAL_DENIAL_COOLDOWN, using default",
+				"value", v, "error", err, "default", DefaultDenialCooldown.String())
+		}
+		return DefaultDenialCooldown
+	}
+	if d < minCooldown || d > maxCooldown {
+		if logger != nil {
+			logger.Warn("APPROVAL_DENIAL_COOLDOWN out of bounds, using default",
+				"value", v, "min", minCooldown.String(), "max", maxCooldown.String(),
+				"default", DefaultDenialCooldown.String())
+		}
+		return DefaultDenialCooldown
+	}
+	return d
+}
+
+// ComputeActionFingerprint returns a stable SHA-256 hex digest for deduplicating
+// approval requests. The fingerprint covers agent, approver, and the normalized
+// action JSON payload.
+func ComputeActionFingerprint(agentID int64, approverID string, action []byte) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%d:%s:", agentID, approverID)
+	h.Write(action)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// FindRecentDeniedApproval returns the most recent denied approval with the
+// same fingerprint within the cooldown window, or nil if none exists.
+func FindRecentDeniedApproval(ctx context.Context, d DBTX, agentID int64, approverID, fingerprint string, since time.Time) (*Approval, error) {
+	if fingerprint == "" {
+		return nil, nil
+	}
+
+	row := d.QueryRow(ctx,
+		`SELECT `+approvalColumns+`
+		 FROM approvals
+		 WHERE agent_id = $1
+		   AND approver_id = $2
+		   AND action_fingerprint = $3
+		   AND status = 'denied'
+		   AND denied_at IS NOT NULL
+		   AND datetime(denied_at) > datetime($4)
+		 ORDER BY denied_at DESC
+		 LIMIT 1`,
+		agentID, approverID, fingerprint, TimestampForSQLite(since),
+	)
+	appr, err := scanApproval(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return appr, nil
+}

--- a/db/approval_dedup_test.go
+++ b/db/approval_dedup_test.go
@@ -1,22 +1,23 @@
-package db
+package db_test
 
 import (
 	"context"
 	"testing"
 	"time"
 
+	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
 )
 
 func TestComputeActionFingerprintStable(t *testing.T) {
 	t.Parallel()
 	action := []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`)
-	a := ComputeActionFingerprint(42, "approver-1", action)
-	b := ComputeActionFingerprint(42, "approver-1", action)
+	a := db.ComputeActionFingerprint(42, "approver-1", action)
+	b := db.ComputeActionFingerprint(42, "approver-1", action)
 	if a != b {
 		t.Fatalf("expected stable fingerprint, got %q vs %q", a, b)
 	}
-	if a == ComputeActionFingerprint(43, "approver-1", action) {
+	if a == db.ComputeActionFingerprint(43, "approver-1", action) {
 		t.Fatal("expected different fingerprint for different agent")
 	}
 }
@@ -29,7 +30,7 @@ func TestFindRecentDeniedApproval(t *testing.T) {
 	agentID := testhelper.InsertAgent(t, tx, uid)
 
 	action := []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`)
-	fingerprint := ComputeActionFingerprint(agentID, uid, action)
+	fingerprint := db.ComputeActionFingerprint(agentID, uid, action)
 	approvalID := testhelper.GenerateID(t, "appr_")
 
 	_, err := tx.Exec(context.Background(),
@@ -41,7 +42,7 @@ func TestFindRecentDeniedApproval(t *testing.T) {
 		t.Fatalf("insert denied approval: %v", err)
 	}
 
-	found, err := FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(-time.Hour))
+	found, err := db.FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(-time.Hour))
 	if err != nil {
 		t.Fatalf("FindRecentDeniedApproval: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestFindRecentDeniedApproval(t *testing.T) {
 		t.Fatalf("expected recent denial %q, got %+v", approvalID, found)
 	}
 
-	outsideWindow, err := FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(time.Minute))
+	outsideWindow, err := db.FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatalf("FindRecentDeniedApproval outside window: %v", err)
 	}

--- a/db/approval_dedup_test.go
+++ b/db/approval_dedup_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestComputeActionFingerprintStable(t *testing.T) {
+	t.Parallel()
+	action := []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`)
+	a := ComputeActionFingerprint(42, "approver-1", action)
+	b := ComputeActionFingerprint(42, "approver-1", action)
+	if a != b {
+		t.Fatalf("expected stable fingerprint, got %q vs %q", a, b)
+	}
+	if a == ComputeActionFingerprint(43, "approver-1", action) {
+		t.Fatal("expected different fingerprint for different agent")
+	}
+}
+
+func TestFindRecentDeniedApproval(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgent(t, tx, uid)
+
+	action := []byte(`{"type":"email.send","parameters":{"to":"alice@example.com"}}`)
+	fingerprint := ComputeActionFingerprint(agentID, uid, action)
+	approvalID := testhelper.GenerateID(t, "appr_")
+
+	_, err := tx.Exec(context.Background(),
+		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, status, action_fingerprint, expires_at, denied_at, denial_reason)
+		 VALUES ($1, $2, $3, $4, '{"description":"test"}', 'denied', $5, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+1 hour'), strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), 'No')`,
+		approvalID, agentID, uid, action, fingerprint,
+	)
+	if err != nil {
+		t.Fatalf("insert denied approval: %v", err)
+	}
+
+	found, err := FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("FindRecentDeniedApproval: %v", err)
+	}
+	if found == nil || found.ApprovalID != approvalID {
+		t.Fatalf("expected recent denial %q, got %+v", approvalID, found)
+	}
+
+	outsideWindow, err := FindRecentDeniedApproval(context.Background(), tx, agentID, uid, fingerprint, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("FindRecentDeniedApproval outside window: %v", err)
+	}
+	if outsideWindow != nil {
+		t.Fatalf("expected nil outside cooldown window, got %+v", outsideWindow)
+	}
+}

--- a/db/approvals.go
+++ b/db/approvals.go
@@ -11,28 +11,31 @@ import (
 
 // Approval represents a row from the approvals table.
 type Approval struct {
-	ApprovalID      string
-	AgentID         int64
-	ApproverID      string
-	Action          []byte // raw JSONB
-	Context         []byte // raw JSONB
-	Status          string
-	ExecutionStatus *string
-	ExecutionResult []byte // raw JSONB
-	ExecutedAt      *time.Time
-	ResourceDetails []byte // raw JSONB — human-readable resource metadata
-	ExpiresAt       time.Time
-	ApprovedAt      *time.Time
-	DeniedAt        *time.Time
-	CancelledAt     *time.Time
-	CreatedAt       time.Time
+	ApprovalID        string
+	AgentID           int64
+	ApproverID        string
+	Action            []byte // raw JSONB
+	Context           []byte // raw JSONB
+	Status            string
+	ExecutionStatus   *string
+	ExecutionResult   []byte // raw JSONB
+	ExecutedAt        *time.Time
+	ResourceDetails   []byte // raw JSONB — human-readable resource metadata
+	ExpiresAt         time.Time
+	ApprovedAt        *time.Time
+	DeniedAt          *time.Time
+	CancelledAt       *time.Time
+	DenialReason      *string
+	ActionFingerprint string
+	CreatedAt         time.Time
 }
 
 // approvalColumns is the canonical column list for SELECT on the approvals table.
 // Keep in sync with scanApproval.
 const approvalColumns = `approval_id, agent_id, approver_id, action, context,
 	status, execution_status, execution_result, executed_at, resource_details,
-	expires_at, approved_at, denied_at, cancelled_at, created_at`
+	expires_at, approved_at, denied_at, cancelled_at, denial_reason,
+	action_fingerprint, created_at`
 
 // ApprovalCursor identifies the position of the last item on a page,
 // using both created_at and approval_id as a compound key to avoid
@@ -52,10 +55,11 @@ type ApprovalPage struct {
 func scanApproval(row rowScanner) (*Approval, error) {
 	var a Approval
 	var executedAt, expiresAt, approvedAt, deniedAt, cancelledAt, createdAt sql.NullString
+	var denialReason, actionFingerprint sql.NullString
 	err := row.Scan(
 		&a.ApprovalID, &a.AgentID, &a.ApproverID, &a.Action, &a.Context,
 		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &executedAt, &a.ResourceDetails,
-		&expiresAt, &approvedAt, &deniedAt, &cancelledAt, &createdAt,
+		&expiresAt, &approvedAt, &deniedAt, &cancelledAt, &denialReason, &actionFingerprint, &createdAt,
 	)
 	if err != nil {
 		return nil, err
@@ -80,6 +84,13 @@ func scanApproval(row rowScanner) (*Approval, error) {
 	a.CancelledAt, err2 = sqliteTimePtr(cancelledAt)
 	if err2 != nil {
 		return nil, err2
+	}
+	if denialReason.Valid {
+		reason := denialReason.String
+		a.DenialReason = &reason
+	}
+	if actionFingerprint.Valid {
+		a.ActionFingerprint = actionFingerprint.String
 	}
 	a.CreatedAt, err2 = sqliteTimeRequired(createdAt)
 	if err2 != nil {
@@ -198,13 +209,14 @@ func GetApprovalByIDAndApprover(ctx context.Context, db DBTX, approvalID, approv
 // ApproveApproval atomically sets the approval status to 'approved' and records
 // the timestamp. Returns the updated approval and the agent's metadata snapshot.
 func ApproveApproval(ctx context.Context, db DBTX, approvalID, approverID string) (*Approval, []byte, error) {
-	return resolveApproval(ctx, db, approvalID, approverID, "approved", "approved_at")
+	return resolveApproval(ctx, db, approvalID, approverID, "approved", "approved_at", "")
 }
 
 // DenyApproval atomically sets the approval status to 'denied' and records the
 // timestamp. Returns the updated approval and the agent's metadata snapshot.
-func DenyApproval(ctx context.Context, db DBTX, approvalID, approverID string) (*Approval, []byte, error) {
-	return resolveApproval(ctx, db, approvalID, approverID, "denied", "denied_at")
+// reason is optional human-readable context for the agent; empty string is stored as NULL.
+func DenyApproval(ctx context.Context, db DBTX, approvalID, approverID, reason string) (*Approval, []byte, error) {
+	return resolveApproval(ctx, db, approvalID, approverID, "denied", "denied_at", reason)
 }
 
 // resolveApproval is the shared implementation for ApproveApproval and
@@ -214,7 +226,7 @@ func DenyApproval(ctx context.Context, db DBTX, approvalID, approverID string) (
 //
 // Safety: newStatus and timestampCol are caller-controlled constants
 // ("approved"/"denied" and "approved_at"/"denied_at"), never user input.
-func resolveApproval(ctx context.Context, db DBTX, approvalID, approverID, newStatus, timestampCol string) (*Approval, []byte, error) {
+func resolveApproval(ctx context.Context, db DBTX, approvalID, approverID, newStatus, timestampCol, denialReason string) (*Approval, []byte, error) {
 	// SQLite rejects UPDATE-in-WITH combined with JOIN to agents (PostgreSQL shape).
 	tx, owned, err := BeginOrContinue(ctx, db)
 	if err != nil {
@@ -224,15 +236,30 @@ func resolveApproval(ctx context.Context, db DBTX, approvalID, approverID, newSt
 		defer func() { _ = RollbackTx(ctx, tx) }()
 	}
 
-	query := fmt.Sprintf(
-		`UPDATE approvals
-		 SET status = $3, %s = strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', 'now')
-		 WHERE approval_id = $1 AND approver_id = $2
-		   AND status = 'pending' AND datetime(expires_at) > datetime('now')
-		 RETURNING %s`,
-		timestampCol, approvalColumns,
-	)
-	row := tx.QueryRow(ctx, query, approvalID, approverID, newStatus)
+	var query string
+	var args []any
+	if newStatus == "denied" && denialReason != "" {
+		query = fmt.Sprintf(
+			`UPDATE approvals
+			 SET status = $3, %s = strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', 'now'), denial_reason = $4
+			 WHERE approval_id = $1 AND approver_id = $2
+			   AND status = 'pending' AND datetime(expires_at) > datetime('now')
+			 RETURNING %s`,
+			timestampCol, approvalColumns,
+		)
+		args = []any{approvalID, approverID, newStatus, denialReason}
+	} else {
+		query = fmt.Sprintf(
+			`UPDATE approvals
+			 SET status = $3, %s = strftime('%%Y-%%m-%%dT%%H:%%M:%%fZ', 'now')
+			 WHERE approval_id = $1 AND approver_id = $2
+			   AND status = 'pending' AND datetime(expires_at) > datetime('now')
+			 RETURNING %s`,
+			timestampCol, approvalColumns,
+		)
+		args = []any{approvalID, approverID, newStatus}
+	}
+	row := tx.QueryRow(ctx, query, args...)
 	appr, err := scanApproval(row)
 	if err == nil {
 		var agentMeta []byte

--- a/db/approvals_test.go
+++ b/db/approvals_test.go
@@ -19,7 +19,7 @@ func TestApprovalsSchema(t *testing.T) {
 			"approval_id", "agent_id", "approver_id", "action", "context",
 			"status", "execution_status", "execution_result", "executed_at",
 			"expires_at", "approved_at", "denied_at",
-			"cancelled_at", "created_at",
+			"cancelled_at", "denial_reason", "action_fingerprint", "created_at",
 		})
 	})
 	t.Run("request_ids", func(t *testing.T) {
@@ -39,6 +39,7 @@ func TestApprovalIndexes(t *testing.T) {
 		{"approvals", "idx_approvals_agent_created"},
 		{"approvals", "idx_approvals_expires_at"},
 		{"approvals", "idx_approvals_approver_created"},
+		{"approvals", "idx_approvals_denial_dedup"},
 		{"request_ids", "idx_request_ids_created_at"},
 	}
 

--- a/db/migrations/20260607021010_approvals_denial_dedup.sql
+++ b/db/migrations/20260607021010_approvals_denial_dedup.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+
+ALTER TABLE approvals
+    ADD COLUMN denial_reason text CHECK (char_length(denial_reason) <= 500),
+    ADD COLUMN action_fingerprint text CHECK (char_length(action_fingerprint) <= 64);
+
+CREATE INDEX idx_approvals_denial_dedup
+    ON approvals (agent_id, approver_id, action_fingerprint, denied_at DESC)
+    WHERE status = 'denied';
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_approvals_denial_dedup;
+
+ALTER TABLE approvals
+    DROP COLUMN IF EXISTS action_fingerprint,
+    DROP COLUMN IF EXISTS denial_reason;

--- a/db/migrations_sqlite/00001_init.sql
+++ b/db/migrations_sqlite/00001_init.sql
@@ -288,9 +288,13 @@ CREATE TABLE approvals (
     execution_result TEXT,
     executed_at TEXT,
     resource_details TEXT,
+    denial_reason TEXT,
+    action_fingerprint TEXT,
     CONSTRAINT approvals_action_check CHECK (length(action) <= 65536),
     CONSTRAINT approvals_approval_id_check CHECK (length(approval_id) <= 255),
     CONSTRAINT approvals_context_check CHECK (length(context) <= 262144),
+    CONSTRAINT approvals_denial_reason_check CHECK (denial_reason IS NULL OR length(denial_reason) <= 500),
+    CONSTRAINT approvals_action_fingerprint_check CHECK (action_fingerprint IS NULL OR length(action_fingerprint) <= 64),
     CONSTRAINT approvals_execution_status_check CHECK (execution_status IS NULL OR execution_status IN ('pending', 'success', 'error')),
     CONSTRAINT approvals_status_check CHECK (status IN ('pending', 'approved', 'denied', 'cancelled')),
     CONSTRAINT chk_execution_columns_consistent CHECK (
@@ -304,6 +308,7 @@ CREATE INDEX idx_approvals_agent_created ON approvals(agent_id, created_at);
 CREATE INDEX idx_approvals_agent_status ON approvals(agent_id, status);
 CREATE INDEX idx_approvals_approver_created ON approvals(approver_id, created_at DESC, approval_id DESC);
 CREATE INDEX idx_approvals_expires_at ON approvals(expires_at);
+CREATE INDEX idx_approvals_denial_dedup ON approvals(agent_id, approver_id, action_fingerprint, denied_at DESC) WHERE status = 'denied';
 
 CREATE TABLE action_configurations (
     id TEXT PRIMARY KEY,

--- a/db/testhelper/fixtures_approvals.go
+++ b/db/testhelper/fixtures_approvals.go
@@ -29,7 +29,9 @@ func InsertApprovalWithStatus(t *testing.T, d db.DBTX, approvalID string, agentI
 // The agent and approver must already exist via InsertUser and InsertAgent.
 func InsertApprovalWithCreatedAt(t *testing.T, d db.DBTX, approvalID string, agentID int64, approverID string, createdAt time.Time) {
 	t.Helper()
-	expiresAt := createdAt.Add(time.Hour)
+	// expires_at must stay in the future for pending-list queries even when
+	// created_at is set to an arbitrary historical timestamp in tests.
+	expiresAt := time.Now().UTC().Add(24 * time.Hour)
 	mustExec(t, d,
 		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, status, expires_at, created_at)
 		 VALUES ($1, $2, $3, '{"type":"test"}', '{"description":"test"}', 'pending', $4, $5)`,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -469,6 +469,20 @@ permission-slip status "$APPROVAL_ID"
 
 If your agent needs to wait for approval, implement your own polling loop externally. This gives you full control over timing, cancellation, and concurrency.
 
+Poll `GET /approvals/{approval_id}/status` and treat the HTTP status code as authoritative:
+
+| Outcome | HTTP | `error.code` (if non-200) | Agent action |
+|---|---|---|---|
+| Still pending | `200` | — | Keep polling (`terminal: false`) |
+| Approved | `200` | — | Stop polling; read `execution_result` (`terminal: true`) |
+| Denied | `409` | `approval_denied` | **Stop.** Do not retry without user intervention |
+| Expired | `410` | `approval_expired` | Stop; submit a new approval if still needed |
+| Cancelled | `409` | `approval_cancelled` | Stop; submit a new approval only if the user asks |
+
+Every `200` response includes `terminal` and `retryable` booleans. Terminal-negative states always return non-200 responses with `retryable: false` in the error body. When the approver supplied a denial reason, it appears in `error.details.reason` (non-200) or the `reason` field (200 responses for historical compatibility).
+
+**Dedup protection:** If you re-submit the same action shortly after a denial, Permission Slip returns `409 Conflict` with `approval_recently_denied` instead of creating a new pending approval. This prevents spamming the approver. The cooldown window defaults to 10 minutes and is configurable server-side via `APPROVAL_DENIAL_COOLDOWN`.
+
 Alternatively, the user can share the approval confirmation code out-of-band (paste it in chat, set it in your config, etc.).
 
 #### 4a-3. Verify and Get Token
@@ -657,7 +671,9 @@ All errors follow a consistent format:
 | `invite_locked` | 423 | 5 failed registration attempts — user must create new invite |
 | `registration_expired` | 410 | Didn't verify within 5 minutes — re-register |
 | `invalid_code` | 401 | Wrong confirmation code — check `attempts_remaining` in details |
-| `approval_denied` | 403 | User explicitly denied — do not retry without user intervention |
+| `approval_denied` | 409 | User explicitly denied — do not retry without user intervention |
+| `approval_cancelled` | 409 | Agent or user cancelled — do not retry the same approval ID |
+| `approval_recently_denied` | 409 | Same action was recently denied — do not retry; wait for user guidance |
 | `approval_expired` | 410 | Approval TTL elapsed — re-request |
 | `invalid_parameters` | 403 | Parameters don't match what was approved — must match exactly |
 | `token_already_used` | 403 | Token consumed — request new approval |

--- a/frontend/src/hooks/__tests__/useDenyApproval.test.tsx
+++ b/frontend/src/hooks/__tests__/useDenyApproval.test.tsx
@@ -36,9 +36,33 @@ describe("useDenyApproval", () => {
       {
         headers: { Authorization: expect.stringMatching(/^Bearer /) },
         params: { path: { approval_id: "approval-abc" } },
+        body: undefined,
       },
     );
     expect(result.current.isPending).toBe(false);
+  });
+
+  it("sends optional denial reason in request body", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockPost.mockResolvedValue({
+      data: { approval_id: "approval-abc", status: "denied", denied_at: "2026-02-21T12:00:00Z" },
+    });
+
+    const { result } = renderHook(() => useDenyApproval(), {
+      wrapper,
+    });
+
+    await settleAuthHydration();
+    await act(async () => {
+      await result.current.denyApproval("approval-abc", "Not authorized for this recipient");
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/approvals/{approval_id}/deny",
+      expect.objectContaining({
+        body: { reason: "Not authorized for this recipient" },
+      }),
+    );
   });
 
   it("throws when not authenticated", async () => {

--- a/frontend/src/hooks/useDenyApproval.ts
+++ b/frontend/src/hooks/useDenyApproval.ts
@@ -8,16 +8,18 @@ export function useDenyApproval() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: async (approvalId: string) => {
+    mutationFn: async ({ approvalId, reason }: { approvalId: string; reason?: string }) => {
       if (!session?.access_token) {
         throw new Error("Not authenticated");
       }
 
+      const trimmedReason = reason?.trim();
       const { error } = await client.POST(
         "/v1/approvals/{approval_id}/deny",
         {
           headers: { Authorization: `Bearer ${session.access_token}` },
           params: { path: { approval_id: approvalId } },
+          body: trimmedReason ? { reason: trimmedReason } : undefined,
         },
       );
       if (error) throw new Error("Failed to deny request");
@@ -29,7 +31,8 @@ export function useDenyApproval() {
   });
 
   return {
-    denyApproval: (approvalId: string) => mutation.mutateAsync(approvalId),
+    denyApproval: (approvalId: string, reason?: string) =>
+      mutation.mutateAsync({ approvalId, reason }),
     isPending: mutation.isPending,
   };
 }

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -114,6 +114,7 @@ export function ReviewApprovalDialog({
   const [standingApprovalCreated, setStandingApprovalCreated] = useState(false);
   const [autoApproveFuture, setAutoApproveFuture] = useState(false);
   const [pendingAction, setPendingAction] = useState<"approve" | null>(null);
+  const [denialReason, setDenialReason] = useState("");
   const [paramsOpen, setParamsOpen] = useState(false);
   const isApproved = approveResult !== null;
   const { approveApproval } = useApproveApproval();
@@ -226,13 +227,14 @@ export function ReviewApprovalDialog({
 
   const handleDeny = useCallback(async () => {
     try {
-      await denyApproval(approval.approval_id);
+      const reason = denialReason.trim();
+      await denyApproval(approval.approval_id, reason || undefined);
       toast.success("Request denied");
       onOpenChange(false);
     } catch {
       toast.error("Failed to deny request. Please try again.");
     }
-  }, [denyApproval, approval.approval_id, onOpenChange]);
+  }, [denyApproval, approval.approval_id, denialReason, onOpenChange]);
 
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
@@ -240,6 +242,7 @@ export function ReviewApprovalDialog({
       setStandingApprovalCreated(false);
       setAutoApproveFuture(false);
       setPendingAction(null);
+      setDenialReason("");
     }
     onOpenChange(nextOpen);
   }
@@ -463,6 +466,22 @@ export function ReviewApprovalDialog({
                   </Label>
                 </div>
               )}
+
+              <div className="space-y-2">
+                <Label htmlFor="denial-reason" className="text-sm font-medium">
+                  Reason for denial (optional)
+                </Label>
+                <textarea
+                  id="denial-reason"
+                  value={denialReason}
+                  onChange={(event) => setDenialReason(event.target.value)}
+                  disabled={isBusy || isExpired}
+                  maxLength={500}
+                  rows={3}
+                  placeholder="Explain why you're denying this request so the agent can adapt."
+                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
 
               <Button
                 size="lg"

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func main() {
 
 	// Apply APPROVAL_REQUEST_TTL override (defaults to 10m, clamped to [1m, 24h]).
 	db.DefaultApprovalTTL = db.ApprovalTTLFromEnv(logger)
+	db.DefaultDenialCooldown = db.DenialCooldownFromEnv(logger)
 
 	// Configure dependencies
 	var deps api.Deps
@@ -132,7 +133,7 @@ func main() {
 		log.Println("Rate limiting: disabled (development mode)")
 	}
 	deps.BaseURL = os.Getenv("BASE_URL")
-	deps.InviteHMACKey = os.Getenv("INVITE_HMAC_KEY")
+	deps.ApprovalDenialCooldown = db.DefaultDenialCooldown
 
 	// Initialize SSE broker for real-time approval notifications.
 	deps.ApprovalEvents = api.NewApprovalEventBroker()

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -261,19 +261,36 @@ request:
                     trace_id: "trace_xyz789"
       
       '409':
-        description: Duplicate request ID
+        description: Duplicate request ID or recently denied action
         content:
           application/json:
             schema:
               $ref: '../schemas/errors.yaml#/ErrorResponse'
-            example:
-              error:
-                code: "duplicate_request_id"
-                message: "Request ID already used"
-                retryable: false
-                details:
-                  request_id: "a925fbe0-db83-4969-9dc5-27f40385f12c"
-                trace_id: "trace_xyz789"
+            examples:
+              duplicate_request_id:
+                summary: Duplicate request ID
+                value:
+                  error:
+                    code: "duplicate_request_id"
+                    message: "Request ID already used"
+                    retryable: false
+                    details:
+                      request_id: "a925fbe0-db83-4969-9dc5-27f40385f12c"
+                    trace_id: "trace_xyz789"
+              recently_denied:
+                summary: Recently denied action (dedup short-circuit)
+                value:
+                  error:
+                    code: "approval_recently_denied"
+                    message: "This action was recently denied; do not retry without user intervention"
+                    retryable: false
+                    details:
+                      approval_id: "appr_xyz789"
+                      status: "denied"
+                      terminal: true
+                      retryable: false
+                      reason: "Recipient not on approved contacts list."
+                    trace_id: "trace_xyz789"
       
       '429':
         $ref: '../responses/errors.yaml#/TooManyRequests'
@@ -933,11 +950,25 @@ approvalStatus:
       - `pending` → `approved` (with execution result) or `denied` or `cancelled`
       - Once resolved, the status is final and will not change
 
+      ## Terminal States (Non-200 Responses)
+
+      Terminal-negative states return explicit HTTP error codes so agents cannot
+      mistake them for "still pending":
+
+      - `denied` → `409 Conflict` with error code `approval_denied`, `retryable: false`
+      - `expired` → `410 Gone` with error code `approval_expired`, `retryable: false`
+      - `cancelled` → `409 Conflict` with error code `approval_cancelled`, `retryable: false`
+
+      Successful responses (`pending`, `approved`) return `200 OK` and include
+      `terminal` and `retryable` boolean fields. Agents MUST respect these flags
+      and MUST NOT re-submit actions that received a terminal-negative response.
+
       ## Recommended Polling Strategy
 
       - Poll every 1–2 seconds for the first 30 seconds
       - Then every 5 seconds until expiration
-      - Stop polling when status is no longer `pending` or when `expires_at` has passed
+      - Stop polling when status is no longer `pending`, when `terminal` is `true`,
+        when a non-200 response is received, or when `expires_at` has passed
       - Prefer SSE (`GET /v1/approvals/events`) for real-time notifications when possible
 
       ## Security
@@ -967,12 +998,16 @@ approvalStatus:
                 value:
                   approval_id: "appr_xyz789"
                   status: "pending"
+                  terminal: false
+                  retryable: false
                   expires_at: "2026-02-21T10:35:00Z"
               approved_with_result:
                 summary: Approved and executed successfully
                 value:
                   approval_id: "appr_xyz789"
                   status: "approved"
+                  terminal: true
+                  retryable: false
                   approved_at: "2026-02-21T10:30:00Z"
                   expires_at: "2026-02-21T10:35:00Z"
                   execution_status: "success"
@@ -985,16 +1020,67 @@ approvalStatus:
                 value:
                   approval_id: "appr_xyz789"
                   status: "approved"
+                  terminal: true
+                  retryable: false
                   approved_at: "2026-02-21T10:30:00Z"
                   expires_at: "2026-02-21T10:35:00Z"
                   execution_status: "pending"
+
+      '409':
+        description: Approval denied or cancelled (terminal, non-retryable)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            examples:
               denied:
-                summary: Approval denied
+                summary: Approval denied by approver
                 value:
+                  error:
+                    code: "approval_denied"
+                    message: "Approval was denied by the approver"
+                    retryable: false
+                    details:
+                      approval_id: "appr_xyz789"
+                      status: "denied"
+                      terminal: true
+                      retryable: false
+                      reason: "Recipient not on approved contacts list."
+                      denied_at: "2026-02-21T10:30:00Z"
+                    trace_id: "trace_xyz789"
+              cancelled:
+                summary: Approval cancelled by agent
+                value:
+                  error:
+                    code: "approval_cancelled"
+                    message: "Approval was cancelled"
+                    retryable: false
+                    details:
+                      approval_id: "appr_xyz789"
+                      status: "cancelled"
+                      terminal: true
+                      retryable: false
+                      cancelled_at: "2026-02-21T10:29:00Z"
+                    trace_id: "trace_xyz789"
+
+      '410':
+        description: Approval expired (terminal, non-retryable)
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "approval_expired"
+                message: "Approval has expired"
+                retryable: false
+                details:
                   approval_id: "appr_xyz789"
-                  status: "denied"
-                  denied_at: "2026-02-21T10:30:00Z"
-                  expires_at: "2026-02-21T10:35:00Z"
+                  status: "expired"
+                  terminal: true
+                  retryable: false
+                  expires_at: "2026-02-21T10:25:00Z"
+                trace_id: "trace_xyz789"
 
       '401':
         $ref: '../responses/errors.yaml#/Unauthorized'
@@ -1034,6 +1120,9 @@ denyApproval:
       authenticated user (as approver) and must be in `pending` status and
       not expired.
 
+      An optional `reason` may be supplied so the agent receives human-readable
+      feedback instead of blindly retrying the same action.
+
       This is a dashboard endpoint for human approvers.
 
     tags:
@@ -1044,6 +1133,15 @@ denyApproval:
 
     parameters:
       - $ref: '../parameters/common.yaml#/ApprovalId'
+
+    requestBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/approvals.yaml#/DenyApprovalRequest'
+          example:
+            reason: "Recipient not on approved contacts list."
 
     responses:
       '200':

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -122,6 +122,8 @@ ApprovalRequestResponse:
     result, or listen via `GET /v1/approvals/events` (SSE).
   required:
     - status
+    - terminal
+    - retryable
   properties:
     approval_id:
       type: string
@@ -153,6 +155,20 @@ ApprovalRequestResponse:
         `approved` — auto-approved via standing approval, result is inline.
       example: "pending"
 
+    terminal:
+      type: boolean
+      description: |
+        `true` when the approval lifecycle is complete (`approved`).
+        `false` while awaiting human review (`pending`).
+      example: false
+
+    retryable:
+      type: boolean
+      description: |
+        Whether the agent should retry the request. Always `false` for approval
+        request responses — agents must not blindly re-submit denied actions.
+      example: false
+
     expires_at:
       type: string
       format: date-time
@@ -182,7 +198,20 @@ ApprovalRequestResponse:
     approval_id: "appr_xyz789"
     approval_url: "http://localhost:8080/permission-slip/approve/appr_xyz789"
     status: "pending"
+    terminal: false
+    retryable: false
     expires_at: "2026-02-11T13:25:00Z"
+
+DenyApprovalRequest:
+  type: object
+  properties:
+    reason:
+      type: string
+      maxLength: 500
+      description: |
+        Optional human-readable explanation for the denial. Returned to the
+        agent via the status endpoint so it can adapt rather than retry blindly.
+      example: "This recipient is not on the approved contacts list."
 
 CancelApprovalRequest:
   type: object
@@ -394,6 +423,8 @@ ApprovalStatusResponse:
   required:
     - approval_id
     - status
+    - terminal
+    - retryable
   properties:
     approval_id:
       type: string
@@ -409,6 +440,32 @@ ApprovalStatusResponse:
         - expired
       description: Current status of the approval request. Pending approvals past their expiration time are returned as "expired".
       example: "approved"
+
+    terminal:
+      type: boolean
+      description: |
+        `true` when the approval lifecycle is complete and will not change
+        (`approved`, `denied`, `cancelled`, `expired`). `false` while still
+        `pending`.
+      example: true
+
+    retryable:
+      type: boolean
+      description: |
+        Whether the agent should retry the request. Always `false` for approval
+        status responses — terminal-negative states return non-200 HTTP codes.
+      example: false
+
+    reason:
+      type: string
+      maxLength: 500
+      description: |
+        Optional human-readable explanation when the approver denied the
+        request. Present on successful (200) responses only when the approver
+        supplied a reason; terminal error responses include `reason` in
+        `error.details` instead.
+      example: "Recipient not on approved contacts list."
+
     approved_at:
       type: string
       format: date-time
@@ -464,3 +521,9 @@ DenyApprovalResponse:
       format: date-time
       description: When the approval was denied
       example: "2026-02-21T10:30:00Z"
+    reason:
+      type: string
+      maxLength: 500
+      description: |
+        Optional human-readable explanation provided by the approver when denying.
+      example: "Recipient not on approved contacts list."

--- a/spec/openapi/components/schemas/errors.yaml
+++ b/spec/openapi/components/schemas/errors.yaml
@@ -33,6 +33,8 @@ Error:
         # 403 Forbidden
         - agent_not_authorized
         - approval_denied
+        - approval_cancelled
+        - approval_recently_denied
         - token_already_used
         - insufficient_scope
         - invalid_parameters
@@ -56,6 +58,8 @@ Error:
         - agent_already_registered
         - duplicate_request_id
         - approval_already_resolved
+        - approval_cancelled
+        - approval_recently_denied
         - duplicate_credential
         # 410 Gone
         - registration_expired

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -2800,19 +2800,36 @@ paths:
                         approver: alice
                       trace_id: trace_xyz789
         '409':
-          description: Duplicate request ID
+          description: Duplicate request ID or recently denied action
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-              example:
-                error:
-                  code: duplicate_request_id
-                  message: Request ID already used
-                  retryable: false
-                  details:
-                    request_id: a925fbe0-db83-4969-9dc5-27f40385f12c
-                  trace_id: trace_xyz789
+              examples:
+                duplicate_request_id:
+                  summary: Duplicate request ID
+                  value:
+                    error:
+                      code: duplicate_request_id
+                      message: Request ID already used
+                      retryable: false
+                      details:
+                        request_id: a925fbe0-db83-4969-9dc5-27f40385f12c
+                      trace_id: trace_xyz789
+                recently_denied:
+                  summary: Recently denied action (dedup short-circuit)
+                  value:
+                    error:
+                      code: approval_recently_denied
+                      message: This action was recently denied; do not retry without user intervention
+                      retryable: false
+                      details:
+                        approval_id: appr_xyz789
+                        status: denied
+                        terminal: true
+                        retryable: false
+                        reason: Recipient not on approved contacts list.
+                      trace_id: trace_xyz789
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
@@ -3401,6 +3418,9 @@ paths:
         authenticated user (as approver) and must be in `pending` status and
         not expired.
 
+        An optional `reason` may be supplied so the agent receives human-readable
+        feedback instead of blindly retrying the same action.
+
         This is a dashboard endpoint for human approvers.
       tags:
         - Approvals
@@ -3408,6 +3428,14 @@ paths:
         - SupabaseSession: []
       parameters:
         - $ref: '#/components/parameters/ApprovalId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DenyApprovalRequest'
+            example:
+              reason: Recipient not on approved contacts list.
       responses:
         '200':
           description: Approval denied successfully
@@ -3487,11 +3515,25 @@ paths:
         - `pending` → `approved` (with execution result) or `denied` or `cancelled`
         - Once resolved, the status is final and will not change
 
+        ## Terminal States (Non-200 Responses)
+
+        Terminal-negative states return explicit HTTP error codes so agents cannot
+        mistake them for "still pending":
+
+        - `denied` → `409 Conflict` with error code `approval_denied`, `retryable: false`
+        - `expired` → `410 Gone` with error code `approval_expired`, `retryable: false`
+        - `cancelled` → `409 Conflict` with error code `approval_cancelled`, `retryable: false`
+
+        Successful responses (`pending`, `approved`) return `200 OK` and include
+        `terminal` and `retryable` boolean fields. Agents MUST respect these flags
+        and MUST NOT re-submit actions that received a terminal-negative response.
+
         ## Recommended Polling Strategy
 
         - Poll every 1–2 seconds for the first 30 seconds
         - Then every 5 seconds until expiration
-        - Stop polling when status is no longer `pending` or when `expires_at` has passed
+        - Stop polling when status is no longer `pending`, when `terminal` is `true`,
+          when a non-200 response is received, or when `expires_at` has passed
         - Prefer SSE (`GET /v1/approvals/events`) for real-time notifications when possible
 
         ## Security
@@ -3517,12 +3559,16 @@ paths:
                   value:
                     approval_id: appr_xyz789
                     status: pending
+                    terminal: false
+                    retryable: false
                     expires_at: '2026-02-21T10:35:00Z'
                 approved_with_result:
                   summary: Approved and executed successfully
                   value:
                     approval_id: appr_xyz789
                     status: approved
+                    terminal: true
+                    retryable: false
                     approved_at: '2026-02-21T10:30:00Z'
                     expires_at: '2026-02-21T10:35:00Z'
                     execution_status: success
@@ -3535,16 +3581,11 @@ paths:
                   value:
                     approval_id: appr_xyz789
                     status: approved
+                    terminal: true
+                    retryable: false
                     approved_at: '2026-02-21T10:30:00Z'
                     expires_at: '2026-02-21T10:35:00Z'
                     execution_status: pending
-                denied:
-                  summary: Approval denied
-                  value:
-                    approval_id: appr_xyz789
-                    status: denied
-                    denied_at: '2026-02-21T10:30:00Z'
-                    expires_at: '2026-02-21T10:35:00Z'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -3562,6 +3603,60 @@ paths:
                   retryable: false
                   details:
                     approval_id: appr_xyz789
+                  trace_id: trace_xyz789
+        '409':
+          description: Approval denied or cancelled (terminal, non-retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                denied:
+                  summary: Approval denied by approver
+                  value:
+                    error:
+                      code: approval_denied
+                      message: Approval was denied by the approver
+                      retryable: false
+                      details:
+                        approval_id: appr_xyz789
+                        status: denied
+                        terminal: true
+                        retryable: false
+                        reason: Recipient not on approved contacts list.
+                        denied_at: '2026-02-21T10:30:00Z'
+                      trace_id: trace_xyz789
+                cancelled:
+                  summary: Approval cancelled by agent
+                  value:
+                    error:
+                      code: approval_cancelled
+                      message: Approval was cancelled
+                      retryable: false
+                      details:
+                        approval_id: appr_xyz789
+                        status: cancelled
+                        terminal: true
+                        retryable: false
+                        cancelled_at: '2026-02-21T10:29:00Z'
+                      trace_id: trace_xyz789
+        '410':
+          description: Approval expired (terminal, non-retryable)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: approval_expired
+                  message: Approval has expired
+                  retryable: false
+                  details:
+                    approval_id: appr_xyz789
+                    status: expired
+                    terminal: true
+                    retryable: false
+                    expires_at: '2026-02-21T10:25:00Z'
                   trace_id: trace_xyz789
         '429':
           $ref: '#/components/responses/TooManyRequests'
@@ -6472,6 +6567,8 @@ components:
         result, or listen via `GET /v1/approvals/events` (SSE).
       required:
         - status
+        - terminal
+        - retryable
       properties:
         approval_id:
           type: string
@@ -6499,6 +6596,18 @@ components:
             `pending` — approval created, awaiting human review.
             `approved` — auto-approved via standing approval, result is inline.
           example: pending
+        terminal:
+          type: boolean
+          description: |
+            `true` when the approval lifecycle is complete (`approved`).
+            `false` while awaiting human review (`pending`).
+          example: false
+        retryable:
+          type: boolean
+          description: |
+            Whether the agent should retry the request. Always `false` for approval
+            request responses — agents must not blindly re-submit denied actions.
+          example: false
         expires_at:
           type: string
           format: date-time
@@ -6524,6 +6633,8 @@ components:
         approval_id: appr_xyz789
         approval_url: http://localhost:8080/permission-slip/approve/appr_xyz789
         status: pending
+        terminal: false
+        retryable: false
         expires_at: '2026-02-11T13:25:00Z'
     CancelApprovalRequest:
       type: object
@@ -6539,6 +6650,16 @@ components:
           example: 21d9ec79-6b20-45b9-8695-83537318966d
       example:
         request_id: 21d9ec79-6b20-45b9-8695-83537318966d
+    DenyApprovalRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          maxLength: 500
+          description: |
+            Optional human-readable explanation for the denial. Returned to the
+            agent via the status endpoint so it can adapt rather than retry blindly.
+          example: This recipient is not on the approved contacts list.
     CancelApprovalResponse:
       type: object
       required:
@@ -6738,6 +6859,12 @@ components:
           format: date-time
           description: When the approval was denied
           example: '2026-02-21T10:30:00Z'
+        reason:
+          type: string
+          maxLength: 500
+          description: |
+            Optional human-readable explanation provided by the approver when denying.
+          example: Recipient not on approved contacts list.
     ApprovalStatusResponse:
       type: object
       description: |
@@ -6747,6 +6874,8 @@ components:
       required:
         - approval_id
         - status
+        - terminal
+        - retryable
       properties:
         approval_id:
           type: string
@@ -6762,6 +6891,28 @@ components:
             - expired
           description: Current status of the approval request. Pending approvals past their expiration time are returned as "expired".
           example: approved
+        terminal:
+          type: boolean
+          description: |
+            `true` when the approval lifecycle is complete and will not change
+            (`approved`, `denied`, `cancelled`, `expired`). `false` while still
+            `pending`.
+          example: true
+        retryable:
+          type: boolean
+          description: |
+            Whether the agent should retry the request. Always `false` for approval
+            status responses — terminal-negative states return non-200 HTTP codes.
+          example: false
+        reason:
+          type: string
+          maxLength: 500
+          description: |
+            Optional human-readable explanation when the approver denied the
+            request. Present on successful (200) responses only when the approver
+            supplied a reason; terminal error responses include `reason` in
+            `error.details` instead.
+          example: Recipient not on approved contacts list.
         approved_at:
           type: string
           format: date-time
@@ -10432,6 +10583,8 @@ components:
             - oauth_refresh_failed
             - agent_not_authorized
             - approval_denied
+            - approval_cancelled
+            - approval_recently_denied
             - token_already_used
             - insufficient_scope
             - invalid_parameters
@@ -10451,6 +10604,8 @@ components:
             - agent_already_registered
             - duplicate_request_id
             - approval_already_resolved
+            - approval_cancelled
+            - approval_recently_denied
             - duplicate_credential
             - registration_expired
             - verification_locked

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -345,6 +345,8 @@ components:
       $ref: './components/schemas/approvals.yaml#/ApprovalRequestResponse'
     CancelApprovalRequest:
       $ref: './components/schemas/approvals.yaml#/CancelApprovalRequest'
+    DenyApprovalRequest:
+      $ref: './components/schemas/approvals.yaml#/DenyApprovalRequest'
     CancelApprovalResponse:
       $ref: './components/schemas/approvals.yaml#/CancelApprovalResponse'
     ApprovalSummary:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Agents polling `GET /approvals/{id}/status` now get explicit terminal semantics: `terminal`/`retryable` on 200 responses, and non-200 HTTP codes (`409` denied/cancelled, `410` expired) with structured error bodies for terminal-negative states.
- Re-submitting an action that was recently denied is short-circuited via action fingerprint + cooldown (`APPROVAL_DENIAL_COOLDOWN`, default 10m) instead of creating a new pending approval.
- Approvers can optionally supply a denial reason (dashboard UI + `POST /approvals/{id}/deny` body); the reason is surfaced back to agents in status/error responses.

Closes #1282

## Test plan

### Claude Code
- [x] OpenAPI spec updated (`terminal`, `retryable`, `reason`, new error codes/responses)
- [x] OpenAPI bundle regenerated
- [x] Frontend API client regenerated; `npm run build` passes
- [x] Frontend hook tests pass (`useDenyApproval`)
- [x] Added backend tests for status HTTP mapping, dedup short-circuit, and deny-with-reason
- [x] `gofmt` on all changed Go files
- [ ] Backend tests not run locally (sandbox Go 1.24 / bigquery constraint) — rely on CI

### OpenClaw
- [ ] Verify deny-with-reason UX in the approval review dialog feels natural
- [ ] Confirm breaking change to status polling is acceptable for existing agent integrations

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb5a1d00-1eeb-42be-960d-c80a419a037d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb5a1d00-1eeb-42be-960d-c80a419a037d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

