### PR TITLE
build(cli): restore TypeScript 6 with explicit types field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,3 +378,45 @@ When using gh, the local git remote uses a proxy, so always set the repo explici
 ```bash
 GH_HOST=github.com GH_REPO=supersuit-tech/permission-slip gh <command>
 ```
+
+## Pushing Release Tags (web sessions)
+
+**In the cloud/web sandbox, `git push origin <tag>` does NOT work for tags.** The git
+remote is a proxy that only authorizes pushing the session's assigned feature branch —
+any tag push (e.g. `cli/v*`, which triggers `publish-cli.yml`) is rejected with
+`HTTP 403`. Do not waste retries on it.
+
+**Create the tag through the GitHub REST API instead** — it goes straight to authenticated
+GitHub and bypasses the proxy. This is exactly what the `version-tag` skill does. A
+`GH_TOKEN` is available in the environment:
+
+```bash
+# Resolve the target commit (latest main, after any version-bump PR has merged)
+SHA=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+  https://api.github.com/repos/supersuit-tech/permission-slip/git/ref/heads/main \
+  | jq -r '.object.sha')
+
+# Create the tag ref (fires the publish workflow)
+curl -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/supersuit-tech/permission-slip/git/refs \
+  -d "{\"ref\":\"refs/tags/cli/v<version>\",\"sha\":\"$SHA\"}"
+```
+
+Before tagging, confirm the package.json version at that SHA matches the tag (the publish
+workflow's "Verify package version matches tag" step will fail otherwise).
+
+**`publish-cli.yml` publishes only on a `cli/v*` tag push** — there is no
+`workflow_dispatch` trigger, so a branch push or manual dispatch will not publish.
+
+### When a publish run fails at `npm publish`
+
+A `404 '... is not in this registry'` from `npm publish` is npm's misleading symptom for
+an **auth failure** — the `NPM_TOKEN` secret is expired or invalid (scoped-package
+publishes return 404 instead of 401). The fix is a credential rotation the user must do:
+regenerate an npm token with read/write to the `@permission-slip` scope and update the
+`NPM_TOKEN` repo secret. Then re-run the failed job (no new tag needed):
+
+```bash
+curl -sS -X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+  https://api.github.com/repos/supersuit-tech/permission-slip/actions/runs/<run_id>/rerun-failed-jobs
+```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^25.6.0",
         "jest": "^30.3.0",
         "ts-jest": "^29.3.0",
-        "typescript": "^5.7.2"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -4215,9 +4215,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^25.6.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.3.0",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   },
   "jest": {
     "preset": "ts-jest/presets/default-esm",

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node", "jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Follow-up to #1291. That PR stopped the bleeding by pinning TypeScript back to 5.7; this one returns the CLI to **TypeScript 6** the right way and documents the release-tag lesson so future web sessions don't relearn it.

**Why TS6 broke originally:** TypeScript 6.0 no longer auto-includes every `@types/*` package, so the Node and Jest ambient globals went missing during `tsc` (`TS2591: Cannot find name 'process'/'Buffer'/'node:fs'`). The fix is to name them explicitly.

## Changes

- `cli/tsconfig.json`: add `"types": ["node", "jest"]`.
- `cli/package.json`: move `typescript` back to `^6.0.3`.
- `CLAUDE.md`: document that release tags must be created via the GitHub REST API (the sandbox git proxy rejects tag pushes with 403), that `publish-cli.yml` only fires on a `cli/v*` tag, and how to recover a publish run that fails on an expired `NPM_TOKEN`.

No version bump and no republish: the emitted `dist/` is identical, so this is a build-tooling-only change.

## Test plan

- [x] `npm test` — 55/55 pass on TypeScript 6.0.3
- [x] `npm run build` (`tsc`) — succeeds, emits `dist/`

https://claude.ai/code/session_01PeqQej4ESEHhCftCbbNX1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeqQej4ESEHhCftCbbNX1o)_