### PR TITLE
build: stamp git commit into frontend bundle for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_COMMIT_TIMESTAMP := $(shell git log -1 --format=%cI HEAD 2>/dev/null || echo "unknown")
 build: generate
-	cd frontend && npm run build
+	cd frontend && VITE_GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) VITE_GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) npm run build
 	touch frontend/dist/.gitkeep
 	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .
 
 # CI / slim server build: expects bundle + generate-frontend-from-bundle already
 # (see install-build-deps). Does not install mobile or CLI npm dependencies.
 build-ci:
-	cd frontend && npm run build
+	cd frontend && VITE_GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) VITE_GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) npm run build
 	touch frontend/dist/.gitkeep
 	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .
 


### PR DESCRIPTION
The local build and build-ci Make targets ran npm run build without
passing VITE_GIT_COMMIT_HASH/VITE_GIT_COMMIT_TIMESTAMP, so self-hosted
servers built via make (rather than the docker-build/deploy path)
rendered "Build unknown" in the footer regardless of the checked-out
commit. Pass the existing GIT_COMMIT_HASH/GIT_COMMIT_TIMESTAMP make
variables through to the frontend build so the footer reflects the real
build, matching the Docker/Fly path.