### PR TITLE
Bulk approval requests + CLI changelog for agent discoverability

### DIFF
--- a/api/agent_approvals_bulk.go
+++ b/api/agent_approvals_bulk.go
@@ -171,7 +171,7 @@ func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
 		}
 
 		results := make([]bulkApprovalItemResult, len(prepared))
-		var pendingApprovals []*db.Approval
+		var pendingApprovals []db.Approval
 		anyPending := false
 
 		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
@@ -229,7 +229,7 @@ func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
 					RequestID: item.requestID,
 					Status:    "denied",
 					Error: &bulkItemError{
-						Code:    ErrApprovalRecentlyDenied,
+						Code:    string(ErrApprovalRecentlyDenied),
 						Message: "This action was recently denied; do not retry without user intervention",
 					},
 				}
@@ -269,7 +269,7 @@ func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
 				return
 			}
 
-			pendingApprovals = append(pendingApprovals, appr)
+			pendingApprovals = append(pendingApprovals, *appr)
 			anyPending = true
 			results[i] = bulkApprovalItemResult{
 				RequestID:  item.requestID,
@@ -294,8 +294,8 @@ func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
 		if anyPending {
 			NotifyBulkApprovalRequest(r.Context(), deps, group, agent, approverProfile, actionType)
 			notifyBulkApprovalChange(deps, agent.ApproverID, bulkGroupID)
-			for _, appr := range pendingApprovals {
-				emitApprovalRequestAuditEvent(r.Context(), deps.DB, agent.ApproverID, appr, agent.Metadata)
+			for i := range pendingApprovals {
+				emitApprovalRequestAuditEvent(r.Context(), deps.DB, agent.ApproverID, &pendingApprovals[i], agent.Metadata)
 			}
 		}
 

--- a/api/agent_approvals_bulk.go
+++ b/api/agent_approvals_bulk.go
@@ -1,0 +1,633 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/shared"
+)
+
+const (
+	bulkApprovalMinItems = 2
+	bulkApprovalMaxItems = 50
+)
+
+type bulkApprovalRequestItem struct {
+	RequestID       string                  `json:"request_id" validate:"required"`
+	Action          json.RawMessage         `json:"action" validate:"required"`
+	Context         json.RawMessage         `json:"context" validate:"required"`
+	Configuration   *agentApprovalConfigRef `json:"configuration,omitempty"`
+	PaymentMethodID string                  `json:"payment_method_id,omitempty"`
+	AmountCents     *int                    `json:"amount_cents,omitempty"`
+}
+
+type agentBulkRequestApprovalRequest struct {
+	Items     []bulkApprovalRequestItem `json:"items" validate:"required,min=2,max=50,dive"`
+	ExpiresIn *int                      `json:"expires_in,omitempty" validate:"omitempty,gte=60,lte=86400"`
+}
+
+type bulkApprovalItemResult struct {
+	RequestID          string           `json:"request_id"`
+	ApprovalID         string           `json:"approval_id,omitempty"`
+	Status             string           `json:"status"`
+	Result             *json.RawMessage `json:"result,omitempty"`
+	StandingApprovalID string           `json:"standing_approval_id,omitempty"`
+	ExecutionStatus    *string          `json:"execution_status,omitempty"`
+	ExecutionResult    *json.RawMessage `json:"execution_result,omitempty"`
+	Error              *bulkItemError   `json:"error,omitempty"`
+}
+
+type bulkItemError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type agentBulkRequestApprovalResponse struct {
+	BulkGroupID string                   `json:"bulk_group_id"`
+	ApprovalURL string                   `json:"approval_url,omitempty"`
+	ActionType  string                   `json:"action_type"`
+	ItemCount   int                      `json:"item_count"`
+	Status      string                   `json:"status"`
+	ExpiresAt   *time.Time               `json:"expires_at,omitempty"`
+	CreatedAt   *time.Time               `json:"created_at,omitempty"`
+	Results     []bulkApprovalItemResult `json:"results"`
+}
+
+type preparedBulkItem struct {
+	requestID           string
+	action              json.RawMessage
+	context             json.RawMessage
+	actionType          string
+	actionParams        json.RawMessage
+	actionFingerprint   string
+	connectorInstanceID string
+	resourceDetails     []byte
+}
+
+func RegisterAgentBulkApprovalRoutes(mux *http.ServeMux, deps *Deps) {
+	requireAgent := RequireAgentSignature(deps)
+	mux.Handle("POST /approvals/bulk-request", requireAgent(handleAgentBulkRequestApproval(deps)))
+	mux.Handle("GET /approval-groups/{group_id}/status", requireAgent(handleAgentBulkGroupStatus(deps)))
+}
+
+func init() {
+	RegisterRouteGroup(func(mux *http.ServeMux, deps *Deps) {
+		RegisterAgentBulkApprovalRoutes(mux, deps)
+	})
+}
+
+func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		agent := AuthenticatedAgent(r.Context())
+
+		var req agentBulkRequestApprovalRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		if len(req.Items) < bulkApprovalMinItems || len(req.Items) > bulkApprovalMaxItems {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("bulk request must contain between %d and %d items", bulkApprovalMinItems, bulkApprovalMaxItems)))
+			return
+		}
+
+		// Reject payment fields in bulk (v1).
+		for i, item := range req.Items {
+			if strings.TrimSpace(item.PaymentMethodID) != "" || item.AmountCents != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					fmt.Sprintf("payment actions are not supported in bulk (item %d)", i)))
+				return
+			}
+		}
+
+		prepared, err := prepareBulkItems(w, r, deps, agent, req.Items)
+		if err != nil {
+			return // response already written
+		}
+		if prepared == nil {
+			return
+		}
+
+		actionType := prepared[0].actionType
+		for _, p := range prepared[1:] {
+			if p.actionType != actionType {
+				errResp := BadRequest(ErrInvalidRequest, "all items in a bulk request must share the same action type")
+				errResp.Error.Details = map[string]any{
+					"expected_action_type":   actionType,
+					"mismatched_action_type": p.actionType,
+				}
+				RespondError(w, r, http.StatusBadRequest, errResp)
+				return
+			}
+		}
+
+		if deps.Connectors != nil {
+			requiresPayment, payErr := db.GetActionRequiresPaymentMethod(r.Context(), deps.DB, actionType)
+			if payErr != nil {
+				log.Printf("[%s] BulkRequest: payment check: %v", TraceID(r.Context()), payErr)
+				CaptureError(r.Context(), payErr)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to validate action"))
+				return
+			}
+			if requiresPayment {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					"payment-required actions are not supported in bulk"))
+				return
+			}
+		}
+
+		expiresAt := time.Now().UTC().Add(db.DefaultApprovalTTL)
+		if req.ExpiresIn != nil {
+			expiresAt = time.Now().UTC().Add(time.Duration(*req.ExpiresIn) * time.Second)
+		}
+
+		bulkGroupID, err := generatePrefixedID("bgrp_", 16)
+		if err != nil {
+			log.Printf("[%s] BulkRequest: generate group id: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+			return
+		}
+
+		approverProfile, err := db.GetProfileByUserID(r.Context(), deps.DB, agent.ApproverID)
+		if err != nil || approverProfile == nil {
+			if err != nil {
+				log.Printf("[%s] BulkRequest: profile lookup: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+			}
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApproverNotFound, "Approver profile not found"))
+			return
+		}
+
+		results := make([]bulkApprovalItemResult, len(prepared))
+		var pendingApprovals []*db.Approval
+		anyPending := false
+
+		tx, owned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] BulkRequest: begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+			return
+		}
+		if owned {
+			defer db.RollbackTx(r.Context(), tx)
+		}
+
+		group, err := db.InsertApprovalBulkGroup(r.Context(), tx, db.InsertApprovalBulkGroupParams{
+			BulkGroupID: bulkGroupID,
+			AgentID:     agent.AgentID,
+			ApproverID:  agent.ApproverID,
+			ActionType:  actionType,
+			ItemCount:   len(prepared),
+			ExpiresAt:   expiresAt,
+		})
+		if err != nil {
+			log.Printf("[%s] BulkRequest: insert group: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+			return
+		}
+
+		cooldownSince := time.Now().UTC().Add(-approvalDenialCooldown(deps))
+
+		for i, item := range prepared {
+			outcome := attemptStandingApprovalForBulk(r.Context(), deps, agent, item)
+			if outcome.duplicateRequest {
+				RespondError(w, r, http.StatusConflict, Conflict(ErrDuplicateRequestID,
+					fmt.Sprintf("A request with request_id %q has already been submitted", item.requestID)))
+				return
+			}
+			if outcome.approved {
+				results[i] = bulkApprovalItemResult{
+					RequestID:          item.requestID,
+					Status:             "approved",
+					Result:             outcome.result,
+					StandingApprovalID: outcome.standingApprovalID,
+				}
+				continue
+			}
+
+			if recentDenied, err := db.FindRecentDeniedApproval(r.Context(), tx, agent.AgentID, agent.ApproverID, item.actionFingerprint, cooldownSince); err != nil {
+				log.Printf("[%s] BulkRequest: recent denial lookup: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+				return
+			} else if recentDenied != nil {
+				results[i] = bulkApprovalItemResult{
+					RequestID: item.requestID,
+					Status:    "denied",
+					Error: &bulkItemError{
+						Code:    ErrApprovalRecentlyDenied,
+						Message: "This action was recently denied; do not retry without user intervention",
+					},
+				}
+				continue
+			}
+
+			approvalID, genErr := generatePrefixedID("appr_", 16)
+			if genErr != nil {
+				log.Printf("[%s] BulkRequest: generate approval id: %v", TraceID(r.Context()), genErr)
+				CaptureError(r.Context(), genErr)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+				return
+			}
+
+			groupID := bulkGroupID
+			appr, insErr := db.InsertApproval(r.Context(), tx, db.InsertApprovalParams{
+				ApprovalID:        approvalID,
+				AgentID:           agent.AgentID,
+				ApproverID:        agent.ApproverID,
+				BulkGroupID:       &groupID,
+				Action:            item.action,
+				Context:           item.context,
+				ResourceDetails:   item.resourceDetails,
+				ActionFingerprint: item.actionFingerprint,
+				ExpiresAt:         expiresAt,
+			}, item.requestID)
+			if insErr != nil {
+				var apprErr *db.ApprovalError
+				if errors.As(insErr, &apprErr) && apprErr.Code == db.ApprovalErrDuplicateRequest {
+					RespondError(w, r, http.StatusConflict, Conflict(ErrDuplicateRequestID,
+						fmt.Sprintf("A request with request_id %q has already been submitted", item.requestID)))
+					return
+				}
+				log.Printf("[%s] BulkRequest: insert approval: %v", TraceID(r.Context()), insErr)
+				CaptureError(r.Context(), insErr)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+				return
+			}
+
+			pendingApprovals = append(pendingApprovals, appr)
+			anyPending = true
+			results[i] = bulkApprovalItemResult{
+				RequestID:  item.requestID,
+				ApprovalID: appr.ApprovalID,
+				Status:     "pending",
+			}
+		}
+
+		if owned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] BulkRequest: commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to create bulk approval"))
+				return
+			}
+		}
+
+		if err := db.TouchAgentLastActive(r.Context(), deps.DB, agent.AgentID); err != nil {
+			log.Printf("[%s] BulkRequest: touch last_active: %v", TraceID(r.Context()), agent.AgentID, err)
+		}
+
+		if anyPending {
+			NotifyBulkApprovalRequest(r.Context(), deps, group, agent, approverProfile, actionType)
+			notifyBulkApprovalChange(deps, agent.ApproverID, bulkGroupID)
+			for _, appr := range pendingApprovals {
+				emitApprovalRequestAuditEvent(r.Context(), deps.DB, agent.ApproverID, appr, agent.Metadata)
+			}
+		}
+
+		groupStatus := db.BulkGroupAggregateStatus(pendingApprovals, time.Now().UTC())
+		if !anyPending {
+			groupStatus = "resolved"
+		}
+
+		resp := agentBulkRequestApprovalResponse{
+			BulkGroupID: bulkGroupID,
+			ActionType:  actionType,
+			ItemCount:   len(prepared),
+			Status:      groupStatus,
+			ExpiresAt:   &group.ExpiresAt,
+			CreatedAt:   &group.CreatedAt,
+			Results:     results,
+		}
+		if anyPending {
+			resp.ApprovalURL = fmt.Sprintf("%s/approve-group/%s", deps.BaseURL, bulkGroupID)
+		}
+
+		RespondJSON(w, http.StatusOK, resp)
+	}
+}
+
+func prepareBulkItems(w http.ResponseWriter, r *http.Request, deps *Deps, agent *db.Agent, items []bulkApprovalRequestItem) ([]preparedBulkItem, error) {
+	prepared := make([]preparedBulkItem, 0, len(items))
+	for i, item := range items {
+		item.RequestID = strings.TrimSpace(item.RequestID)
+		if item.RequestID == "" || len(item.RequestID) > 255 {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("item %d: request_id is required and must be at most 255 characters", i)))
+			return nil, fmt.Errorf("invalid request_id")
+		}
+		if isRawJSONNull(item.Action) || isRawJSONNull(item.Context) {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("item %d: action and context must be JSON objects", i)))
+			return nil, fmt.Errorf("invalid json")
+		}
+		if err := ValidateJSONObject(item.Action); err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("item %d: action must be a JSON object", i)))
+			return nil, fmt.Errorf("invalid json")
+		}
+		if err := ValidateJSONObject(item.Context); err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+				fmt.Sprintf("item %d: context must be a JSON object", i)))
+			return nil, fmt.Errorf("invalid json")
+		}
+
+		actionObj, actionType, ok := parseAndNormalizeBulkAction(w, r, deps, item.Action, i)
+		if !ok {
+			return nil, fmt.Errorf("invalid action")
+		}
+
+		connectorInstanceID, err := applyConnectorInstanceToAction(r.Context(), deps.DB, agent, actionType, actionObj)
+		if err != nil {
+			var ciErr *connectorInstanceResolutionError
+			if errors.As(err, &ciErr) {
+				RespondError(w, r, ciErr.status, ciErr.resp)
+				return nil, err
+			}
+			log.Printf("[%s] BulkRequest prepare item %d: connector instance: %v", TraceID(r.Context()), i, err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to process action"))
+			return nil, err
+		}
+		if updated, mErr := json.Marshal(actionObj); mErr == nil {
+			item.Action = updated
+		}
+
+		actionParams := json.RawMessage(actionObj["parameters"])
+		if !validateActionParameters(w, r, deps.DB, actionType, actionParams) {
+			return nil, fmt.Errorf("invalid parameters")
+		}
+
+		if item.Configuration != nil {
+			result := ValidateConfigurationReference(w, r, deps, item.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
+			if result == nil {
+				return nil, fmt.Errorf("invalid configuration")
+			}
+		}
+
+		resourceDetails := resolveResourceDetailsForBulk(r.Context(), deps, agent, actionType, actionParams, connectorInstanceID)
+		contextForStore := mergeSlackContextFromResourceDetailsIntoContext(
+			mergeEmailThreadFromResourceDetailsIntoContext(item.Context, resourceDetails),
+			resourceDetails,
+		)
+
+		prepared = append(prepared, preparedBulkItem{
+			requestID:           item.RequestID,
+			action:              item.Action,
+			context:             contextForStore,
+			actionType:          actionType,
+			actionParams:        actionParams,
+			actionFingerprint:   db.ComputeActionFingerprint(agent.AgentID, agent.ApproverID, item.Action),
+			connectorInstanceID: connectorInstanceID,
+			resourceDetails:     resourceDetails,
+		})
+	}
+	return prepared, nil
+}
+
+func parseAndNormalizeBulkAction(w http.ResponseWriter, r *http.Request, deps *Deps, action json.RawMessage, index int) (map[string]json.RawMessage, string, bool) {
+	var actionObj map[string]json.RawMessage
+	if err := json.Unmarshal(action, &actionObj); err != nil {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+			fmt.Sprintf("item %d: action must be a JSON object", index)))
+		return nil, "", false
+	}
+	typeRaw, hasType := actionObj["type"]
+	if !hasType {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+			fmt.Sprintf("item %d: action.type is required", index)))
+		return nil, "", false
+	}
+	var actionType string
+	if err := json.Unmarshal(typeRaw, &actionType); err != nil || strings.TrimSpace(actionType) == "" {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+			fmt.Sprintf("item %d: action.type must be a non-empty string", index)))
+		return nil, "", false
+	}
+	if len(actionType) > shared.ActionTypeMaxLength {
+		RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+			fmt.Sprintf("item %d: action.type exceeds maximum length", index)))
+		return nil, "", false
+	}
+
+	if deps.Connectors != nil {
+		connAction, conn, ok := deps.Connectors.GetActionWithConnector(actionType)
+		if !ok {
+			errResp := BadRequest(ErrUnsupportedActionType, fmt.Sprintf("unknown action type %q", actionType))
+			errResp.Error.Details = map[string]any{"action_type": actionType, "item_index": index}
+			RespondError(w, r, http.StatusBadRequest, errResp)
+			return nil, "", false
+		}
+		if aliaser, ok := connAction.(connectors.ParameterAliaser); ok {
+			if aliases := aliaser.ParameterAliases(); len(aliases) > 0 {
+				if rawParams, hasParams := actionObj["parameters"]; hasParams {
+					actionObj["parameters"] = connectors.NormalizeParameters(aliases, rawParams)
+				}
+			}
+		}
+		if normalizer, ok := connAction.(connectors.Normalizer); ok {
+			if rawParams, hasParams := actionObj["parameters"]; hasParams {
+				actionObj["parameters"] = normalizer.Normalize(rawParams)
+			}
+		}
+		if rawParams, hasParams := actionObj["parameters"]; hasParams {
+			var validationErr error
+			if rv, ok := connAction.(connectors.RequestValidator); ok {
+				validationErr = rv.ValidateRequest(json.RawMessage(rawParams))
+			} else if pv, ok := conn.(connectors.ParamValidator); ok {
+				validationErr = pv.ValidateParams(actionType, json.RawMessage(rawParams))
+			}
+			if validationErr != nil {
+				var ve *connectors.ValidationError
+				msg := "invalid action parameters"
+				if errors.As(validationErr, &ve) {
+					msg = ve.Message
+				}
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest,
+					fmt.Sprintf("item %d: %s", index, msg)))
+				return nil, "", false
+			}
+		}
+	}
+
+	return actionObj, actionType, true
+}
+
+func resolveResourceDetailsForBulk(ctx context.Context, deps *Deps, agent *db.Agent, actionType string, actionParams json.RawMessage, connectorInstanceID string) []byte {
+	if deps.Connectors == nil {
+		return nil
+	}
+	cid := strings.SplitN(actionType, ".", 2)
+	if len(cid) != 2 {
+		return nil
+	}
+	conn, ok := deps.Connectors.Get(cid[0])
+	if !ok {
+		return nil
+	}
+	resolver, ok := conn.(connectors.ResourceDetailResolver)
+	if !ok {
+		return nil
+	}
+	resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	details, err := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams,
+		resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID))
+	if err != nil {
+		log.Printf("[%s] BulkRequest ResolveResourceDetails: %v", TraceID(ctx), err)
+		return nil
+	}
+	if details == nil {
+		return nil
+	}
+	encoded, err := json.Marshal(details)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+type bulkStandingOutcome struct {
+	approved           bool
+	duplicateRequest   bool
+	result             *json.RawMessage
+	standingApprovalID string
+}
+
+func attemptStandingApprovalForBulk(ctx context.Context, deps *Deps, agent *db.Agent, item preparedBulkItem) bulkStandingOutcome {
+	approvals, err := db.FindActiveStandingApprovalsForAgent(ctx, deps.DB, agent.AgentID, item.actionType, item.connectorInstanceID)
+	if err != nil || len(approvals) == 0 {
+		return bulkStandingOutcome{}
+	}
+
+	var sa *db.StandingApproval
+	for _, candidate := range approvals {
+		if len(candidate.Constraints) == 0 {
+			sa = candidate
+			break
+		}
+		if err := db.ValidateParametersAgainstConfig(candidate.Constraints, item.actionParams); err != nil {
+			continue
+		}
+		sa = candidate
+		break
+	}
+	if sa == nil {
+		return bulkStandingOutcome{}
+	}
+
+	exec, err := db.RecordStandingApprovalExecutionByAgent(ctx, deps.DB, sa.StandingApprovalID, agent.AgentID, item.requestID, item.actionParams)
+	if err != nil {
+		var saErr *db.StandingApprovalError
+		if errors.As(err, &saErr) && saErr.Code == db.StandingApprovalErrDuplicateRequest {
+			return bulkStandingOutcome{duplicateRequest: true}
+		}
+		return bulkStandingOutcome{}
+	}
+
+	result, execErr := executeConnectorAction(ctx, deps, exec.AgentID, exec.UserID, item.actionType, item.actionParams, nil, item.connectorInstanceID)
+	emitStandingApprovalAuditEvent(ctx, deps.DB, exec.UserID, exec.AgentID, sa.StandingApprovalID, exec.ActionType, exec.AgentMeta, execErr)
+	if execErr != nil {
+		return bulkStandingOutcome{}
+	}
+
+	NotifyStandingApprovalExecution(ctx, deps, exec, agent, item.actionType, item.actionParams)
+
+	var actionResultPtr *json.RawMessage
+	if result != nil {
+		actionResultPtr = &result.Data
+	}
+
+	return bulkStandingOutcome{
+		approved:           true,
+		result:             actionResultPtr,
+		standingApprovalID: sa.StandingApprovalID,
+	}
+}
+
+func handleAgentBulkGroupStatus(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		agent := AuthenticatedAgent(r.Context())
+		groupID := strings.TrimSpace(r.PathValue("group_id"))
+		if groupID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "group_id is required"))
+			return
+		}
+
+		group, err := db.GetApprovalBulkGroupByIDAndAgent(r.Context(), deps.DB, groupID, agent.AgentID)
+		if err != nil {
+			log.Printf("[%s] BulkGroupStatus: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get bulk group status"))
+			return
+		}
+		if group == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Bulk group not found"))
+			return
+		}
+
+		approvals, err := db.ListApprovalsByBulkGroupID(r.Context(), deps.DB, groupID)
+		if err != nil {
+			log.Printf("[%s] BulkGroupStatus list: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get bulk group status"))
+			return
+		}
+
+		RespondJSON(w, http.StatusOK, buildBulkGroupStatusResponse(*group, approvals))
+	}
+}
+
+func buildBulkGroupStatusResponse(group db.ApprovalBulkGroup, approvals []db.Approval) agentBulkGroupStatusResponse {
+	results := make([]bulkApprovalItemResult, 0, len(approvals))
+	for _, a := range approvals {
+		status := resolvedApprovalStatus(a)
+		item := bulkApprovalItemResult{
+			RequestID:  "",
+			ApprovalID: a.ApprovalID,
+			Status:     status,
+		}
+		if a.ExecutionStatus != nil {
+			item.ExecutionStatus = a.ExecutionStatus
+		}
+		if len(a.ExecutionResult) > 0 {
+			raw := json.RawMessage(a.ExecutionResult)
+			item.ExecutionResult = &raw
+		}
+		results = append(results, item)
+	}
+
+	return agentBulkGroupStatusResponse{
+		BulkGroupID: group.BulkGroupID,
+		ActionType:  group.ActionType,
+		ItemCount:   group.ItemCount,
+		Status:      db.BulkGroupAggregateStatus(approvals, time.Now().UTC()),
+		ExpiresAt:   group.ExpiresAt,
+		CreatedAt:   group.CreatedAt,
+		Results:     results,
+	}
+}
+
+type agentBulkGroupStatusResponse struct {
+	BulkGroupID string                   `json:"bulk_group_id"`
+	ActionType  string                   `json:"action_type"`
+	ItemCount   int                      `json:"item_count"`
+	Status      string                   `json:"status"`
+	ExpiresAt   time.Time                `json:"expires_at"`
+	CreatedAt   time.Time                `json:"created_at"`
+	Results     []bulkApprovalItemResult `json:"results"`
+}

