### PR TITLE
Add one-command self-hosted updater (make redeploy)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
        migrate-up migrate-down migrate-create db-setup seed \
        bundle install-connectors \
        audit audit-backend audit-frontend audit-mobile \
-       docker-build deploy \
+       docker-build deploy redeploy \
        cli cli-install cli-build cli-test
 
 # Install all dependencies (frontend + backend + mobile + cli)
@@ -111,6 +111,12 @@ deploy:
 		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY} \
 		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
 		--build-arg GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP)
+
+# Update a self-hosted (systemd) install in one step: pull latest, reinstall
+# deps, rebuild, and restart the service. See scripts/redeploy.sh for details.
+# Override the unit name with PS_SERVICE=<name> if it isn't "permission-slip".
+redeploy:
+	./scripts/redeploy.sh
 
 # ---------- Testing ----------
 

--- a/Makefile
+++ b/Makefile
@@ -73,14 +73,14 @@ GIT_SHA := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 GIT_COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 GIT_COMMIT_TIMESTAMP := $(shell git log -1 --format=%cI HEAD 2>/dev/null || echo "unknown")
 build: generate
-	cd frontend && npm run build
+	cd frontend && VITE_GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) VITE_GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) npm run build
 	touch frontend/dist/.gitkeep
 	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .
 
 # CI / slim server build: expects bundle + generate-frontend-from-bundle already
 # (see install-build-deps). Does not install mobile or CLI npm dependencies.
 build-ci:
-	cd frontend && npm run build
+	cd frontend && VITE_GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) VITE_GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) npm run build
 	touch frontend/dist/.gitkeep
 	go build -ldflags "-X main.version=$(GIT_SHA)" -o bin/server .
 

--- a/docs/deployment-self-hosted.md
+++ b/docs/deployment-self-hosted.md
@@ -194,6 +194,38 @@ curl https://$PS_HOSTNAME/api/health            # through Tailscale (run from an
 
 ---
 
