### PR TITLE
fix(cli): pin TypeScript to 5.7.x to unblock npm publishing

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -6,6 +6,16 @@ about new capabilities since their last use.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.18] - 2026-06-08
+
+### Fixed
+
+- **CLI publishing restored.** The npm publish workflow had been failing since 0.1.16
+  because a TypeScript 6.0 bump broke Node type resolution during the `tsc` build, so
+  0.1.16 and 0.1.17 never reached npm. Pinned TypeScript back to 5.7.x to unblock
+  publishing; this release carries the 0.1.16/0.1.17 features (`request-bulk`,
+  `changelog`, bulk group status polling) to npm.
+
 ## [0.1.17] - 2026-06-07
 
 ### Added

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@permission-slip/cli",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3"
@@ -19,7 +19,7 @@
         "@types/node": "^25.6.0",
         "jest": "^30.3.0",
         "ts-jest": "^29.3.0",
-        "typescript": "^6.0.3"
+        "typescript": "^5.7.2"
       },
       "engines": {
         "node": ">=18"
@@ -4215,9 +4215,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@permission-slip/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Agent-facing CLI for Permission Slip — register, verify, and interact with Permission Slip servers",
   "license": "MIT",
   "type": "module",
@@ -30,7 +30,7 @@
     "@types/node": "^25.6.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.3.0",
-    "typescript": "^6.0.3"
+    "typescript": "^5.7.2"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",


### PR DESCRIPTION
## Summary

The `publish-cli` workflow has failed on every CLI release since **0.1.15** (last successfully published 2026-04-23). Tags `cli/v0.1.16` and `cli/v0.1.17` were pushed but never reached npm, so npm is stuck at 0.1.15.

**Root cause:** the 0.1.16 dependency bump moved `typescript` from `^5.7.2` to `^6.0.3`. TypeScript 6.0 breaks Node type resolution under this `tsconfig` (`module/moduleResolution: NodeNext`, no explicit `types`/`lib`), so the `tsc` build step fails with hundreds of `TS2591: Cannot find name 'process'/'Buffer'/'node:fs'` errors. The tests pass because `ts-jest` suppresses these diagnostics via `diagnostics.ignoreCodes`, so the failure only surfaces in the real `tsc` build — which is exactly the step that gates publishing.

Confirmed by bisection:
- `typescript@5.7` + `@types/node@25` → builds clean ✅
- `typescript@6.0` + `@types/node@22` → fails ❌
- `typescript@6.0` + `@types/node@25` (current) → fails ❌

## Changes

- Pin `typescript` back to `^5.7.x` (resolves to 5.9.3) — the fix.
- Bump CLI version `0.1.17 → 0.1.18`.
- Add a 0.1.18 CHANGELOG entry documenting the publishing fix.

Publishing 0.1.18 carries the stranded 0.1.16/0.1.17 work (`request-bulk`, `changelog`, bulk group status polling) to npm in one shot.

## Test plan

- [x] `npm test` — 59/59 pass
- [x] `npm run build` (`tsc`) — succeeds, emits `dist/`
- [ ] Merge, then tag `cli/v0.1.18` to trigger the publish workflow

## Follow-up (not in this PR)

Staying on TypeScript 6 is viable but needs a `tsconfig` change (likely an explicit `"types": ["node", "jest"]` or `lib`/resolution setting). Tracked separately — this PR just stops the bleeding.

https://claude.ai/code/session_01PeqQej4ESEHhCftCbbNX1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeqQej4ESEHhCftCbbNX1o)_