--- a/api/agent_approvals_bulk.go
+++ b/api/agent_approvals_bulk.go
@@ -288,7 +288,7 @@ func handleAgentBulkRequestApproval(deps *Deps) http.HandlerFunc {
 		}
 
 		if err := db.TouchAgentLastActive(r.Context(), deps.DB, agent.AgentID); err != nil {
-			log.Printf("[%s] BulkRequest: touch last_active: %v", TraceID(r.Context()), agent.AgentID, err)
+			log.Printf("[%s] BulkRequest: touch last_active for agent %d: %v", TraceID(r.Context()), agent.AgentID, err)
 		}
 
 		if anyPending {

--- a/api/agent_approvals_bulk_test.go
+++ b/api/agent_approvals_bulk_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func setupBulkTestAgent(t *testing.T) (agentID int64, privKey ed25519.PrivateKey, router http.Handler) {
+	t.Helper()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, priv, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID = testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+	deps := &Deps{DB: tx, JWTSigningSecret: testJWTSecret, BaseURL: "http://localhost:8080"}
+	return agentID, priv, NewRouter(deps)
+}
+
+func TestBulkRequestRejectsMixedActionTypes(t *testing.T) {
+	t.Parallel()
+	agentID, privKey, router := setupBulkTestAgent(t)
+
+	reqBody := `{"items":[{"request_id":"req_m1","action":{"type":"email.send","parameters":{"to":"a@example.com"}},"context":{}},{"request_id":"req_m2","action":{"type":"calendar.create_event","parameters":{"title":"x"}},"context":{}}]}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/bulk-request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBulkRequestRejectsSingleItem(t *testing.T) {
+	t.Parallel()
+	agentID, privKey, router := setupBulkTestAgent(t)
+
+	reqBody := `{"items":[{"request_id":"req_one","action":{"type":"email.send","parameters":{"to":"a@example.com"}},"context":{}}]}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/bulk-request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestBulkRequestCreatesGroup(t *testing.T) {
+	t.Parallel()
+	agentID, privKey, router := setupBulkTestAgent(t)
+
+	reqBody := `{"items":[{"request_id":"req_b1","action":{"type":"email.send","parameters":{"to":"a@example.com","subject":"Hi","body":"One"}},"context":{"description":"first"}},{"request_id":"req_b2","action":{"type":"email.send","parameters":{"to":"b@example.com","subject":"Hi","body":"Two"}},"context":{"description":"second"}}]}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/bulk-request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp agentBulkRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.BulkGroupID == "" {
+		t.Fatal("expected bulk_group_id")
+	}
+	if resp.ItemCount != 2 {
+		t.Fatalf("expected item_count 2, got %d", resp.ItemCount)
+	}
+	if len(resp.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Results))
+	}
+
+	statusReq := signedJSONRequest(t, http.MethodGet, "/approval-groups/"+resp.BulkGroupID+"/status", "", privKey, agentID)
+	statusW := httptest.NewRecorder()
+	router.ServeHTTP(statusW, statusReq)
+	if statusW.Code != http.StatusOK {
+		t.Fatalf("group status: expected 200, got %d: %s", statusW.Code, statusW.Body.String())
+	}
+}

--- a/api/approval_events.go
+++ b/api/approval_events.go
@@ -240,6 +240,15 @@ func notifyApprovalChange(deps *Deps, userID string, eventType string, approvalI
 	}
 }
 
+// notifyBulkApprovalChange sends an SSE event when a bulk group is created or updated.
+func notifyBulkApprovalChange(deps *Deps, userID string, bulkGroupID string) {
+	if deps.ApprovalEvents == nil {
+		return
+	}
+	event := fmt.Sprintf("event: bulk_approval_changed\ndata: {\"bulk_group_id\":%q}", bulkGroupID)
+	deps.ApprovalEvents.Notify(userID, event)
+}
+
 // notifyApprovalExecuted sends an SSE event with the execution status when an
 // approved action has been executed. This notifies the approver's connected
 // browser tabs so they can update the UI with the execution outcome.

--- a/api/approval_notify.go
+++ b/api/approval_notify.go
@@ -55,6 +55,46 @@ func NotifyApprovalRequest(ctx context.Context, deps *Deps, approval *db.Approva
 	log.Printf("notify: dispatched approval notification for %s to user %s", approval.ApprovalID, approver.ID)
 }
 
+// NotifyBulkApprovalRequest dispatches one notification for a bulk approval group.
+func NotifyBulkApprovalRequest(ctx context.Context, deps *Deps, group *db.ApprovalBulkGroup, agent *db.Agent, approver *db.Profile, actionType string) {
+	if deps.Notifier == nil {
+		return
+	}
+	if deps.BaseURL == "" {
+		log.Printf("notify: skipping bulk notification for %s — BASE_URL is not configured", group.BulkGroupID)
+		return
+	}
+
+	agentName := extractAgentName(agent)
+	approvalURL := fmt.Sprintf("%s/approve-group/%s", deps.BaseURL, group.BulkGroupID)
+	actionJSON, _ := json.Marshal(map[string]string{"type": actionType})
+
+	notifApproval := notify.Approval{
+		ApprovalID:  group.BulkGroupID,
+		BulkGroupID: group.BulkGroupID,
+		AgentID:     group.AgentID,
+		AgentName:   agentName,
+		Action:      actionJSON,
+		ActionType:  actionType,
+		ItemCount:   group.ItemCount,
+		ApprovalURL: approvalURL,
+		ExpiresAt:   group.ExpiresAt,
+		CreatedAt:   group.CreatedAt,
+		Type:        notify.NotificationTypeBulkApproval,
+	}
+
+	recipient := notify.Recipient{
+		UserID:   approver.ID,
+		Username: approver.Username,
+		Email:    approver.Email,
+		Phone:    approver.Phone,
+	}
+
+	deps.Notifier.Dispatch(ctx, notifApproval, recipient)
+	log.Printf("notify: dispatched bulk approval notification for %s (%d items) to user %s",
+		group.BulkGroupID, group.ItemCount, approver.ID)
+}
+
 // extractAgentName pulls the human-readable name from agent metadata JSONB.
 // Falls back to "Agent <id>" if no name is set.
 func extractAgentName(agent *db.Agent) string {

--- a/api/approvals.go
+++ b/api/approvals.go
@@ -19,6 +19,7 @@ import (
 type approvalResponse struct {
 	ApprovalID      string     `json:"approval_id"`
 	AgentID         int64      `json:"agent_id"`
+	BulkGroupID     *string    `json:"bulk_group_id,omitempty"`
 	Action          any        `json:"action"`
 	Context         any        `json:"context"`
 	Status          string     `json:"status"`
@@ -61,6 +62,7 @@ type denyApprovalRequest struct {
 type approvalDetailResponse struct {
 	ApprovalID      string     `json:"approval_id"`
 	AgentID         int64      `json:"agent_id"`
+	BulkGroupID     *string    `json:"bulk_group_id,omitempty"`
 	Action          any        `json:"action"`
 	Context         any        `json:"context"`
 	Status          string     `json:"status"`
@@ -402,6 +404,7 @@ func toApprovalResponse(ctx context.Context, a db.Approval) approvalResponse {
 	resp := approvalResponse{
 		ApprovalID:  a.ApprovalID,
 		AgentID:     a.AgentID,
+		BulkGroupID: a.BulkGroupID,
 		Status:      resolvedApprovalStatus(a),
 		ExpiresAt:   a.ExpiresAt,
 		ApprovedAt:  a.ApprovedAt,
@@ -445,6 +448,7 @@ func toApprovalDetailResponse(a db.Approval) approvalDetailResponse {
 	resp := approvalDetailResponse{
 		ApprovalID:      a.ApprovalID,
 		AgentID:         a.AgentID,
+		BulkGroupID:     a.BulkGroupID,
 		Status:          resolvedApprovalStatus(a),
 		ExecutionStatus: a.ExecutionStatus,
 		ExecutedAt:      a.ExecutedAt,

--- a/api/approvals_bulk.go
+++ b/api/approvals_bulk.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+func RegisterApprovalBulkRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("GET /approval-groups/{group_id}", requireProfile(handleGetApprovalBulkGroup(deps)))
+	mux.Handle("POST /approval-groups/{group_id}/decide", requireProfile(handleDecideApprovalBulkGroup(deps)))
+}
+
+func init() {
+	RegisterRouteGroup(func(mux *http.ServeMux, deps *Deps) {
+		RegisterApprovalBulkRoutes(mux, deps)
+	})
+}
+
+type bulkGroupResponse struct {
+	BulkGroupID string                   `json:"bulk_group_id"`
+	AgentID     int64                    `json:"agent_id"`
+	ActionType  string                   `json:"action_type"`
+	ItemCount   int                      `json:"item_count"`
+	Status      string                   `json:"status"`
+	ExpiresAt   time.Time                `json:"expires_at"`
+	CreatedAt   time.Time                `json:"created_at"`
+	Items       []approvalDetailResponse `json:"items"`
+}
+
+type bulkDecisionRequest struct {
+	Decisions []bulkDecisionItem `json:"decisions" validate:"required,min=1,max=50,dive"`
+}
+
+type bulkDecisionItem struct {
+	ApprovalID string `json:"approval_id" validate:"required"`
+	Decision   string `json:"decision" validate:"required,oneof=approve deny"`
+}
+
+type bulkDecisionResult struct {
+	ApprovalID       string           `json:"approval_id"`
+	Status           string           `json:"status"`
+	ConfirmationCode string           `json:"confirmation_code,omitempty"`
+	ExecutionStatus  *string          `json:"execution_status,omitempty"`
+	ExecutionResult  *json.RawMessage `json:"execution_result,omitempty"`
+	Error            *bulkItemError   `json:"error,omitempty"`
+}
+
+type bulkDecisionResponse struct {
+	BulkGroupID string               `json:"bulk_group_id"`
+	Results     []bulkDecisionResult `json:"results"`
+}
+
+func handleGetApprovalBulkGroup(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		groupID := strings.TrimSpace(r.PathValue("group_id"))
+		if groupID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "group_id is required"))
+			return
+		}
+
+		group, err := db.GetApprovalBulkGroupByIDAndApprover(r.Context(), deps.DB, groupID, profile.ID)
+		if err != nil {
+			log.Printf("[%s] GetBulkGroup: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get bulk group"))
+			return
+		}
+		if group == nil {
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Bulk group not found"))
+			return
+		}
+
+		approvals, err := db.ListApprovalsByBulkGroupID(r.Context(), deps.DB, groupID)
+		if err != nil {
+			log.Printf("[%s] GetBulkGroup list: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to get bulk group"))
+			return
+		}
+
+		items := make([]approvalDetailResponse, len(approvals))
+		for i, a := range approvals {
+			items[i] = toApprovalDetailResponse(a)
+		}
+
+		RespondJSON(w, http.StatusOK, bulkGroupResponse{
+			BulkGroupID: group.BulkGroupID,
+			AgentID:     group.AgentID,
+			ActionType:  group.ActionType,
+			ItemCount:   group.ItemCount,
+			Status:      db.BulkGroupAggregateStatus(approvals, time.Now().UTC()),
+			ExpiresAt:   group.ExpiresAt,
+			CreatedAt:   group.CreatedAt,
+			Items:       items,
+		})
+	}
+}
+
+func handleDecideApprovalBulkGroup(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		groupID := strings.TrimSpace(r.PathValue("group_id"))
+		if groupID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "group_id is required"))
+			return
+		}
+
+		group, err := db.GetApprovalBulkGroupByIDAndApprover(r.Context(), deps.DB, groupID, profile.ID)
+		if err != nil || group == nil {
+			if err != nil {
+				log.Printf("[%s] DecideBulkGroup lookup: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to decide bulk group"))
+				return
+			}
+			RespondError(w, r, http.StatusNotFound, NotFound(ErrApprovalNotFound, "Bulk group not found"))
+			return
+		}
+
+		var req bulkDecisionRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		groupApprovals, err := db.ListApprovalsByBulkGroupID(r.Context(), deps.DB, groupID)
+		if err != nil {
+			log.Printf("[%s] DecideBulkGroup list: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to decide bulk group"))
+			return
+		}
+
+		byID := make(map[string]db.Approval, len(groupApprovals))
+		for _, a := range groupApprovals {
+			byID[a.ApprovalID] = a
+		}
+
+		results := make([]bulkDecisionResult, 0, len(req.Decisions))
+		for _, d := range req.Decisions {
+			appr, ok := byID[d.ApprovalID]
+			if !ok {
+				results = append(results, bulkDecisionResult{
+					ApprovalID: d.ApprovalID,
+					Status:     "skipped",
+					Error: &bulkItemError{
+						Code:    "approval_not_in_group",
+						Message: "Approval is not part of this bulk group",
+					},
+				})
+				continue
+			}
+
+			if resolvedApprovalStatus(appr) != "pending" {
+				results = append(results, bulkDecisionResult{
+					ApprovalID: d.ApprovalID,
+					Status:     "skipped",
+					Error: &bulkItemError{
+						Code:    "approval_already_resolved",
+						Message: fmt.Sprintf("Approval is already %s", resolvedApprovalStatus(appr)),
+					},
+				})
+				continue
+			}
+
+			switch d.Decision {
+			case "approve":
+				result := approveBulkItem(r, deps, profile.ID, d.ApprovalID)
+				results = append(results, result)
+			case "deny":
+				result := denyBulkItem(r, deps, profile.ID, d.ApprovalID)
+				results = append(results, result)
+			}
+		}
+
+		notifyBulkApprovalChange(deps, profile.ID, groupID)
+
+		RespondJSON(w, http.StatusOK, bulkDecisionResponse{
+			BulkGroupID: groupID,
+			Results:     results,
+		})
+	}
+}
+
+func approveBulkItem(r *http.Request, deps *Deps, userID, approvalID string) bulkDecisionResult {
+	appr, agentMeta, err := db.ApproveApproval(r.Context(), deps.DB, approvalID, userID)
+	if err != nil {
+		var apprErr *db.ApprovalError
+		if errors.As(err, &apprErr) {
+			return bulkDecisionResult{
+				ApprovalID: approvalID,
+				Status:     "skipped",
+				Error: &bulkItemError{
+					Code:    apprErr.Code,
+					Message: "Could not approve item",
+				},
+			}
+		}
+		return bulkDecisionResult{
+			ApprovalID: approvalID,
+			Status:     "skipped",
+			Error:      &bulkItemError{Code: "internal_error", Message: "Failed to approve item"},
+		}
+	}
+
+	confirmCode, err := generateConfirmationCodePlaintext()
+	if err != nil {
+		log.Printf("[%s] bulk approve confirm code: %v", TraceID(r.Context()), err)
+		confirmCode = ""
+	}
+
+	execCtx, cancel := contextWithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	execStatus, execResultJSON := executeApprovalAction(execCtx, deps, userID, appr)
+
+	emitApprovalAuditEvent(r.Context(), deps.DB, userID, appr, agentMeta)
+	notifyApprovalChange(deps, userID, "approval_resolved", appr.ApprovalID)
+	notifyApprovalExecuted(deps, userID, appr.ApprovalID, execStatus)
+
+	result := bulkDecisionResult{
+		ApprovalID:       appr.ApprovalID,
+		Status:           "approved",
+		ConfirmationCode: confirmCode,
+		ExecutionStatus:  &execStatus,
+	}
+	if execResultJSON != nil {
+		raw := json.RawMessage(execResultJSON)
+		result.ExecutionResult = &raw
+	}
+	return result
+}
+
+func denyBulkItem(r *http.Request, deps *Deps, userID, approvalID string) bulkDecisionResult {
+	appr, agentMeta, err := db.DenyApproval(r.Context(), deps.DB, approvalID, userID, "")
+	if err != nil {
+		return bulkDecisionResult{
+			ApprovalID: approvalID,
+			Status:     "skipped",
+			Error:      &bulkItemError{Code: "deny_failed", Message: "Failed to deny item"},
+		}
+	}
+
+	emitApprovalAuditEvent(r.Context(), deps.DB, userID, appr, agentMeta)
+	notifyApprovalChange(deps, userID, "approval_resolved", appr.ApprovalID)
+
+	return bulkDecisionResult{
+		ApprovalID: appr.ApprovalID,
+		Status:     "denied",
+	}
+}
+
+func contextWithTimeout(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), d)
+}

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to `@permission-slip/cli` are documented here. Agents should run
+`permission-slip changelog` (or read this file) at the start of each session to learn
+about new capabilities since their last use.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.17] - 2026-06-07
+
+### Added
+
+- **`request-bulk` command** — submit N same-type actions in one approval request so the
+  user gets a single notification and reviews all items on one screen. Use this instead
+  of calling `request` N times when you need multiple actions of the same type (e.g.
+  creating 4 calendar events).
+  ```bash
+  permission-slip request-bulk --action calendar.create_event --actions '[{...},{...}]'
+  ```
+  Constraints: same action type only, 2–50 items, no payment actions in bulk (v1).
+
+- **`changelog` command** — shows CLI changes since your last recorded version. Run at
+  the start of every session so you always know about new commands and behavior.
+
+- **Bulk group status polling** — `permission-slip status --group <bulk_group_id>` polls
+  per-item outcomes for a bulk submission.
+
+### Agent guidance
+
+- Before planning multi-step workflows, run `permission-slip changelog` to check for new
+  bulk or batch capabilities — prefer `request-bulk` over repeated `request` calls when
+  all actions share the same type.
+- After any CLI upgrade, run `permission-slip changelog --mark-read` once you've updated
+  your notes/memory.
+
+## [0.1.16] - prior releases
+
+See git history for earlier CLI changes.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.15",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@permission-slip/cli",
-      "version": "0.1.15",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",
@@ -12,7 +12,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc",

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -307,4 +307,50 @@ export class ApiClient {
       routerPath: `/approvals/${approvalId}/status`,
     });
   }
+
+  /** GET /approval-groups/{id}/status — bulk group status for agents */
+  async bulkGroupStatus(groupId: string) {
+    return this.request<{
+      bulk_group_id: string;
+      action_type: string;
+      item_count: number;
+      status: string;
+      expires_at: string;
+      created_at: string;
+      results: Array<{
+        approval_id?: string;
+        request_id?: string;
+        status: string;
+        execution_status?: string;
+        execution_result?: unknown;
+      }>;
+    }>({
+      method: "GET",
+      routerPath: `/approval-groups/${groupId}/status`,
+    });
+  }
+
+  /** POST /approvals/bulk-request — submit N same-type actions */
+  async requestBulkApproval(
+    items: Array<{
+      request_id?: string;
+      action: { type: string; parameters: unknown };
+      context: Record<string, unknown>;
+    }>,
+  ) {
+    return this.request<{
+      bulk_group_id: string;
+      approval_url?: string;
+      action_type: string;
+      item_count: number;
+      status: string;
+      expires_at?: string;
+      created_at?: string;
+      results: unknown[];
+    }>({
+      method: "POST",
+      routerPath: "/approvals/bulk-request",
+      body: { items },
+    });
+  }
 }

--- a/cli/src/changelog.ts
+++ b/cli/src/changelog.ts
@@ -1,0 +1,108 @@
+/**
+ * Changelog parsing and "since last use" tracking for agent discoverability.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfig, saveConfig } from "./config/store.js";
+
+export interface ChangelogEntry {
+  version: string;
+  date?: string;
+  body: string;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CHANGELOG_PATH = path.join(__dirname, "..", "..", "CHANGELOG.md");
+
+/** Current CLI version from package.json (bundled at build). */
+export function currentCliVersion(): string {
+  try {
+    const pkgPath = path.join(__dirname, "..", "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { version?: string };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+/** Parse CHANGELOG.md into versioned entries (## [x.y.z] headers). */
+export function parseChangelog(content: string): ChangelogEntry[] {
+  const entries: ChangelogEntry[] = [];
+  const sections = content.split(/^## \[/m).slice(1);
+  for (const section of sections) {
+    const headerEnd = section.indexOf("]");
+    if (headerEnd === -1) continue;
+    const header = section.slice(0, headerEnd);
+    const [version, datePart] = header.split("] - ");
+    const body = section.slice(headerEnd + 1).trim();
+    entries.push({
+      version: version.trim(),
+      date: datePart?.trim(),
+      body,
+    });
+  }
+  return entries;
+}
+
+export function loadChangelogEntries(): ChangelogEntry[] {
+  if (!fs.existsSync(CHANGELOG_PATH)) {
+    return [];
+  }
+  return parseChangelog(fs.readFileSync(CHANGELOG_PATH, "utf-8"));
+}
+
+/** Semver-ish compare: returns negative if a < b, 0 if equal, positive if a > b. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da - db;
+  }
+  return 0;
+}
+
+export function entriesSinceVersion(
+  entries: ChangelogEntry[],
+  sinceVersion: string | undefined,
+): ChangelogEntry[] {
+  if (!sinceVersion) {
+    return entries;
+  }
+  return entries.filter((e) => compareVersions(e.version, sinceVersion) > 0);
+}
+
+export function getLastChangelogVersion(): string | undefined {
+  return loadConfig().last_changelog_version;
+}
+
+export function markChangelogRead(version?: string): void {
+  saveConfig({ last_changelog_version: version ?? currentCliVersion() });
+}
+
+/** Short stderr notice for agents — skipped when empty or PS_CLI_NO_CHANGELOG=1. */
+export function printUnreadChangelogNotice(): void {
+  if (process.env["PS_CLI_NO_CHANGELOG"] === "1") {
+    return;
+  }
+  const entries = loadChangelogEntries();
+  const unread = entriesSinceVersion(entries, getLastChangelogVersion());
+  if (unread.length === 0) {
+    return;
+  }
+  const versions = unread.map((e) => e.version).join(", ");
+  console.error(
+    `[permission-slip] CLI updates since your last session (${versions}). ` +
+      "Run: permission-slip changelog",
+  );
+}
+
+export function readChangelogFile(): string {
+  if (!fs.existsSync(CHANGELOG_PATH)) {
+    return "";
+  }
+  return fs.readFileSync(CHANGELOG_PATH, "utf-8");
+}

--- a/cli/src/commands/changelog.ts
+++ b/cli/src/commands/changelog.ts
@@ -1,0 +1,54 @@
+/**
+ * permission-slip changelog [--mark-read] [--since <version>]
+ *
+ * Shows CLI changes agents should know about. Run at the start of each session.
+ */
+
+import type { Command } from "commander";
+import {
+  currentCliVersion,
+  entriesSinceVersion,
+  getLastChangelogVersion,
+  loadChangelogEntries,
+  markChangelogRead,
+} from "../changelog.js";
+import { output, type OutputOptions } from "../output.js";
+
+export function changelogCommand(program: Command): void {
+  program
+    .command("changelog")
+    .description(
+      "Show CLI changes since your last use — run at the start of each agent session",
+    )
+    .option("--since <version>", "Show entries newer than this version")
+    .option("--mark-read", "Record current CLI version as read after displaying")
+    .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
+    .action((opts: { since?: string; markRead?: boolean; pretty?: boolean }) => {
+      const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
+      const entries = loadChangelogEntries();
+      const since = opts.since ?? getLastChangelogVersion();
+      const unread = entriesSinceVersion(entries, since);
+
+      output(
+        {
+          current_version: currentCliVersion(),
+          last_read_version: getLastChangelogVersion() ?? null,
+          unread_count: unread.length,
+          agent_note:
+            unread.length > 0
+              ? "Review unread entries and update your workflow notes. Prefer request-bulk for multiple same-type actions."
+              : "No unread changelog entries.",
+          entries: unread.map((e) => ({
+            version: e.version,
+            date: e.date ?? null,
+            summary: e.body.split("\n").slice(0, 8).join("\n"),
+          })),
+        },
+        outputOpts,
+      );
+
+      if (opts.markRead) {
+        markChangelogRead();
+      }
+    });
+}

--- a/cli/src/commands/request-bulk.ts
+++ b/cli/src/commands/request-bulk.ts
@@ -1,0 +1,91 @@
+/**
+ * permission-slip request-bulk --action <type> --actions '<json-array>'
+ *
+ * Submits N same-type actions as one bulk approval (one notification for the user).
+ */
+
+import type { Command } from "commander";
+import { ApiClient } from "../api/client.js";
+import { resolveAgentId } from "./status.js";
+import { requireServerUrl } from "../config/serverUrl.js";
+import { output, type OutputOptions } from "../output.js";
+import { shellQuote } from "../util/shell.js";
+
+interface BulkActionItem {
+  request_id?: string;
+  parameters: unknown;
+  description?: string;
+  risk_level?: string;
+}
+
+export function requestBulkCommand(program: Command): void {
+  program
+    .command("request-bulk")
+    .description(
+      "Request bulk approval for N same-type actions (one notification for the user)",
+    )
+    .requiredOption("--action <action_id>", "Shared action type for all items")
+    .requiredOption(
+      "--actions <json>",
+      "JSON array of action items: [{\"parameters\":{...},\"description\":\"...\"}, ...]",
+    )
+    .option(
+      "--server <url>",
+      "Permission Slip server URL — required unless PS_SERVER or config default_server is set",
+    )
+    .option("--agent-id <id>", "Agent ID (auto-detected from saved registration)")
+    .option("--pretty", "Pretty-printed JSON (default is compact JSON)")
+    .action(async (opts: {
+      action: string;
+      actions: string;
+      server?: string;
+      agentId?: string;
+      pretty?: boolean;
+    }) => {
+      const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
+      try {
+        const { url: server } = requireServerUrl({ serverFlag: opts.server });
+        let items: BulkActionItem[];
+        try {
+          items = JSON.parse(opts.actions) as BulkActionItem[];
+        } catch {
+          throw new Error(`--actions must be a valid JSON array. Got: ${opts.actions}`);
+        }
+        if (!Array.isArray(items) || items.length < 2) {
+          throw new Error("--actions must be a JSON array with at least 2 items");
+        }
+
+        const agentId = resolveAgentId(server, opts.agentId);
+        const client = new ApiClient({ serverUrl: server, agentId });
+
+        const bodyItems = items.map((item) => ({
+          request_id: item.request_id,
+          action: {
+            type: opts.action,
+            parameters: item.parameters ?? {},
+          },
+          context: {
+            ...(item.description ? { description: item.description } : {}),
+            ...(item.risk_level ? { risk_level: item.risk_level } : {}),
+          },
+        }));
+
+        const result = await client.requestBulkApproval(bodyItems);
+
+        output(
+          {
+            ...result,
+            next_step:
+              result.status === "pending" || result.status === "partial"
+                ? "Bulk approval submitted. Poll: " +
+                  `permission-slip status --group ${shellQuote(result.bulk_group_id ?? "")} --server ${shellQuote(server)}`
+                : undefined,
+          },
+          outputOpts,
+        );
+      } catch (err) {
+        output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);
+        process.exit(1);
+      }
+    });
+}

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -15,8 +15,9 @@ import { output, type OutputOptions } from "../output.js";
 export function statusCommand(program: Command): void {
   program
     .command("status")
-    .description("Show registration state, or check approval status with an approval_id")
+    .description("Show registration state, or check approval/bulk group status")
     .argument("[approval_id]", "Approval ID to check (omit for registration status)")
+    .option("--group <bulk_group_id>", "Bulk group ID to poll (instead of approval_id)")
     .option(
       "--server <url>",
       "Permission Slip server URL — required unless PS_SERVER or config default_server is set",
@@ -26,6 +27,7 @@ export function statusCommand(program: Command): void {
     .action(async (approvalId: string | undefined, opts: {
       server?: string;
       agentId?: string;
+      group?: string;
       pretty?: boolean;
     }) => {
       const outputOpts: OutputOptions = { pretty: opts.pretty ?? false };
@@ -34,15 +36,19 @@ export function statusCommand(program: Command): void {
         const agentId = resolveAgentId(server, opts.agentId);
         const client = new ApiClient({ serverUrl: server, agentId });
 
-        if (!approvalId) {
-          // No approval_id: show registration state.
+        if (!approvalId && !opts.group) {
           const result = await client.status();
           output(result, outputOpts);
           return;
         }
 
-        // Single check, return immediately.
-        const result = await client.approvalStatus(approvalId);
+        if (opts.group) {
+          const result = await client.bulkGroupStatus(opts.group);
+          output(result, outputOpts);
+          return;
+        }
+
+        const result = await client.approvalStatus(approvalId!);
         output(result, outputOpts);
       } catch (err) {
         output({ error: err instanceof Error ? err.message : String(err) }, outputOpts);

--- a/cli/src/config/store.ts
+++ b/cli/src/config/store.ts
@@ -100,6 +100,8 @@ export function findRegistration(server: string): Registration | undefined {
 /** Stored in ~/.permission-slip/config.json — extend with new optional fields as needed. */
 export interface CliConfigFile {
   default_server?: string;
+  /** Last CLI version for which the agent read the changelog. */
+  last_changelog_version?: string;
 }
 
 export function normalizeServerUrl(url: string): string {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,7 +12,9 @@
  *   capabilities  List available action configurations and standing approvals
  *   connectors    List available connectors
  *   request        Request approval for an action (auto-approves if standing approval matches)
+ *   request-bulk   Request bulk approval for N same-type actions (one notification)
  *   request-status Check the status/outcome of an approval request
+ *   changelog      Show CLI updates since your last session (read before multi-step work)
  *   config        Show or update saved configuration and registrations
  *   whoami        Show agent identity and registration info
  *
@@ -26,10 +28,13 @@ import { statusCommand } from "./commands/status.js";
 import { capabilitiesCommand } from "./commands/capabilities.js";
 import { connectorsCommand } from "./commands/connectors.js";
 import { requestCommand } from "./commands/request.js";
+import { requestBulkCommand } from "./commands/request-bulk.js";
 import { requestStatusCommand } from "./commands/request-status.js";
+import { changelogCommand } from "./commands/changelog.js";
 import { configCommand } from "./commands/config.js";
 import { whoamiCommand } from "./commands/whoami.js";
 import { autoApproveRequestCommand } from "./commands/autoApproveRequest.js";
+import { printUnreadChangelogNotice, currentCliVersion } from "./changelog.js";
 
 const program = new Command();
 
@@ -43,9 +48,11 @@ program
     "Quick start:\n" +
     "  1. Register:  permission-slip register --invite-code <code>\n" +
     "  2. Verify:    permission-slip verify --code <confirmation_code>\n" +
-    "  3. Discover:  permission-slip capabilities",
+    "  3. Changelog:  permission-slip changelog   (check for new capabilities)\n" +
+    "  4. Discover:  permission-slip capabilities\n" +
+    "  5. Bulk work: permission-slip request-bulk --action <type> --actions '[...]'",
   )
-  .version("0.1.0");
+  .version(currentCliVersion());
 
 registerCommand(program);
 verifyCommand(program);
@@ -53,9 +60,17 @@ statusCommand(program);
 capabilitiesCommand(program);
 connectorsCommand(program);
 requestCommand(program);
+requestBulkCommand(program);
 requestStatusCommand(program);
+changelogCommand(program);
 configCommand(program);
 whoamiCommand(program);
 autoApproveRequestCommand(program);
+
+// Surface unread changelog entries unless this IS the changelog command.
+const invoked = process.argv[2];
+if (invoked !== "changelog") {
+  printUnreadChangelogNotice();
+}
 
 program.parse(process.argv);

--- a/cli/tests/changelog.test.ts
+++ b/cli/tests/changelog.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  compareVersions,
+  currentCliVersion,
+  entriesSinceVersion,
+  markChangelogRead,
+  parseChangelog,
+  getLastChangelogVersion,
+} from "../src/changelog.js";
+
+const SAMPLE = `# Changelog
+
+## [0.2.0] - 2026-06-01
+
+### Added
+- New feature
+
+## [0.1.0] - 2026-01-01
+
+### Added
+- Initial
+`;
+
+describe("changelog", () => {
+  it("parses version sections", () => {
+    const entries = parseChangelog(SAMPLE);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]?.version).toBe("0.2.0");
+  });
+
+  it("compareVersions orders semver", () => {
+    expect(compareVersions("0.2.0", "0.1.0")).toBeGreaterThan(0);
+    expect(compareVersions("0.1.0", "0.2.0")).toBeLessThan(0);
+  });
+
+  it("entriesSinceVersion filters", () => {
+    const entries = parseChangelog(SAMPLE);
+    const unread = entriesSinceVersion(entries, "0.1.0");
+    expect(unread).toHaveLength(1);
+    expect(unread[0]?.version).toBe("0.2.0");
+  });
+
+  it("currentCliVersion reads package.json", () => {
+    expect(currentCliVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("markChangelogRead persists version", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ps-changelog-"));
+    process.env["PS_CLI_TEST_CONFIG_DIR"] = tmp;
+    markChangelogRead("1.2.3");
+    expect(getLastChangelogVersion()).toBe("1.2.3");
+    delete process.env["PS_CLI_TEST_CONFIG_DIR"];
+  });
+});

--- a/db/agent_approvals.go
+++ b/db/agent_approvals.go
@@ -51,6 +51,7 @@ type InsertApprovalParams struct {
 	ApprovalID        string
 	AgentID           int64
 	ApproverID        string
+	BulkGroupID       *string
 	Action            []byte // raw JSONB
 	Context           []byte // raw JSONB
 	ResourceDetails   []byte // raw JSONB — human-readable resource metadata (optional)
@@ -86,10 +87,10 @@ func InsertApproval(ctx context.Context, d DBTX, p InsertApprovalParams, request
 	}
 
 	row := tx.QueryRow(ctx,
-		`INSERT INTO approvals (approval_id, agent_id, approver_id, action, context, resource_details, action_fingerprint, status, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, NULLIF($7, ''), 'pending', $8)
+		`INSERT INTO approvals (approval_id, agent_id, approver_id, bulk_group_id, action, context, resource_details, action_fingerprint, status, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, NULLIF($8, ''), 'pending', $9)
 		 RETURNING `+approvalColumns,
-		p.ApprovalID, p.AgentID, p.ApproverID, p.Action, p.Context, p.ResourceDetails, p.ActionFingerprint, TimestampForSQLite(p.ExpiresAt),
+		p.ApprovalID, p.AgentID, p.ApproverID, p.BulkGroupID, p.Action, p.Context, p.ResourceDetails, p.ActionFingerprint, TimestampForSQLite(p.ExpiresAt),
 	)
 	appr, err := scanApproval(row)
 	if err != nil {

--- a/db/approval_bulk_groups.go
+++ b/db/approval_bulk_groups.go
@@ -1,0 +1,181 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ApprovalBulkGroup represents a row from approval_bulk_groups.
+type ApprovalBulkGroup struct {
+	BulkGroupID string
+	AgentID     int64
+	ApproverID  string
+	ActionType  string
+	ItemCount   int
+	AllowMixed  bool
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+}
+
+const approvalBulkGroupColumns = `bulk_group_id, agent_id, approver_id, action_type, item_count, allow_mixed, expires_at, created_at`
+
+func scanApprovalBulkGroup(row rowScanner) (*ApprovalBulkGroup, error) {
+	var g ApprovalBulkGroup
+	var allowMixed int
+	var expiresAt, createdAt sql.NullString
+	err := row.Scan(
+		&g.BulkGroupID, &g.AgentID, &g.ApproverID, &g.ActionType, &g.ItemCount,
+		&allowMixed, &expiresAt, &createdAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	g.AllowMixed = allowMixed != 0
+	var err2 error
+	g.ExpiresAt, err2 = sqliteTimeRequired(expiresAt)
+	if err2 != nil {
+		return nil, err2
+	}
+	g.CreatedAt, err2 = sqliteTimeRequired(createdAt)
+	if err2 != nil {
+		return nil, err2
+	}
+	return &g, nil
+}
+
+// InsertApprovalBulkGroupParams holds parameters for creating a bulk group row.
+type InsertApprovalBulkGroupParams struct {
+	BulkGroupID string
+	AgentID     int64
+	ApproverID  string
+	ActionType  string
+	ItemCount   int
+	ExpiresAt   time.Time
+}
+
+// InsertApprovalBulkGroup inserts a bulk group row within the current transaction.
+func InsertApprovalBulkGroup(ctx context.Context, d DBTX, p InsertApprovalBulkGroupParams) (*ApprovalBulkGroup, error) {
+	row := d.QueryRow(ctx,
+		`INSERT INTO approval_bulk_groups (bulk_group_id, agent_id, approver_id, action_type, item_count, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING `+approvalBulkGroupColumns,
+		p.BulkGroupID, p.AgentID, p.ApproverID, p.ActionType, p.ItemCount, TimestampForSQLite(p.ExpiresAt),
+	)
+	return scanApprovalBulkGroup(row)
+}
+
+// GetApprovalBulkGroupByIDAndApprover returns a bulk group owned by the approver.
+func GetApprovalBulkGroupByIDAndApprover(ctx context.Context, d DBTX, bulkGroupID, approverID string) (*ApprovalBulkGroup, error) {
+	row := d.QueryRow(ctx,
+		`SELECT `+approvalBulkGroupColumns+`
+		 FROM approval_bulk_groups
+		 WHERE bulk_group_id = $1 AND approver_id = $2`,
+		bulkGroupID, approverID,
+	)
+	g, err := scanApprovalBulkGroup(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// GetApprovalBulkGroupByIDAndAgent returns a bulk group owned by the agent.
+func GetApprovalBulkGroupByIDAndAgent(ctx context.Context, d DBTX, bulkGroupID string, agentID int64) (*ApprovalBulkGroup, error) {
+	row := d.QueryRow(ctx,
+		`SELECT `+approvalBulkGroupColumns+`
+		 FROM approval_bulk_groups
+		 WHERE bulk_group_id = $1 AND agent_id = $2`,
+		bulkGroupID, agentID,
+	)
+	g, err := scanApprovalBulkGroup(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// ListApprovalsByBulkGroupID returns all approvals in a bulk group, ordered by created_at.
+func ListApprovalsByBulkGroupID(ctx context.Context, d DBTX, bulkGroupID string) ([]Approval, error) {
+	rows, err := d.Query(ctx,
+		`SELECT `+approvalColumns+`
+		 FROM approvals
+		 WHERE bulk_group_id = $1
+		 ORDER BY created_at ASC, approval_id ASC`,
+		bulkGroupID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var approvals []Approval
+	for rows.Next() {
+		a, err := scanApproval(rows)
+		if err != nil {
+			return nil, err
+		}
+		approvals = append(approvals, *a)
+	}
+	return approvals, rows.Err()
+}
+
+// BulkGroupAggregateStatus computes pending/partial/resolved from child approvals.
+func BulkGroupAggregateStatus(approvals []Approval, now time.Time) string {
+	if len(approvals) == 0 {
+		return "resolved"
+	}
+	pendingCount := 0
+	for _, a := range approvals {
+		status := a.Status
+		if status == "pending" && !a.ExpiresAt.IsZero() && a.ExpiresAt.Before(now) {
+			status = "expired"
+		}
+		if status == "pending" {
+			pendingCount++
+		}
+	}
+	if pendingCount == len(approvals) {
+		return "pending"
+	}
+	if pendingCount == 0 {
+		return "resolved"
+	}
+	return "partial"
+}
+
+// ListDistinctPendingBulkGroupIDs returns bulk group IDs with pending non-expired
+// items for the given approver, for dashboard list deduplication.
+func ListDistinctPendingBulkGroupIDs(ctx context.Context, d DBTX, approverID string) ([]string, error) {
+	rows, err := d.Query(ctx,
+		`SELECT DISTINCT bulk_group_id
+		 FROM approvals
+		 WHERE approver_id = $1
+		   AND bulk_group_id IS NOT NULL
+		   AND status = 'pending'
+		   AND datetime(expires_at) > datetime('now')`,
+		approverID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list bulk group ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/db/approvals.go
+++ b/db/approvals.go
@@ -14,6 +14,7 @@ type Approval struct {
 	ApprovalID        string
 	AgentID           int64
 	ApproverID        string
+	BulkGroupID       *string
 	Action            []byte // raw JSONB
 	Context           []byte // raw JSONB
 	Status            string
@@ -32,7 +33,7 @@ type Approval struct {
 
 // approvalColumns is the canonical column list for SELECT on the approvals table.
 // Keep in sync with scanApproval.
-const approvalColumns = `approval_id, agent_id, approver_id, action, context,
+const approvalColumns = `approval_id, agent_id, approver_id, bulk_group_id, action, context,
 	status, execution_status, execution_result, executed_at, resource_details,
 	expires_at, approved_at, denied_at, cancelled_at, denial_reason,
 	action_fingerprint, created_at`
@@ -54,15 +55,19 @@ type ApprovalPage struct {
 // scanApproval scans a single row into an Approval. The row must select approvalColumns.
 func scanApproval(row rowScanner) (*Approval, error) {
 	var a Approval
+	var bulkGroupID sql.NullString
 	var executedAt, expiresAt, approvedAt, deniedAt, cancelledAt, createdAt sql.NullString
 	var denialReason, actionFingerprint sql.NullString
 	err := row.Scan(
-		&a.ApprovalID, &a.AgentID, &a.ApproverID, &a.Action, &a.Context,
+		&a.ApprovalID, &a.AgentID, &a.ApproverID, &bulkGroupID, &a.Action, &a.Context,
 		&a.Status, &a.ExecutionStatus, &a.ExecutionResult, &executedAt, &a.ResourceDetails,
 		&expiresAt, &approvedAt, &deniedAt, &cancelledAt, &denialReason, &actionFingerprint, &createdAt,
 	)
 	if err != nil {
 		return nil, err
+	}
+	if bulkGroupID.Valid {
+		a.BulkGroupID = &bulkGroupID.String
 	}
 	var err2 error
 	a.ExecutedAt, err2 = sqliteTimePtr(executedAt)

--- a/db/migrations/20260607021017_add_approval_bulk_groups.sql
+++ b/db/migrations/20260607021017_add_approval_bulk_groups.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Bulk approval groups: N same-type actions submitted as one notification/review unit.
+
+CREATE TABLE approval_bulk_groups (
+    bulk_group_id   text        PRIMARY KEY CHECK (char_length(bulk_group_id) <= 255),
+    agent_id        bigint      NOT NULL REFERENCES agents(agent_id) ON DELETE CASCADE,
+    approver_id     uuid        NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    action_type     text        NOT NULL CHECK (char_length(action_type) <= 128),
+    item_count      int         NOT NULL CHECK (item_count > 0),
+    allow_mixed     boolean     NOT NULL DEFAULT false,
+    expires_at      timestamptz NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_approval_bulk_groups_approver_created
+    ON approval_bulk_groups (approver_id, created_at DESC, bulk_group_id DESC);
+
+CREATE INDEX idx_approval_bulk_groups_agent_created
+    ON approval_bulk_groups (agent_id, created_at DESC);
+
+ALTER TABLE approvals ADD COLUMN bulk_group_id text REFERENCES approval_bulk_groups(bulk_group_id) ON DELETE SET NULL;
+
+CREATE INDEX idx_approvals_bulk_group_id ON approvals (bulk_group_id) WHERE bulk_group_id IS NOT NULL;
+
+ALTER TABLE approval_bulk_groups ENABLE ROW LEVEL SECURITY;
+CREATE POLICY app_backend_all ON approval_bulk_groups FOR ALL TO app_backend USING (true) WITH CHECK (true);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_approvals_bulk_group_id;
+ALTER TABLE approvals DROP COLUMN IF EXISTS bulk_group_id;
+DROP TABLE IF EXISTS approval_bulk_groups;

--- a/db/migrations_sqlite/00003_approval_bulk_groups.sql
+++ b/db/migrations_sqlite/00003_approval_bulk_groups.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+
+CREATE TABLE approval_bulk_groups (
+    bulk_group_id   TEXT PRIMARY KEY,
+    agent_id        INTEGER NOT NULL,
+    approver_id     TEXT NOT NULL,
+    action_type     TEXT NOT NULL,
+    item_count      INTEGER NOT NULL CHECK (item_count > 0),
+    allow_mixed     INTEGER NOT NULL DEFAULT 0 CHECK (allow_mixed IN (0, 1)),
+    expires_at      TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    FOREIGN KEY (agent_id) REFERENCES agents(agent_id) ON DELETE CASCADE,
+    FOREIGN KEY (approver_id) REFERENCES profiles(id) ON DELETE CASCADE,
+    CONSTRAINT approval_bulk_groups_bulk_group_id_check CHECK (length(bulk_group_id) <= 255),
+    CONSTRAINT approval_bulk_groups_action_type_check CHECK (length(action_type) <= 128)
+);
+
+CREATE INDEX idx_approval_bulk_groups_approver_created
+    ON approval_bulk_groups (approver_id, created_at DESC, bulk_group_id DESC);
+
+CREATE INDEX idx_approval_bulk_groups_agent_created
+    ON approval_bulk_groups (agent_id, created_at DESC);
+
+ALTER TABLE approvals ADD COLUMN bulk_group_id TEXT REFERENCES approval_bulk_groups(bulk_group_id) ON DELETE SET NULL;
+
+CREATE INDEX idx_approvals_bulk_group_id ON approvals (bulk_group_id) WHERE bulk_group_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_approvals_bulk_group_id;
+-- SQLite does not support DROP COLUMN in older versions; recreate would be needed for full down.
+-- For tests, dropping the table is sufficient.
+DROP TABLE IF EXISTS approval_bulk_groups;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -31,14 +31,45 @@ npx @permission-slip/cli register --invite-code <code>
 # Step 2: Verify (user shares the confirmation code from their dashboard)
 npx @permission-slip/cli verify --code <confirmation_code>
 
-# Step 3: Discover what you can do
+# Step 3: Read the CLI changelog (do this every session — new capabilities appear here)
+npx @permission-slip/cli changelog
+npx @permission-slip/cli changelog --mark-read   # after updating your notes
+
+# Step 4: Discover what you can do
 npx @permission-slip/cli capabilities
 
-# Step 4: Request approval (auto-executes if standing approval matches)
+# Step 5: Request approval (auto-executes if standing approval matches)
 npx @permission-slip/cli request --action email.send --params '{"to":"user@example.com","subject":"Hi"}'
+
+# Bulk: N same-type actions → one notification (prefer this over N separate requests)
+npx @permission-slip/cli request-bulk --action calendar.create_event --actions '[
+  {"parameters":{"title":"Standup","start":"2026-06-08T09:00:00Z"}},
+  {"parameters":{"title":"Retro","start":"2026-06-08T15:00:00Z"}}
+]'
+npx @permission-slip/cli status --group <bulk_group_id>
 ```
 
 Run `npx @permission-slip/cli --help` for all available commands.
+
+### CLI changelog (agents: read every session)
+
+The CLI ships a **changelog** (`permission-slip changelog`) so you always learn about
+new commands and behavior without guessing. At the start of each session:
+
+1. Run `permission-slip changelog` — shows entries newer than your last `--mark-read`.
+2. Update your workflow notes if bulk or other capabilities apply.
+3. Run `permission-slip changelog --mark-read` when done.
+
+If you skip this, the CLI prints a one-line reminder on the next command.
+
+### Bulk approval requests
+
+When you need **multiple actions of the same type** (e.g. create 4 calendar events),
+use **`request-bulk`** instead of calling `request` four times. The user gets **one**
+notification and reviews all items on a single screen.
+
+**Rules (v1):** same action type only, 2–50 items, no payment actions, best-effort
+per-item execution after approval.
 
 ### Self-hosted servers
 

--- a/frontend/src/hooks/useApprovalBulkGroup.ts
+++ b/frontend/src/hooks/useApprovalBulkGroup.ts
@@ -1,0 +1,34 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type ApprovalBulkGroupSummary =
+  components["schemas"]["ApprovalBulkGroupSummary"];
+
+export function useApprovalBulkGroup(bulkGroupId: string | undefined) {
+  const { session } = useAuth();
+  const accessToken = session?.access_token;
+  const tokenRef = useRef(accessToken);
+  if (accessToken) {
+    tokenRef.current = accessToken;
+  }
+
+  return useQuery({
+    queryKey: ["approval-bulk-group", bulkGroupId ?? ""],
+    queryFn: async (): Promise<ApprovalBulkGroupSummary> => {
+      const token = tokenRef.current;
+      if (!token || !bulkGroupId) {
+        throw new Error("Missing token or group id");
+      }
+      const { data, error } = await client.GET("/v1/approval-groups/{group_id}", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { path: { group_id: bulkGroupId } },
+      });
+      if (error) throw new Error("Failed to load bulk approval group");
+      return data;
+    },
+    enabled: !!accessToken && !!bulkGroupId,
+  });
+}

--- a/frontend/src/hooks/useApprovalEvents.ts
+++ b/frontend/src/hooks/useApprovalEvents.ts
@@ -64,12 +64,14 @@ export function useApprovalEvents() {
     es.addEventListener("approval_created", onApprovalCreated);
     es.addEventListener("approval_resolved", invalidateApprovals);
     es.addEventListener("approval_cancelled", invalidateApprovals);
+    es.addEventListener("bulk_approval_changed", invalidateApprovals);
 
     // Clean up on unmount or token change.
     return () => {
       es.removeEventListener("approval_created", onApprovalCreated);
       es.removeEventListener("approval_resolved", invalidateApprovals);
       es.removeEventListener("approval_cancelled", invalidateApprovals);
+      es.removeEventListener("bulk_approval_changed", invalidateApprovals);
       es.close();
       eventSourceRef.current = null;
     };

--- a/frontend/src/hooks/useBulkDecideApprovalGroup.ts
+++ b/frontend/src/hooks/useBulkDecideApprovalGroup.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import type { components } from "@/api/schema";
+
+export type BulkDecisionItem = components["schemas"]["BulkApprovalDecisionItem"];
+export type BulkDecisionResponse =
+  components["schemas"]["BulkApprovalDecisionResponse"];
+
+export function useBulkDecideApprovalGroup() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      bulkGroupId,
+      decisions,
+    }: {
+      bulkGroupId: string;
+      decisions: BulkDecisionItem[];
+    }): Promise<BulkDecisionResponse> => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+      const { data, error } = await client.POST(
+        "/v1/approval-groups/{group_id}/decide",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { group_id: bulkGroupId } },
+          body: { decisions },
+        },
+      );
+      if (error) throw new Error("Failed to submit bulk decisions");
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["approvals"] });
+        queryClient.invalidateQueries({
+          queryKey: ["approval-bulk-group", variables.bulkGroupId],
+        });
+      }, 2_000);
+    },
+  });
+
+  return {
+    decideBulkGroup: mutation.mutateAsync,
+    isPending: mutation.isPending,
+    result: mutation.data,
+    error: mutation.error,
+  };
+}

--- a/frontend/src/pages/approve/ApproveGroupRedirectPage.tsx
+++ b/frontend/src/pages/approve/ApproveGroupRedirectPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import { useAgents } from "@/hooks/useAgents";
+import { useApprovalBulkGroup } from "@/hooks/useApprovalBulkGroup";
+import { getAgentDisplayName } from "@/lib/agents";
+import { ReviewBulkApprovalDialog } from "@/pages/dashboard/ReviewBulkApprovalDialog";
+
+export function ApproveGroupRedirectPage() {
+  const { groupId } = useParams<{ groupId: string }>();
+  const navigate = useNavigate();
+  const { data: group, isLoading, error } = useApprovalBulkGroup(groupId ?? undefined);
+  const { agents } = useAgents();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (group && !dialogOpen) {
+      setDialogOpen(true);
+    }
+  }, [group, dialogOpen]);
+
+  const agentDisplayName = (() => {
+    if (!group) return "";
+    const agent = agents.find((a) => a.agent_id === group.agent_id);
+    if (agent) return getAgentDisplayName(agent);
+    return `Agent ${group.agent_id}`;
+  })();
+
+  function handleOpenChange(nextOpen: boolean) {
+    setDialogOpen(nextOpen);
+    if (!nextOpen) {
+      navigate("/", { replace: true });
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+        <p className="text-lg font-semibold">Bulk approval not found</p>
+        <button
+          type="button"
+          onClick={() => navigate("/", { replace: true })}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          Go to Dashboard
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading || !group || !groupId) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4">
+        <Loader2 className="text-muted-foreground size-6 animate-spin" />
+        <p className="text-muted-foreground text-sm">Loading bulk approval…</p>
+      </div>
+    );
+  }
+
+  return (
+    <ReviewBulkApprovalDialog
+      bulkGroupId={groupId}
+      agentDisplayName={agentDisplayName}
+      open={dialogOpen}
+      onOpenChange={handleOpenChange}
+    />
+  );
+}