+## Updating an existing install
+
+To pull the latest release and apply it, run one command from the repo:
+
+```bash
+cd ~/permission-slip
+make redeploy
+```
+
+This pulls `origin/main`, reinstalls dependencies, rebuilds the frontend and
+server, restarts the systemd service, and prints the build it's now running
+(the same short SHA shown in the app footer, so you can confirm the update took
+effect). New connector fields, manifest changes, and migrations are picked up on
+the restart — there's nothing else to remember.
+
+> The running server is only ever replaced by a **successful** build. If the
+> build fails, `make redeploy` stops before restarting and your service keeps
+> serving the previous working binary. A transient `git pull` failure is
+> non-fatal — it rebuilds the current checkout instead.
+
+> **Named the service something other than `permission-slip`?** Pass it through:
+> ```bash
+> PS_SERVICE=my-unit make redeploy
+> ```
+
+> **Cross-compiling on a beefier box?** `make redeploy` builds and restarts on
+> the machine it runs on. If you build elsewhere and `scp bin/server` over (see
+> the build note in Step 1), pull + build there, copy the binary, then restart
+> on the host with `sudo systemctl restart permission-slip`.
+
+---
+
 ## Step 5: Connect Google
 
 Permission Slip's Google connector handles Gmail and Calendar actions. To enable it, register an OAuth client in Google Cloud:

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Update a self-hosted Permission Slip install to the latest main and restart
+# the systemd service — one command, nothing to remember.
+#
+#   make redeploy           # from the repo root (preferred)
+#   scripts/redeploy.sh     # or run it directly
+#
+# Override the systemd unit name if you didn't call it "permission-slip":
+#
+#   PS_SERVICE=my-unit scripts/redeploy.sh
+#
+# Safety: the running server is only ever replaced by a SUCCESSFUL build. A
+# failed `git pull` (e.g. a transient network blip) or a failed dependency
+# install is non-fatal — the script falls back to rebuilding the current
+# checkout. If the build itself fails, the script aborts BEFORE restarting, so
+# the service keeps serving the last known-good binary.
+set -euo pipefail
+
+SERVICE="${PS_SERVICE:-permission-slip}"
+
+# Resolve the repo root from this script's location so it works from anywhere.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# nvm-installed node isn't always on PATH for non-interactive shells; pull it in
+# so `make build` (which runs npm) doesn't fail with "node: command not found".
+if ! command -v node >/dev/null 2>&1 && [ -s "$HOME/.nvm/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$HOME/.nvm/nvm.sh"
+fi
+
+echo "==> Pulling latest from origin/main"
+if ! git pull --ff-only; then
+  echo "    WARNING: git pull failed — rebuilding the current checkout instead." >&2
+fi
+
+echo "==> Refreshing dependencies"
+if ! make install; then
+  echo "    WARNING: dependency install failed — continuing with existing dependencies." >&2
+fi
+
+echo "==> Building frontend + server"
+# If this fails, 'set -e' aborts here, BEFORE the restart below, leaving the
+# currently-running service untouched.
+make build
+
+echo "==> Restarting service: $SERVICE"
+if command -v systemctl >/dev/null 2>&1; then
+  sudo systemctl restart "$SERVICE"
+else
+  echo "    systemctl not found — restart your server process manually." >&2
+fi
+
+SHA="$(git rev-parse --short HEAD)"
+echo "==> Done. Now running build $SHA — the app footer should show 'Build $SHA'."


### PR DESCRIPTION
## Summary

Self-hosted installs run a static `bin/server` under systemd, and there was no single command to apply a new release. Updating meant remembering to `git pull`, `make build`, and restart the service **in the right order**. Crucially, the connector manifest→DB seed (`seedRegisteredConnectors`) only runs at process startup, so skipping the restart silently leaves the DB — and therefore the UI — on stale connector definitions. This is exactly what made a recently-merged Proton Mail fix (#1290) appear not to work on a live box: the new credential fields were in the binary but the running process (and DB seed) were stale.

This PR makes updating turnkey and closes a related footer-versioning gap that made staleness impossible to diagnose at a glance.

### Changes
- **`scripts/redeploy.sh` + `make redeploy`** — one command: pull `origin/main` → reinstall deps → rebuild frontend + server → restart the systemd unit → print the build SHA it's now running.
  - The running server is only ever replaced by a **successful** build; if the build fails, the script aborts *before* restarting, leaving the last known-good binary in place.
  - A transient `git pull` or dependency-install failure is non-fatal — it falls back to rebuilding the current checkout.
  - Sources nvm if `node` isn't on PATH; unit name overridable via `PS_SERVICE`.
- **Makefile `build`/`build-ci`** now pass `VITE_GIT_COMMIT_HASH`/`VITE_GIT_COMMIT_TIMESTAMP` into the frontend build (previously only the Docker/Fly path did), so the app footer shows a real `Build <sha> · <date>` instead of "Build unknown" on self-hosted/local builds.
- **`docs/deployment-self-hosted.md`** — new "Updating an existing install" section documenting `make redeploy` and its safety semantics.

## Test plan
- [x] `bash -n scripts/redeploy.sh` — syntax check passes
- [x] `make -n redeploy` — target resolves to `./scripts/redeploy.sh`
- [x] `make -n build` — confirms `VITE_GIT_COMMIT_HASH`/`VITE_GIT_COMMIT_TIMESTAMP` are now passed to `npm run build`
- [ ] Not run here: a live `make redeploy` (it pulls/builds/restarts a real systemd host) — the logic mirrors the documented setup commands. Verify on a self-hosted box: run `make redeploy`, confirm the footer shows the new SHA and the Proton Mail credential dialog renders the Bridge fields.

Note: this change is build tooling + docs + a shell script; no Go/frontend source changed, so existing test suites are unaffected.

https://claude.ai/code/session_01HPkMWi2Yt6hdoQ5zGTWomH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPkMWi2Yt6hdoQ5zGTWomH)_