### PR TITLE
Declare Proton Mail bridge credential fields in manifest

### DIFF
--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -194,8 +194,55 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				Service:         "protonmail",
 				AuthType:        "custom",
 				InstructionsURL: "https://github.com/supersuit-tech/permission-slip/blob/main/docs/connectors/protonmail.md",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         "username",
+						Label:       "Bridge username",
+						Placeholder: "Your Proton address as shown by Bridge info",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(true),
+					},
+					{
+						Key:         "password",
+						Label:       "Bridge password",
+						Placeholder: "From Bridge info (not your Proton account password)",
+						Secret:      ptrBool(true),
+						Required:    ptrBool(true),
+						HelpText:    "Run protonmail-bridge info to get the Bridge-generated password. This is not your Proton account login password.",
+					},
+					{
+						Key:         "imap_host",
+						Label:       "IMAP host",
+						Placeholder: "127.0.0.1",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(false),
+					},
+					{
+						Key:         "imap_port",
+						Label:       "IMAP port",
+						Placeholder: "1143",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(false),
+					},
+					{
+						Key:         "smtp_host",
+						Label:       "SMTP host",
+						Placeholder: "127.0.0.1",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(false),
+					},
+					{
+						Key:         "smtp_port",
+						Label:       "SMTP port",
+						Placeholder: "1025",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(false),
+					},
+				},
 			},
 		},
 		Templates: protonmailTemplates(),
 	}
 }
+
+func ptrBool(b bool) *bool { return &b }

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -1,6 +1,7 @@
 package protonmail
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -195,6 +196,49 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 	}
 	if cred.InstructionsURL == "" {
 		t.Error("credential instructions_url is empty, want a URL")
+	}
+
+	wantFields := []struct {
+		key      string
+		secret   bool
+		required bool
+	}{
+		{key: "username", secret: false, required: true},
+		{key: "password", secret: true, required: true},
+		{key: "imap_host", secret: false, required: false},
+		{key: "imap_port", secret: false, required: false},
+		{key: "smtp_host", secret: false, required: false},
+		{key: "smtp_port", secret: false, required: false},
+	}
+	if len(cred.Fields) != len(wantFields) {
+		t.Fatalf("credential fields has %d items, want %d", len(cred.Fields), len(wantFields))
+	}
+	for i, want := range wantFields {
+		got := cred.Fields[i]
+		if got.Key != want.key {
+			t.Errorf("credential fields[%d].key = %q, want %q", i, got.Key, want.key)
+		}
+		if got.Label == "" {
+			t.Errorf("credential fields[%d].label is empty, want a label", i)
+		}
+		if got.Secret == nil || *got.Secret != want.secret {
+			gotSecret := "<nil>"
+			if got.Secret != nil {
+				gotSecret = fmt.Sprintf("%v", *got.Secret)
+			}
+			t.Errorf("credential fields[%d].secret = %s, want %v", i, gotSecret, want.secret)
+		}
+		if got.Required == nil || *got.Required != want.required {
+			gotRequired := "<nil>"
+			if got.Required != nil {
+				gotRequired = fmt.Sprintf("%v", *got.Required)
+			}
+			t.Errorf("credential fields[%d].required = %s, want %v", i, gotRequired, want.required)
+		}
+	}
+	passwordField := cred.Fields[1]
+	if passwordField.HelpText == "" {
+		t.Error("password field help_text is empty, want guidance about the Bridge password")
 	}
 
 	for _, a := range m.Actions {

--- a/frontend/src/pages/agents/connectors/credentialFields.test.ts
+++ b/frontend/src/pages/agents/connectors/credentialFields.test.ts
@@ -76,4 +76,35 @@ describe("staticCredentialButtonLabel", () => {
     );
     expect(label).toBe("credentials");
   });
+
+  it("uses credentials for Proton Mail bridge fields", () => {
+    const protonFields = [
+      { key: "username", label: "Bridge username", secret: false, required: true },
+      { key: "password", label: "Bridge password", secret: true, required: true },
+      { key: "imap_host", label: "IMAP host", secret: false, required: false },
+      { key: "imap_port", label: "IMAP port", secret: false, required: false },
+      { key: "smtp_host", label: "SMTP host", secret: false, required: false },
+      { key: "smtp_port", label: "SMTP port", secret: false, required: false },
+    ];
+    const credential = cred({
+      service: "protonmail",
+      auth_type: "custom",
+      fields: protonFields,
+    });
+
+    const fields = resolveStaticCredentialFields(credential);
+    expect(fields).toHaveLength(6);
+    expect(fields.map((f) => f.key)).toEqual([
+      "username",
+      "password",
+      "imap_host",
+      "imap_port",
+      "smtp_host",
+      "smtp_port",
+    ]);
+    expect(fields[0]?.secret).toBe(false);
+    expect(fields[1]?.secret).toBe(true);
+    expect(fields[2]?.required).toBe(false);
+    expect(staticCredentialButtonLabel(credential)).toBe("credentials");
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add six `Fields` to the Proton Mail connector manifest (`username`, `password`, and optional IMAP/SMTP host/port) so the setup dialog renders the correct Bridge credential form.
- Password field includes help text clarifying it is the Bridge-generated password, not the Proton account password.
- Extend backend manifest and frontend credential field tests to assert the field set and button label.

Closes #1289

## Test plan

### Claude Code
- [x] `gofmt` on changed Go files
- [x] `npx vitest run src/pages/agents/connectors/credentialFields.test.ts` (6 tests pass)
- [ ] Backend `go test ./connectors/protonmail/...` — not run locally (sandbox Go 1.24.7 vs module `go >= 1.25`); CI will verify

### OpenClaw
- [ ] Open Proton Mail connector setup in the UI and confirm labeled inputs appear instead of "Add API key"
- [ ] Save credentials with only username + password against a running Bridge instance

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94901952-1007-43db-9067-b32e76863403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94901952-1007-43db-9067-b32e76863403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