--- a/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
+++ b/frontend/src/pages/dashboard/PendingApprovalsBanner.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { buildSummary } from "@/components/ActionPreviewSummary";
 import { CountdownBadge, RiskBadge } from "./approval-components";
 import { ReviewApprovalDialog } from "./ReviewApprovalDialog";
+import { ReviewBulkApprovalDialog } from "./ReviewBulkApprovalDialog";
 import { ReviewStandingApprovalRequestDialog } from "./ReviewStandingApprovalRequestDialog";
 
 function resolveAgentName(
@@ -48,6 +49,44 @@ function RuleProposalBannerItem({
       </div>
       <span className="shrink-0 text-xs font-medium underline underline-offset-2 opacity-75">
         Review
+      </span>
+    </button>
+  );
+}
+
+function BulkApprovalBannerItem({
+  bulkGroupId,
+  actionType,
+  itemCount,
+  agentDisplayName,
+  expiresAt,
+  onOpenDialog,
+}: {
+  bulkGroupId: string;
+  actionType: string;
+  itemCount: number;
+  agentDisplayName: string;
+  expiresAt: string;
+  onOpenDialog: (bulkGroupId: string, agentDisplayName: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenDialog(bulkGroupId, agentDisplayName)}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-info/30 bg-info/5 px-4 py-3 text-left text-sm text-foreground shadow-sm transition-colors hover:bg-info/10"
+      aria-label={`Bulk approval: ${itemCount} ${actionType} from ${agentDisplayName}`}
+    >
+      <Bot className="size-5 shrink-0" />
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="font-medium">{actionType}</span>
+        <Badge variant="secondary" className="text-xs">
+          {itemCount} items
+        </Badge>
+        <span className="text-xs opacity-75">{agentDisplayName}</span>
+        <CountdownBadge expiresAt={expiresAt} />
+      </div>
+      <span className="shrink-0 text-xs font-medium underline underline-offset-2 opacity-75">
+        Review batch
       </span>
     </button>
   );
@@ -117,6 +156,10 @@ export function PendingApprovalsBanner() {
   const activeRuleRef = useRef<StandingApprovalRequestSummary | null>(null);
   const activeRuleAgentNameRef = useRef<string>("");
 
+  const [bulkDialogOpen, setBulkDialogOpen] = useState(false);
+  const activeBulkGroupIdRef = useRef<string>("");
+  const activeBulkAgentNameRef = useRef<string>("");
+
   const agentMap = useMemo(() => {
     const map = new Map<number, Agent>();
     for (const agent of agents) {
@@ -159,6 +202,53 @@ export function PendingApprovalsBanner() {
     }
   }, []);
 
+  const { standaloneApprovals, bulkGroups } = useMemo(() => {
+    const groups = new Map<
+      string,
+      { actionType: string; itemCount: number; expiresAt: string; agentId: number }
+    >();
+    const standalone: ApprovalSummary[] = [];
+    for (const approval of approvals) {
+      const gid = approval.bulk_group_id;
+      if (gid) {
+        const existing = groups.get(gid);
+        if (!existing) {
+          groups.set(gid, {
+            actionType: approval.action.type,
+            itemCount: 1,
+            expiresAt: approval.expires_at,
+            agentId: approval.agent_id,
+          });
+        } else {
+          existing.itemCount += 1;
+        }
+      } else {
+        standalone.push(approval);
+      }
+    }
+    return {
+      standaloneApprovals: standalone,
+      bulkGroups: [...groups.entries()].map(([id, meta]) => ({ id, ...meta })),
+    };
+  }, [approvals]);
+
+  const handleOpenBulkDialog = useCallback(
+    (bulkGroupId: string, agentDisplayName: string) => {
+      activeBulkGroupIdRef.current = bulkGroupId;
+      activeBulkAgentNameRef.current = agentDisplayName;
+      setBulkDialogOpen(true);
+    },
+    [],
+  );
+
+  const handleBulkDialogChange = useCallback((nextOpen: boolean) => {
+    setBulkDialogOpen(nextOpen);
+    if (!nextOpen) {
+      activeBulkGroupIdRef.current = "";
+      activeBulkAgentNameRef.current = "";
+    }
+  }, []);
+
   if (isLoading || rulesLoading) return null;
 
   if (error || rulesError) {
@@ -179,15 +269,20 @@ export function PendingApprovalsBanner() {
     );
   }
 
-  const totalPending = approvals.length + ruleProposals.length;
-  if (totalPending === 0 && !dialogOpen && !ruleDialogOpen) return null;
+  const totalPending =
+    standaloneApprovals.length + bulkGroups.length + ruleProposals.length;
+  if (totalPending === 0 && !dialogOpen && !ruleDialogOpen && !bulkDialogOpen) {
+    return null;
+  }
 
   return (
     <>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
         {totalPending} pending item{totalPending !== 1 ? "s" : ""}
       </span>
-      {(ruleProposals.length > 0 || approvals.length > 0) && (
+      {(ruleProposals.length > 0 ||
+        standaloneApprovals.length > 0 ||
+        bulkGroups.length > 0) && (
         <div className="space-y-2" aria-label="Pending approvals and rule proposals">
           {ruleProposals.map((request) => (
             <RuleProposalBannerItem
@@ -197,7 +292,18 @@ export function PendingApprovalsBanner() {
               onOpenDialog={handleOpenRuleDialog}
             />
           ))}
-          {approvals.map((approval) => (
+          {bulkGroups.map((group) => (
+            <BulkApprovalBannerItem
+              key={group.id}
+              bulkGroupId={group.id}
+              actionType={group.actionType}
+              itemCount={group.itemCount}
+              agentDisplayName={resolveAgentName(group.agentId, agentMap)}
+              expiresAt={group.expiresAt}
+              onOpenDialog={handleOpenBulkDialog}
+            />
+          ))}
+          {standaloneApprovals.map((approval) => (
             <ApprovalBannerItem
               key={approval.approval_id}
               approval={approval}
@@ -223,6 +329,14 @@ export function PendingApprovalsBanner() {
           agentDisplayName={activeRuleAgentNameRef.current}
           open={ruleDialogOpen}
           onOpenChange={handleRuleDialogChange}
+        />
+      )}
+      {activeBulkGroupIdRef.current && (
+        <ReviewBulkApprovalDialog
+          bulkGroupId={activeBulkGroupIdRef.current}
+          agentDisplayName={activeBulkAgentNameRef.current}
+          open={bulkDialogOpen}
+          onOpenChange={handleBulkDialogChange}
         />
       )}
     </>

--- a/frontend/src/pages/dashboard/ReviewBulkApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewBulkApprovalDialog.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Bot, Check, Loader2, XCircle } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import { buildSummary } from "@/components/ActionPreviewSummary";
+import { useApprovalBulkGroup } from "@/hooks/useApprovalBulkGroup";
+import { useBulkDecideApprovalGroup } from "@/hooks/useBulkDecideApprovalGroup";
+import type { ApprovalSummary } from "@/hooks/useApprovals";
+import { CountdownBadge, RiskBadge } from "./approval-components";
+
+interface ReviewBulkApprovalDialogProps {
+  bulkGroupId: string;
+  agentDisplayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ItemDecision = "approve" | "deny";
+
+export function ReviewBulkApprovalDialog({
+  bulkGroupId,
+  agentDisplayName,
+  open,
+  onOpenChange,
+}: ReviewBulkApprovalDialogProps) {
+  const { data: group, isLoading, error } = useApprovalBulkGroup(
+    open ? bulkGroupId : undefined,
+  );
+  const { decideBulkGroup, isPending, result } = useBulkDecideApprovalGroup();
+
+  const [decisions, setDecisions] = useState<Record<string, ItemDecision>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (!group?.items) return;
+    setDecisions((prev) => {
+      const next = { ...prev };
+      for (const item of group.items) {
+        if (!(item.approval_id in next)) {
+          next[item.approval_id] = "approve";
+        }
+      }
+      return next;
+    });
+  }, [group?.items]);
+
+  const pendingItems = useMemo(
+    () => group?.items.filter((i) => i.status === "pending") ?? [],
+    [group?.items],
+  );
+
+  const setAll = useCallback((decision: ItemDecision) => {
+    setDecisions((prev) => {
+      const next = { ...prev };
+      for (const item of pendingItems) {
+        next[item.approval_id] = decision;
+      }
+      return next;
+    });
+  }, [pendingItems]);
+
+  const handleSubmit = async () => {
+    if (!group) return;
+    try {
+      await decideBulkGroup({
+        bulkGroupId: group.bulk_group_id,
+        decisions: pendingItems.map((item) => ({
+          approval_id: item.approval_id,
+          decision: decisions[item.approval_id] ?? "approve",
+        })),
+      });
+      setSubmitted(true);
+      toast.success("Bulk review submitted");
+    } catch {
+      toast.error("Failed to submit bulk review");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex flex-wrap items-center gap-2">
+            <Bot className="size-5" />
+            Bulk approval — {group?.action_type ?? "…"}
+            {group && (
+              <Badge variant="secondary">{group.item_count} items</Badge>
+            )}
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading && (
+          <div className="space-y-3">
+            <Skeleton className="h-8 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+        )}
+
+        {error && (
+          <p className="text-destructive text-sm">Could not load bulk group.</p>
+        )}
+
+        {group && !submitted && (
+          <>
+            <p className="text-muted-foreground text-sm">
+              From {agentDisplayName}. Each item defaults to approve — toggle off
+              any you want to deny, then submit once.
+            </p>
+            {group.expires_at && (
+              <CountdownBadge expiresAt={group.expires_at} />
+            )}
+
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={() => setAll("approve")}>
+                Approve all
+              </Button>
+              <Button type="button" variant="outline" size="sm" onClick={() => setAll("deny")}>
+                Deny all
+              </Button>
+            </div>
+
+            <ul className="space-y-3">
+              {group.items.map((item) => (
+                <BulkItemRow
+                  key={item.approval_id}
+                  item={item}
+                  decision={decisions[item.approval_id] ?? "approve"}
+                  onDecisionChange={(d) =>
+                    setDecisions((prev) => ({ ...prev, [item.approval_id]: d }))
+                  }
+                />
+              ))}
+            </ul>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={isPending || pendingItems.length === 0}
+                onClick={() => void handleSubmit()}
+              >
+                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                Submit review
+              </Button>
+            </div>
+          </>
+        )}
+
+        {submitted && result && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Check className="size-4 text-green-600" />
+              Review submitted
+            </div>
+            <ul className="space-y-2 text-sm">
+              {result.results.map((r) => (
+                <li key={r.approval_id} className="flex items-center gap-2">
+                  {r.status === "approved" && <Check className="size-4 text-green-600" />}
+                  {r.status === "denied" && <XCircle className="size-4 text-red-600" />}
+                  <span className="font-mono text-xs">{r.approval_id}</span>
+                  <span>{r.status}</span>
+                  {r.execution_status === "error" && (
+                    <span className="text-destructive">execution failed</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <Button type="button" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function BulkItemRow({
+  item,
+  decision,
+  onDecisionChange,
+}: {
+  item: ApprovalSummary;
+  decision: ItemDecision;
+  onDecisionChange: (d: ItemDecision) => void;
+}) {
+  const summary = buildSummary(
+    item.action.type,
+    item.action.parameters as Record<string, unknown>,
+    null,
+    null,
+    undefined,
+    item.resource_details as Record<string, unknown> | undefined,
+  );
+  const isPending = item.status === "pending";
+
+  return (
+    <li className="rounded-lg border p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <RiskBadge level={item.context.risk_level} />
+            {!isPending && (
+              <Badge variant="outline">{item.status}</Badge>
+            )}
+          </div>
+          <p className="text-muted-foreground truncate text-xs" title={summary}>
+            {summary}
+          </p>
+        </div>
+        {isPending && (
+          <label className="flex shrink-0 cursor-pointer items-center gap-2 text-sm">
+            <Checkbox
+              checked={decision === "approve"}
+              onCheckedChange={(checked) =>
+                onDecisionChange(checked ? "approve" : "deny")
+              }
+            />
+            Approve
+          </label>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -5,6 +5,7 @@ import { ConnectorConfigPage } from "./pages/agents/connectors/ConnectorConfigPa
 import { ActivityPage } from "./pages/activity/ActivityPage";
 import { SettingsLayout } from "./pages/settings/SettingsLayout";
 import { ApproveRedirectPage } from "./pages/approve/ApproveRedirectPage";
+import { ApproveGroupRedirectPage } from "./pages/approve/ApproveGroupRedirectPage";
 import { ApproveRuleRedirectPage } from "./pages/approve/ApproveRuleRedirectPage";
 
 export interface RouteConfig {
@@ -27,5 +28,6 @@ export const appRoutes: RouteConfig[] = [
   { path: "/activity", Component: ActivityPage },
   { path: "/settings/*", Component: SettingsLayout },
   { path: "/approve/:approvalId", Component: ApproveRedirectPage },
+  { path: "/approve-group/:groupId", Component: ApproveGroupRedirectPage },
   { path: "/approve-rule/:requestId", Component: ApproveRuleRedirectPage },
 ];

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip
 
-go 1.22.2
+go 1.25.10
 
 require (
 	cloud.google.com/go/bigquery v1.74.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/supersuit-tech/permission-slip
 
-go 1.25.10
+go 1.22.2
 
 require (
 	cloud.google.com/go/bigquery v1.74.0

--- a/mobile/src/hooks/useApprovalBulkGroup.ts
+++ b/mobile/src/hooks/useApprovalBulkGroup.ts
@@ -1,0 +1,32 @@
+import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+export type ApprovalBulkGroupSummary =
+  components["schemas"]["ApprovalBulkGroupSummary"];
+
+export function useApprovalBulkGroup(bulkGroupId: string | undefined) {
+  const { session } = useAuth();
+  const tokenRef = useRef(session?.access_token);
+  tokenRef.current = session?.access_token;
+
+  return useQuery({
+    queryKey: ["approval-bulk-group", bulkGroupId ?? ""],
+    queryFn: async (): Promise<ApprovalBulkGroupSummary> => {
+      const token = tokenRef.current;
+      if (!token || !bulkGroupId) throw new Error("Missing token or group id");
+      const { data, error } = await client.GET("/v1/approval-groups/{group_id}", {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { path: { group_id: bulkGroupId } },
+      });
+      if (error) {
+        throw new Error(getApiErrorMessage(error, "Failed to load bulk group"));
+      }
+      return data;
+    },
+    enabled: !!session?.access_token && !!bulkGroupId,
+  });
+}

--- a/mobile/src/hooks/useBulkDecideApprovalGroup.ts
+++ b/mobile/src/hooks/useBulkDecideApprovalGroup.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../auth/AuthContext";
+import client from "../api/client";
+import { getApiErrorMessage } from "../api/errors";
+import type { components } from "../api/schema";
+
+type BulkDecisionItem = components["schemas"]["BulkApprovalDecisionItem"];
+
+export function useBulkDecideApprovalGroup() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      bulkGroupId,
+      decisions,
+    }: {
+      bulkGroupId: string;
+      decisions: BulkDecisionItem[];
+    }) => {
+      if (!session?.access_token) throw new Error("Not authenticated");
+      const { data, error } = await client.POST(
+        "/v1/approval-groups/{group_id}/decide",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { group_id: bulkGroupId } },
+          body: { decisions },
+        },
+      );
+      if (error) {
+        throw new Error(getApiErrorMessage(error, "Failed to submit bulk review"));
+      }
+      return data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["approvals"] });
+      queryClient.invalidateQueries({
+        queryKey: ["approval-bulk-group", variables.bulkGroupId],
+      });
+    },
+  });
+}

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -8,6 +8,8 @@ import ApprovalDetailScreen from "../screens/approvals/ApprovalDetailScreen";
 import DeepLinkDetailScreen from "../screens/approvals/DeepLinkDetailScreen";
 import StandingApprovalRequestDetailScreen from "../screens/approvals/StandingApprovalRequestDetailScreen";
 import DeepLinkRuleDetailScreen from "../screens/approvals/DeepLinkRuleDetailScreen";
+import BulkApprovalGroupScreen from "../screens/approvals/BulkApprovalGroupScreen";
+import DeepLinkBulkGroupScreen from "../screens/approvals/DeepLinkBulkGroupScreen";
 import type { StandingApprovalRequestSummary } from "../hooks/useStandingApprovalRequests";
 import SettingsScreen from "../screens/settings/SettingsScreen";
 import type { ApprovalSummary } from "../hooks/useApprovals";
@@ -31,6 +33,12 @@ export type RootStackParamList = {
   };
   DeepLinkRuleDetail: {
     requestId: string;
+  };
+  BulkApprovalGroup: {
+    bulkGroupId: string;
+  };
+  DeepLinkBulkGroup: {
+    bulkGroupId: string;
   };
   Settings: undefined;
 };
@@ -90,6 +98,20 @@ export default function RootNavigator() {
                 headerTitle: "Rule Proposal",
                 headerBackTitle: "Back",
               }}
+            />
+            <Stack.Screen
+              name="BulkApprovalGroup"
+              component={BulkApprovalGroupScreen}
+              options={{
+                headerShown: true,
+                headerTitle: "Bulk Approval",
+                headerBackTitle: "Back",
+              }}
+            />
+            <Stack.Screen
+              name="DeepLinkBulkGroup"
+              component={DeepLinkBulkGroupScreen}
+              options={{ headerShown: false }}
             />
             <Stack.Screen
               name="Settings"

--- a/mobile/src/navigation/linking.ts
+++ b/mobile/src/navigation/linking.ts
@@ -20,6 +20,7 @@ export const linking: LinkingOptions<RootStackParamList> = {
     screens: {
       DeepLinkDetail: "permission-slip/approve/:approvalId",
       DeepLinkRuleDetail: "permission-slip/approve-rule/:requestId",
+      DeepLinkBulkGroup: "permission-slip/approve-group/:bulkGroupId",
       ApprovalList: "",
     },
   },

--- a/mobile/src/screens/approvals/ApprovalListScreen.tsx
+++ b/mobile/src/screens/approvals/ApprovalListScreen.tsx
@@ -91,6 +91,42 @@ export default function ApprovalListScreen({ navigation }: Props) {
     [navigation],
   );
 
+  const handleBulkPress = useCallback(
+    (bulkGroupId: string) => {
+      navigation.navigate("BulkApprovalGroup", { bulkGroupId });
+    },
+    [navigation],
+  );
+
+  const { standaloneApprovals, bulkGroups } = useMemo(() => {
+    const groups = new Map<
+      string,
+      { actionType: string; itemCount: number; agentId: number }
+    >();
+    const standalone: ApprovalSummary[] = [];
+    for (const approval of approvals) {
+      const gid = approval.bulk_group_id;
+      if (gid) {
+        const existing = groups.get(gid);
+        if (!existing) {
+          groups.set(gid, {
+            actionType: approval.action.type,
+            itemCount: 1,
+            agentId: approval.agent_id,
+          });
+        } else {
+          existing.itemCount += 1;
+        }
+      } else {
+        standalone.push(approval);
+      }
+    }
+    return {
+      standaloneApprovals: standalone,
+      bulkGroups: [...groups.entries()].map(([id, meta]) => ({ id, ...meta })),
+    };
+  }, [approvals]);
+
   const handleRulePress = useCallback(
     (request: StandingApprovalRequestSummary) => {
       navigation.navigate("StandingApprovalRequestDetail", {
@@ -143,7 +179,9 @@ export default function ApprovalListScreen({ navigation }: Props) {
         {TABS.map((tab) => {
           const isActive = activeTab === tab.key;
           const count =
-            isActive && approvals.length > 0 ? approvals.length : null;
+            isActive && (standaloneApprovals.length + bulkGroups.length) > 0
+              ? standaloneApprovals.length + bulkGroups.length
+              : null;
           return (
             <TouchableOpacity
               key={tab.key}
@@ -203,17 +241,35 @@ export default function ApprovalListScreen({ navigation }: Props) {
         </View>
       ) : (
         <FlatList
-          data={approvals}
+          data={standaloneApprovals}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={
-            approvals.length === 0 && (activeTab !== "pending" || ruleProposals.length === 0)
+            standaloneApprovals.length === 0 &&
+            bulkGroups.length === 0 &&
+            (activeTab !== "pending" || ruleProposals.length === 0)
               ? styles.emptyContainer
               : styles.list
           }
           ListHeaderComponent={
-            activeTab === "pending" && ruleProposals.length > 0 ? (
+            activeTab === "pending" &&
+            (ruleProposals.length > 0 || bulkGroups.length > 0) ? (
               <View style={styles.ruleSection}>
+                {bulkGroups.map((group) => (
+                  <TouchableOpacity
+                    key={group.id}
+                    style={styles.bulkRow}
+                    onPress={() => handleBulkPress(group.id)}
+                  >
+                    <Text style={styles.bulkTitle}>
+                      {humanizeActionType(group.actionType)} ({group.itemCount}{" "}
+                      items)
+                    </Text>
+                    <Text style={styles.bulkAgent}>
+                      {resolveAgentName(group.agentId)}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
                 {ruleProposals.map((request: StandingApprovalRequestSummary) => (
                   <RuleProposalRow
                     key={request.request_id}
@@ -563,6 +619,23 @@ const styles = StyleSheet.create({
   ruleSection: {
     borderBottomWidth: 1,
     borderBottomColor: colors.gray200,
+  },
+  bulkRow: {
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.gray100,
+    backgroundColor: "#eff6ff",
+  },
+  bulkTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.gray900,
+  },
+  bulkAgent: {
+    fontSize: 12,
+    color: colors.gray500,
+    marginTop: 4,
   },
   ruleRow: {
     paddingHorizontal: 20,

--- a/mobile/src/screens/approvals/BulkApprovalGroupScreen.tsx
+++ b/mobile/src/screens/approvals/BulkApprovalGroupScreen.tsx
@@ -1,0 +1,162 @@
+/**
+ * Bulk approval group review — per-item approve/deny toggles defaulting to approve.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import { useApprovalBulkGroup } from "../../hooks/useApprovalBulkGroup";
+import { useBulkDecideApprovalGroup } from "../../hooks/useBulkDecideApprovalGroup";
+import { colors } from "../../theme/colors";
+import { buildActionSummary } from "./approvalUtils";
+
+type Props = NativeStackScreenProps<RootStackParamList, "BulkApprovalGroup">;
+
+type ItemDecision = "approve" | "deny";
+
+export default function BulkApprovalGroupScreen({ route, navigation }: Props) {
+  const { bulkGroupId } = route.params;
+  const { data: group, isLoading, error } = useApprovalBulkGroup(bulkGroupId);
+  const decide = useBulkDecideApprovalGroup();
+  const [decisions, setDecisions] = useState<Record<string, ItemDecision>>({});
+
+  useEffect(() => {
+    if (!group?.items) return;
+    setDecisions((prev) => {
+      const next = { ...prev };
+      for (const item of group.items) {
+        if (!(item.approval_id in next)) next[item.approval_id] = "approve";
+      }
+      return next;
+    });
+  }, [group?.items]);
+
+  const pendingItems = useMemo(
+    () => group?.items.filter((i) => i.status === "pending") ?? [],
+    [group?.items],
+  );
+
+  const setAll = useCallback(
+    (decision: ItemDecision) => {
+      setDecisions((prev) => {
+        const next = { ...prev };
+        for (const item of pendingItems) next[item.approval_id] = decision;
+        return next;
+      });
+    },
+    [pendingItems],
+  );
+
+  const onSubmit = async () => {
+    if (!group) return;
+    await decide.mutateAsync({
+      bulkGroupId: group.bulk_group_id,
+      decisions: pendingItems.map((item) => ({
+        approval_id: item.approval_id,
+        decision: decisions[item.approval_id] ?? "approve",
+      })),
+    });
+    navigation.goBack();
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (error || !group) {
+    return (
+      <View style={styles.center}>
+        <Text>Could not load bulk group.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>
+        {group.action_type} ({group.item_count} items)
+      </Text>
+      <View style={styles.row}>
+        <TouchableOpacity style={styles.chip} onPress={() => setAll("approve")}>
+          <Text>Approve all</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.chip} onPress={() => setAll("deny")}>
+          <Text>Deny all</Text>
+        </TouchableOpacity>
+      </View>
+      {group.items.map((item) => (
+        <View key={item.approval_id} style={styles.card}>
+          <Text style={styles.summary}>
+            {buildActionSummary(
+              item.action.type,
+              item.action.parameters as Record<string, unknown>,
+            )}
+          </Text>
+          {item.status === "pending" && (
+            <View style={styles.switchRow}>
+              <Text>Approve</Text>
+              <Switch
+                value={(decisions[item.approval_id] ?? "approve") === "approve"}
+                onValueChange={(v) =>
+                  setDecisions((prev) => ({
+                    ...prev,
+                    [item.approval_id]: v ? "approve" : "deny",
+                  }))
+                }
+              />
+            </View>
+          )}
+        </View>
+      ))}
+      <TouchableOpacity
+        style={styles.submit}
+        disabled={decide.isPending || pendingItems.length === 0}
+        onPress={() => void onSubmit()}
+      >
+        <Text style={styles.submitText}>Submit review</Text>
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: "center", justifyContent: "center" },
+  container: { padding: 16, gap: 12 },
+  title: { fontSize: 18, fontWeight: "600" },
+  row: { flexDirection: "row", gap: 8 },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: colors.gray100,
+  },
+  card: {
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+    gap: 8,
+  },
+  summary: { fontSize: 14 },
+  switchRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  submit: {
+    marginTop: 8,
+    backgroundColor: colors.primary,
+    padding: 14,
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  submitText: { color: "#fff", fontWeight: "600" },
+});

--- a/mobile/src/screens/approvals/DeepLinkBulkGroupScreen.tsx
+++ b/mobile/src/screens/approvals/DeepLinkBulkGroupScreen.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { RootStackParamList } from "../../navigation/RootNavigator";
+import { colors } from "../../theme/colors";
+
+type Props = NativeStackScreenProps<RootStackParamList, "DeepLinkBulkGroup">;
+
+export default function DeepLinkBulkGroupScreen({ route, navigation }: Props) {
+  const { bulkGroupId } = route.params;
+
+  useEffect(() => {
+    navigation.replace("BulkApprovalGroup", { bulkGroupId });
+  }, [bulkGroupId, navigation]);
+
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+      <Text style={styles.text}>Loading bulk approval…</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.white,
+  },
+  text: { marginTop: 12, fontSize: 14, color: colors.gray500 },
+});

--- a/notify/format.go
+++ b/notify/format.go
@@ -85,6 +85,9 @@ func BuildPushContent(approval Approval) PushContent {
 	if approval.Type == NotificationTypeStandingApprovalRequest {
 		return buildStandingApprovalRequestPushContent(approval)
 	}
+	if approval.Type == NotificationTypeBulkApproval {
+		return buildBulkApprovalPushContent(approval)
+	}
 
 	if approval.Type == NotificationTypeCardExpiring {
 		info := extractCardExpiringInfo(approval.Context)
@@ -150,4 +153,22 @@ func TruncateUTF8(s string, maxRunes int) string {
 		return string(runes[:maxRunes])
 	}
 	return string(runes[:maxRunes-3]) + "..."
+}
+
+func buildBulkApprovalPushContent(approval Approval) PushContent {
+	title := "Approval Request"
+	if approval.AgentName != "" {
+		title = approval.AgentName
+	}
+	itemWord := "actions"
+	if approval.ItemCount == 1 {
+		itemWord = "action"
+	}
+	body := fmt.Sprintf("Wants approval for %d %s (%s)", approval.ItemCount, itemWord, approval.ActionType)
+	return PushContent{
+		Title:      title,
+		Body:       body,
+		URL:        approval.ApprovalURL,
+		ApprovalID: approval.BulkGroupID,
+	}
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -52,6 +52,9 @@ const (
 	// NotificationTypeStandingApprovalRequest is sent when an agent proposes
 	// a new standing approval rule for human review.
 	NotificationTypeStandingApprovalRequest NotificationType = "standing_approval_request"
+	// NotificationTypeBulkApproval is sent when an agent submits a bulk approval
+	// group — one notification for N same-type actions.
+	NotificationTypeBulkApproval NotificationType = "bulk_approval"
 )
 
 // Approval holds the fields a notification channel needs to construct its
@@ -67,6 +70,10 @@ type Approval struct {
 	ExpiresAt   time.Time
 	CreatedAt   time.Time
 	Type        NotificationType // determines which email/SMS/push template to use; zero value = approval
+	// BulkApproval fields (when Type == NotificationTypeBulkApproval)
+	BulkGroupID string
+	ActionType  string
+	ItemCount   int
 }
 
 // Recipient identifies who should receive the notification and provides

--- a/spec/openapi/components/paths/approvals.yaml
+++ b/spec/openapi/components/paths/approvals.yaml
@@ -1209,3 +1209,163 @@ denyApproval:
 
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
+bulkRequest:
+  post:
+    operationId: bulkRequestApproval
+    summary: Request Bulk Approval for Same-Type Actions
+    description: |
+      Submit N actions of the **same action type** in one request. The approver
+      receives **one** notification and reviews all items on a single screen.
+
+      **Constraints (v1):**
+      - All items must share one action type (mixed types rejected).
+      - Payment-required actions are not supported in bulk.
+      - Minimum 2 items, maximum 50.
+      - Standing-approval auto-approve applies per item at submit time.
+
+      Creation of all child approvals is transactional. Execution at approve
+      time is best-effort per item.
+
+    tags:
+      - Approvals
+
+    security:
+      - PermissionSlipSignature: []
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/approvals.yaml#/BulkApprovalRequest'
+
+    responses:
+      '200':
+        description: Bulk request processed
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/approvals.yaml#/BulkApprovalResponse'
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+getBulkGroup:
+  get:
+    operationId: getApprovalBulkGroup
+    summary: Get Bulk Approval Group
+    description: |
+      Returns a bulk approval group with all child items for the authenticated
+      approver. Used by the group review screen.
+
+    tags:
+      - Approvals
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - name: group_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    responses:
+      '200':
+        description: Bulk group retrieved
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/approvals.yaml#/ApprovalBulkGroupSummary'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+bulkGroupDecide:
+  post:
+    operationId: decideApprovalBulkGroup
+    summary: Submit Per-Item Decisions for a Bulk Group
+    description: |
+      Approve or deny each item in a bulk group in one call. Approved items
+      execute best-effort; partial failures are reported per item.
+
+    tags:
+      - Approvals
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - name: group_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/approvals.yaml#/BulkApprovalDecisionRequest'
+
+    responses:
+      '200':
+        description: Decisions applied
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/approvals.yaml#/BulkApprovalDecisionResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '409':
+        $ref: '../responses/errors.yaml#/Conflict'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+bulkGroupStatus:
+  get:
+    operationId: getApprovalBulkGroupStatus
+    summary: Get Bulk Approval Group Status (Agent)
+    description: |
+      Poll the status of a bulk approval group and per-item outcomes.
+      Only the submitting agent may access this endpoint.
+
+    tags:
+      - Approvals
+
+    security:
+      - PermissionSlipSignature: []
+
+    parameters:
+      - name: group_id
+        in: path
+        required: true
+        schema:
+          type: string
+
+    responses:
+      '200':
+        description: Group status retrieved
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/approvals.yaml#/BulkApprovalGroupStatusResponse'
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+      '404':
+        $ref: '../responses/errors.yaml#/NotFound'
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'

--- a/spec/openapi/components/schemas/approvals.yaml
+++ b/spec/openapi/components/schemas/approvals.yaml
@@ -329,6 +329,13 @@ ApprovalSummary:
       format: date-time
       description: When the approval request was created
       example: "2026-02-11T13:20:00Z"
+    bulk_group_id:
+      type: string
+      nullable: true
+      description: |
+        When set, this approval is part of a bulk group submitted together.
+        Null for single (non-bulk) requests.
+      example: "bgrp_abc123"
     resource_details:
       type: object
       nullable: true
@@ -527,3 +534,270 @@ DenyApprovalResponse:
       description: |
         Optional human-readable explanation provided by the approver when denying.
       example: "Recipient not on approved contacts list."
+
+BulkApprovalRequestItem:
+  type: object
+  required:
+    - request_id
+    - action
+    - context
+  properties:
+    request_id:
+      type: string
+      format: uuid
+      maxLength: 64
+      description: Unique idempotency key for this item within the bulk request.
+    action:
+      $ref: './shared.yaml#/Action'
+    context:
+      $ref: './shared.yaml#/ActionContext'
+    configuration_id:
+      type: string
+      pattern: '^ac_[a-f0-9]{32}$'
+      maxLength: 36
+      description: Optional action configuration reference for this item.
+
+BulkApprovalRequest:
+  type: object
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      minItems: 2
+      maxItems: 50
+      items:
+        $ref: '#/BulkApprovalRequestItem'
+      description: |
+        Same-action-type actions to submit as one bulk approval. Minimum 2 items.
+        Payment-required actions are not supported in bulk (v1).
+    expires_in:
+      type: integer
+      minimum: 60
+      maximum: 86400
+      description: Optional TTL override in seconds for all items in the group.
+
+BulkApprovalResult:
+  type: object
+  required:
+    - request_id
+    - status
+  properties:
+    request_id:
+      type: string
+      description: The item's idempotency key from the request.
+    approval_id:
+      type: string
+      description: Present when status is `pending` or after resolution.
+    status:
+      type: string
+      enum:
+        - pending
+        - approved
+        - denied
+        - cancelled
+        - expired
+      description: Per-item outcome at submission or after human review.
+    result:
+      description: Execution result when auto-approved via standing approval at submit time.
+    standing_approval_id:
+      type: string
+      description: Standing approval that auto-approved this item (if any).
+    execution_status:
+      allOf:
+        - $ref: './shared.yaml#/ExecutionStatus'
+        - nullable: true
+    execution_result:
+      $ref: './shared.yaml#/ExecutionResult'
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+BulkApprovalResponse:
+  type: object
+  required:
+    - bulk_group_id
+    - action_type
+    - item_count
+    - status
+    - results
+  properties:
+    bulk_group_id:
+      type: string
+      description: Identifier for the bulk group. Use for polling and review deep links.
+      example: "bgrp_abc123"
+    approval_url:
+      type: string
+      format: uri
+      description: Review URL for the approver (present when any item is pending).
+    action_type:
+      type: string
+      description: Shared action type for all items in the group.
+    item_count:
+      type: integer
+      description: Number of items in the group.
+    status:
+      type: string
+      enum:
+        - pending
+        - partial
+        - resolved
+      description: |
+        `pending` — at least one item awaiting review.
+        `partial` — some items resolved, some still pending.
+        `resolved` — all items have a final status.
+    expires_at:
+      type: string
+      format: date-time
+    created_at:
+      type: string
+      format: date-time
+    results:
+      type: array
+      items:
+        $ref: '#/BulkApprovalResult'
+
+ApprovalBulkGroupSummary:
+  type: object
+  description: A bulk approval group for dashboard list/detail views.
+  required:
+    - bulk_group_id
+    - agent_id
+    - action_type
+    - item_count
+    - status
+    - expires_at
+    - created_at
+    - items
+  properties:
+    bulk_group_id:
+      type: string
+    agent_id:
+      type: integer
+      format: int64
+    action_type:
+      type: string
+    item_count:
+      type: integer
+    status:
+      type: string
+      enum:
+        - pending
+        - partial
+        - resolved
+    expires_at:
+      type: string
+      format: date-time
+    created_at:
+      type: string
+      format: date-time
+    items:
+      type: array
+      items:
+        $ref: '#/ApprovalSummary'
+
+BulkApprovalDecisionItem:
+  type: object
+  required:
+    - approval_id
+    - decision
+  properties:
+    approval_id:
+      type: string
+    decision:
+      type: string
+      enum:
+        - approve
+        - deny
+
+BulkApprovalDecisionRequest:
+  type: object
+  required:
+    - decisions
+  properties:
+    decisions:
+      type: array
+      minItems: 1
+      maxItems: 50
+      items:
+        $ref: '#/BulkApprovalDecisionItem'
+
+BulkApprovalDecisionResult:
+  type: object
+  required:
+    - approval_id
+    - status
+  properties:
+    approval_id:
+      type: string
+    status:
+      type: string
+      enum:
+        - approved
+        - denied
+        - skipped
+    confirmation_code:
+      type: string
+      description: Ephemeral receipt code when approved.
+    execution_status:
+      allOf:
+        - $ref: './shared.yaml#/ExecutionStatus'
+        - nullable: true
+    execution_result:
+      $ref: './shared.yaml#/ExecutionResult'
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+BulkApprovalDecisionResponse:
+  type: object
+  required:
+    - bulk_group_id
+    - results
+  properties:
+    bulk_group_id:
+      type: string
+    results:
+      type: array
+      items:
+        $ref: '#/BulkApprovalDecisionResult'
+
+BulkApprovalGroupStatusResponse:
+  type: object
+  required:
+    - bulk_group_id
+    - action_type
+    - item_count
+    - status
+    - results
+  properties:
+    bulk_group_id:
+      type: string
+    action_type:
+      type: string
+    item_count:
+      type: integer
+    status:
+      type: string
+      enum:
+        - pending
+        - partial
+        - resolved
+    expires_at:
+      type: string
+      format: date-time
+    created_at:
+      type: string
+      format: date-time
+    results:
+      type: array
+      items:
+        $ref: '#/BulkApprovalResult'

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -3664,6 +3664,145 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/approvals/bulk-request:
+    post:
+      operationId: bulkRequestApproval
+      summary: Request Bulk Approval for Same-Type Actions
+      description: |
+        Submit N actions of the **same action type** in one request. The approver
+        receives **one** notification and reviews all items on a single screen.
+
+        **Constraints (v1):**
+        - All items must share one action type (mixed types rejected).
+        - Payment-required actions are not supported in bulk.
+        - Minimum 2 items, maximum 50.
+        - Standing-approval auto-approve applies per item at submit time.
+
+        Creation of all child approvals is transactional. Execution at approve
+        time is best-effort per item.
+      tags:
+        - Approvals
+      security:
+        - PermissionSlipSignature: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkApprovalRequest'
+      responses:
+        '200':
+          description: Bulk request processed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApprovalResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/approval-groups/{group_id}:
+    get:
+      operationId: getApprovalBulkGroup
+      summary: Get Bulk Approval Group
+      description: |
+        Returns a bulk approval group with all child items for the authenticated
+        approver. Used by the group review screen.
+      tags:
+        - Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bulk group retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalBulkGroupSummary'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/approval-groups/{group_id}/decide:
+    post:
+      operationId: decideApprovalBulkGroup
+      summary: Submit Per-Item Decisions for a Bulk Group
+      description: |
+        Approve or deny each item in a bulk group in one call. Approved items
+        execute best-effort; partial failures are reported per item.
+      tags:
+        - Approvals
+      security:
+        - SupabaseSession: []
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkApprovalDecisionRequest'
+      responses:
+        '200':
+          description: Decisions applied
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApprovalDecisionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /v1/approval-groups/{group_id}/status:
+    get:
+      operationId: getApprovalBulkGroupStatus
+      summary: Get Bulk Approval Group Status (Agent)
+      description: |
+        Poll the status of a bulk approval group and per-item outcomes.
+        Only the submitting agent may access this endpoint.
+      tags:
+        - Approvals
+      security:
+        - PermissionSlipSignature: []
+      parameters:
+        - name: group_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Group status retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkApprovalGroupStatusResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /v1/action-config-templates:
     get:
       operationId: listActionConfigTemplates
@@ -6755,6 +6894,13 @@ components:
           format: date-time
           description: When the approval request was created
           example: '2026-02-11T13:20:00Z'
+        bulk_group_id:
+          type: string
+          nullable: true
+          description: |
+            When set, this approval is part of a bulk group submitted together.
+            Null for single (non-bulk) requests.
+          example: bgrp_abc123
         resource_details:
           type: object
           nullable: true
@@ -6945,6 +7091,160 @@ components:
           $ref: '#/components/schemas/ExecutionResult'
         executed_at:
           $ref: '#/components/schemas/ExecutedAt'
+    BulkApprovalRequest:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          minItems: 2
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/BulkApprovalRequestItem'
+          description: |
+            Same-action-type actions to submit as one bulk approval. Minimum 2 items.
+            Payment-required actions are not supported in bulk (v1).
+        expires_in:
+          type: integer
+          minimum: 60
+          maximum: 86400
+          description: Optional TTL override in seconds for all items in the group.
+    BulkApprovalResponse:
+      type: object
+      required:
+        - bulk_group_id
+        - action_type
+        - item_count
+        - status
+        - results
+      properties:
+        bulk_group_id:
+          type: string
+          description: Identifier for the bulk group. Use for polling and review deep links.
+          example: bgrp_abc123
+        approval_url:
+          type: string
+          format: uri
+          description: Review URL for the approver (present when any item is pending).
+        action_type:
+          type: string
+          description: Shared action type for all items in the group.
+        item_count:
+          type: integer
+          description: Number of items in the group.
+        status:
+          type: string
+          enum:
+            - pending
+            - partial
+            - resolved
+          description: |
+            `pending` — at least one item awaiting review.
+            `partial` — some items resolved, some still pending.
+            `resolved` — all items have a final status.
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApprovalResult'
+    ApprovalBulkGroupSummary:
+      type: object
+      description: A bulk approval group for dashboard list/detail views.
+      required:
+        - bulk_group_id
+        - agent_id
+        - action_type
+        - item_count
+        - status
+        - expires_at
+        - created_at
+        - items
+      properties:
+        bulk_group_id:
+          type: string
+        agent_id:
+          type: integer
+          format: int64
+        action_type:
+          type: string
+        item_count:
+          type: integer
+        status:
+          type: string
+          enum:
+            - pending
+            - partial
+            - resolved
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalSummary'
+    BulkApprovalDecisionRequest:
+      type: object
+      required:
+        - decisions
+      properties:
+        decisions:
+          type: array
+          minItems: 1
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/BulkApprovalDecisionItem'
+    BulkApprovalDecisionResponse:
+      type: object
+      required:
+        - bulk_group_id
+        - results
+      properties:
+        bulk_group_id:
+          type: string
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApprovalDecisionResult'
+    BulkApprovalGroupStatusResponse:
+      type: object
+      required:
+        - bulk_group_id
+        - action_type
+        - item_count
+        - status
+        - results
+      properties:
+        bulk_group_id:
+          type: string
+        action_type:
+          type: string
+        item_count:
+          type: integer
+        status:
+          type: string
+          enum:
+            - pending
+            - partial
+            - resolved
+        expires_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkApprovalResult'
     ActionConfigTemplate:
       type: object
       required:
@@ -10928,6 +11228,109 @@ components:
             recently downgraded from a paid plan. After this time, the shorter
             retention window takes effect.
           example: '2026-03-08T14:30:00Z'
+    BulkApprovalRequestItem:
+      type: object
+      required:
+        - request_id
+        - action
+        - context
+      properties:
+        request_id:
+          type: string
+          format: uuid
+          maxLength: 64
+          description: Unique idempotency key for this item within the bulk request.
+        action:
+          $ref: '#/components/schemas/Action'
+        context:
+          $ref: '#/components/schemas/ActionContext'
+        configuration_id:
+          type: string
+          pattern: ^ac_[a-f0-9]{32}$
+          maxLength: 36
+          description: Optional action configuration reference for this item.
+    BulkApprovalResult:
+      type: object
+      required:
+        - request_id
+        - status
+      properties:
+        request_id:
+          type: string
+          description: The item's idempotency key from the request.
+        approval_id:
+          type: string
+          description: Present when status is `pending` or after resolution.
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - denied
+            - cancelled
+            - expired
+          description: Per-item outcome at submission or after human review.
+        result:
+          description: Execution result when auto-approved via standing approval at submit time.
+        standing_approval_id:
+          type: string
+          description: Standing approval that auto-approved this item (if any).
+        execution_status:
+          allOf:
+            - $ref: '#/components/schemas/ExecutionStatus'
+            - nullable: true
+        execution_result:
+          $ref: '#/components/schemas/ExecutionResult'
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+    BulkApprovalDecisionItem:
+      type: object
+      required:
+        - approval_id
+        - decision
+      properties:
+        approval_id:
+          type: string
+        decision:
+          type: string
+          enum:
+            - approve
+            - deny
+    BulkApprovalDecisionResult:
+      type: object
+      required:
+        - approval_id
+        - status
+      properties:
+        approval_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - approved
+            - denied
+            - skipped
+        confirmation_code:
+          type: string
+          description: Ephemeral receipt code when approved.
+        execution_status:
+          allOf:
+            - $ref: '#/components/schemas/ExecutionStatus'
+            - nullable: true
+        execution_result:
+          $ref: '#/components/schemas/ExecutionResult'
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
     StandingApprovalTemplateSpec:
       type: object
       description: |

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -212,6 +212,18 @@ paths:
   /v1/approvals/{approval_id}/status:
     $ref: './components/paths/approvals.yaml#/approvalStatus'
 
+  /v1/approvals/bulk-request:
+    $ref: './components/paths/approvals.yaml#/bulkRequest'
+
+  /v1/approval-groups/{group_id}:
+    $ref: './components/paths/approvals.yaml#/getBulkGroup'
+
+  /v1/approval-groups/{group_id}/decide:
+    $ref: './components/paths/approvals.yaml#/bulkGroupDecide'
+
+  /v1/approval-groups/{group_id}/status:
+    $ref: './components/paths/approvals.yaml#/bulkGroupStatus'
+
   /v1/action-config-templates:
     $ref: './components/paths/action_config_templates.yaml#/actionConfigTemplates'
 
@@ -359,6 +371,18 @@ components:
       $ref: './components/schemas/approvals.yaml#/DenyApprovalResponse'
     ApprovalStatusResponse:
       $ref: './components/schemas/approvals.yaml#/ApprovalStatusResponse'
+    BulkApprovalRequest:
+      $ref: './components/schemas/approvals.yaml#/BulkApprovalRequest'
+    BulkApprovalResponse:
+      $ref: './components/schemas/approvals.yaml#/BulkApprovalResponse'
+    ApprovalBulkGroupSummary:
+      $ref: './components/schemas/approvals.yaml#/ApprovalBulkGroupSummary'
+    BulkApprovalDecisionRequest:
+      $ref: './components/schemas/approvals.yaml#/BulkApprovalDecisionRequest'
+    BulkApprovalDecisionResponse:
+      $ref: './components/schemas/approvals.yaml#/BulkApprovalDecisionResponse'
+    BulkApprovalGroupStatusResponse:
+      $ref: './components/schemas/approvals.yaml#/BulkApprovalGroupStatusResponse'
 
     # Action Configuration Templates
     ActionConfigTemplate:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Implements bulk approval requests end-to-end: agents submit N same-type actions in one call; users get **one notification** and review all items on a single screen with per-item approve/deny (defaults to approve) plus approve-all/deny-all shortcuts.
- Adds `approval_bulk_groups` schema, OpenAPI paths (`POST /v1/approvals/bulk-request`, `GET/POST /v1/approval-groups/{id}`, agent status polling), grouped notifications, and SSE `bulk_approval_changed` events.
- Ships CLI **`request-bulk`**, **`status --group`**, and a **`changelog`** command (with session reminder) so agents always learn about new capabilities like bulk before falling back to repeated single requests.

Closes #1283

## Test plan

### Claude Code
- [x] Frontend production build (`npm run build`)
- [x] Mobile tests (`npm test -- --ci`) — 300 passed
- [x] CLI tests (`npm test`) — 59 passed including changelog parser
- [x] OpenAPI bundle + frontend/mobile client regeneration
- [ ] Backend tests (`go test ./api/...`) — not run locally (sandbox Go 1.24 vs bigquery go1.25 requirement); CI will verify

### OpenClaw
- [ ] Approve 3 / deny 1 in bulk review UI and confirm per-item execution results
- [ ] Confirm single push/email notification for a 4-item bulk submission
- [ ] Agent workflow: `permission-slip changelog` → `request-bulk` → `status --group`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5eafdde9-a088-445a-8c0f-28e4f5d82945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eafdde9-a088-445a-8c0f-28e4f5d82945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

