### PR TITLE
Remove Fly.io deploy target and stale Fly references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY spec/ /app/spec/
 RUN npm ci
 
 # Vite inlines VITE_* env vars into the JS bundle at build time.
-# Pass these as Docker build args (--build-arg) or via [build.args] in fly.toml.
+# Pass these as Docker build args (--build-arg); see the Makefile docker-build target.
 ARG VITE_SENTRY_DSN
 ARG VITE_POSTHOG_KEY
 ARG VITE_POSTHOG_HOST

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
        migrate-up migrate-down migrate-create db-setup seed \
        bundle install-connectors \
        audit audit-backend audit-frontend audit-mobile \
-       docker-build deploy redeploy \
+       docker-build redeploy \
        cli cli-install cli-build cli-test
 
 # Install all dependencies (frontend + backend + mobile + cli)
@@ -101,16 +101,6 @@ docker-build:
 		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
 		--build-arg GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP) \
 		-t permission-slip .
-
-# Deploy to Fly.io. Reads Supabase build args from the environment.
-# Alternatively, configure [build.args] in fly.toml and just run: fly deploy
-# Usage: VITE_SUPABASE_URL=https://xxx.supabase.co VITE_SUPABASE_PUBLISHABLE_KEY=yyy make deploy
-deploy:
-	fly deploy \
-		--build-arg VITE_SUPABASE_URL=$${VITE_SUPABASE_URL} \
-		--build-arg VITE_SUPABASE_PUBLISHABLE_KEY=$${VITE_SUPABASE_PUBLISHABLE_KEY} \
-		--build-arg GIT_COMMIT_HASH=$(GIT_COMMIT_HASH) \
-		--build-arg GIT_COMMIT_TIMESTAMP=$(GIT_COMMIT_TIMESTAMP)
 
 # Update a self-hosted (systemd) install in one step: pull latest, reinstall
 # deps, rebuild, and restart the service. See scripts/redeploy.sh for details.

--- a/api/rate_limit_middleware.go
+++ b/api/rate_limit_middleware.go
@@ -55,7 +55,7 @@ func DefaultAgentRateLimiterConfig() RateLimiterConfig {
 // HTTP 429 with the standard error format and Retry-After header.
 //
 // The key is the client's IP address, extracted from trustedProxyHeader
-// (e.g. "Fly-Client-IP") when behind a reverse proxy, falling back to
+// (e.g. "X-Forwarded-For") when behind a reverse proxy, falling back to
 // RemoteAddr for direct connections or local development.
 //
 // This runs before authentication, so identity-based (per-agent) rate limiting
@@ -116,16 +116,14 @@ func rateLimitKey(r *http.Request, trustedProxyHeader string) string {
 
 // clientIP extracts the real client IP address from the request.
 //
-// When trustedProxyHeader is set (e.g. "Fly-Client-IP"), the IP is read from
+// When trustedProxyHeader is set (e.g. "X-Forwarded-For"), the IP is read from
 // that header. This is necessary when running behind a reverse proxy where
-// RemoteAddr is always the proxy's IP. Fly-Client-IP is set by Fly.io's proxy
-// and cannot be spoofed by clients, making it the recommended default for
-// Fly.io deployments.
+// RemoteAddr is always the proxy's IP.
 //
 // If the header contains a comma-separated list (as with X-Forwarded-For),
 // the leftmost (first) IP is used. Note: X-Forwarded-For can be spoofed by
-// clients prepending arbitrary IPs, so Fly-Client-IP is preferred when
-// available.
+// clients prepending arbitrary IPs, so only enable this header when running
+// behind a trusted reverse proxy that overwrites it.
 //
 // Falls back to RemoteAddr (with port stripped) when no trusted header is
 // configured or the header is absent — suitable for local development or

--- a/api/rate_limit_middleware_test.go
+++ b/api/rate_limit_middleware_test.go
@@ -220,13 +220,13 @@ func TestRateLimitKey_HandlesIPv6(t *testing.T) {
 	}
 }
 
-func TestClientIP_FlyClientIPHeader(t *testing.T) {
+func TestClientIP_CustomProxyHeader(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "172.16.0.1:12345" // proxy IP
-	req.Header.Set("Fly-Client-IP", "203.0.113.50")
+	req.Header.Set("X-Real-IP", "203.0.113.50")
 
-	ip := clientIP(req, "Fly-Client-IP")
+	ip := clientIP(req, "X-Real-IP")
 	if ip != "203.0.113.50" {
 		t.Fatalf("expected %q, got %q", "203.0.113.50", ip)
 	}
@@ -273,9 +273,9 @@ func TestClientIP_FallsBackToRemoteAddrWhenHeaderMissing(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.168.1.100:54321"
-	// No Fly-Client-IP header set.
+	// No X-Real-IP header set.
 
-	ip := clientIP(req, "Fly-Client-IP")
+	ip := clientIP(req, "X-Real-IP")
 	if ip != "192.168.1.100" {
 		t.Fatalf("expected %q, got %q", "192.168.1.100", ip)
 	}
@@ -285,9 +285,9 @@ func TestClientIP_FallsBackToRemoteAddrWhenHeaderEmpty(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.168.1.100:54321"
-	req.Header.Set("Fly-Client-IP", "")
+	req.Header.Set("X-Real-IP", "")
 
-	ip := clientIP(req, "Fly-Client-IP")
+	ip := clientIP(req, "X-Real-IP")
 	if ip != "192.168.1.100" {
 		t.Fatalf("expected %q, got %q", "192.168.1.100", ip)
 	}
@@ -297,7 +297,7 @@ func TestClientIP_FallsBackToRemoteAddrWhenNoProxyConfigured(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "192.168.1.100:54321"
-	req.Header.Set("Fly-Client-IP", "203.0.113.50") // should be ignored
+	req.Header.Set("X-Real-IP", "203.0.113.50") // should be ignored
 
 	ip := clientIP(req, "")
 	if ip != "192.168.1.100" {
@@ -309,9 +309,9 @@ func TestClientIP_IPv6InProxyHeader(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.RemoteAddr = "172.16.0.1:12345"
-	req.Header.Set("Fly-Client-IP", "2001:db8::1")
+	req.Header.Set("X-Real-IP", "2001:db8::1")
 
-	ip := clientIP(req, "Fly-Client-IP")
+	ip := clientIP(req, "X-Real-IP")
 	if ip != "2001:db8::1" {
 		t.Fatalf("expected %q, got %q", "2001:db8::1", ip)
 	}
@@ -351,16 +351,16 @@ func TestRateLimitMiddleware_UsesProxyHeaderForRateLimiting(t *testing.T) {
 	})
 	limiter.nowFunc = func() time.Time { return now }
 
-	// Configure middleware with Fly-Client-IP as the trusted header.
-	handler := RateLimitMiddleware(limiter, false, "Fly-Client-IP")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Configure middleware with X-Real-IP as the trusted header.
+	handler := RateLimitMiddleware(limiter, false, "X-Real-IP")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Two requests from different RemoteAddrs but the same Fly-Client-IP
+	// Two requests from different RemoteAddrs but the same X-Real-IP
 	// should share a rate limit bucket.
 	req1 := httptest.NewRequest("GET", "/api/v1/agents", nil)
 	req1.RemoteAddr = "172.16.0.1:11111"
-	req1.Header.Set("Fly-Client-IP", "203.0.113.50")
+	req1.Header.Set("X-Real-IP", "203.0.113.50")
 	rec1 := httptest.NewRecorder()
 	handler.ServeHTTP(rec1, req1)
 	if rec1.Code != http.StatusOK {
@@ -368,8 +368,8 @@ func TestRateLimitMiddleware_UsesProxyHeaderForRateLimiting(t *testing.T) {
 	}
 
 	req2 := httptest.NewRequest("GET", "/api/v1/agents", nil)
-	req2.RemoteAddr = "172.16.0.2:22222" // different proxy IP
-	req2.Header.Set("Fly-Client-IP", "203.0.113.50") // same client
+	req2.RemoteAddr = "172.16.0.2:22222"         // different proxy IP
+	req2.Header.Set("X-Real-IP", "203.0.113.50") // same client
 	rec2 := httptest.NewRecorder()
 	handler.ServeHTTP(rec2, req2)
 	if rec2.Code != http.StatusTooManyRequests {
@@ -379,7 +379,7 @@ func TestRateLimitMiddleware_UsesProxyHeaderForRateLimiting(t *testing.T) {
 	// A request from a different client IP should still be allowed.
 	req3 := httptest.NewRequest("GET", "/api/v1/agents", nil)
 	req3.RemoteAddr = "172.16.0.3:33333"
-	req3.Header.Set("Fly-Client-IP", "198.51.100.99") // different client
+	req3.Header.Set("X-Real-IP", "198.51.100.99") // different client
 	rec3 := httptest.NewRecorder()
 	handler.ServeHTTP(rec3, req3)
 	if rec3.Code != http.StatusOK {

--- a/api/router.go
+++ b/api/router.go
@@ -32,7 +32,7 @@ type Deps struct {
 	AuthRateLimiter        *RateLimiter            // rate limiter for /api/auth/* (signup/login); nil disables
 	AgentRateLimiter       *RateLimiter            // post-auth rate limiter (per verified agent); nil disables
 	VerifyRateLimiter      *RateLimiter            // per-IP rate limiter for POST /agents/{id}/verify; nil disables
-	TrustedProxyHeader     string                  // header to read client IP from behind a reverse proxy (e.g. "Fly-Client-IP"); empty uses RemoteAddr
+	TrustedProxyHeader     string                  // header to read client IP from behind a reverse proxy (e.g. "X-Forwarded-For"); empty uses RemoteAddr
 	AllowedOrigins         []string                // allowed CORS origins; empty means cross-origin requests are blocked
 	Logger                 *slog.Logger            // structured logger for request logging; if nil, request logging is skipped
 	ApprovalEvents         *ApprovalEventBroker    // SSE broker for real-time approval notifications; nil disables SSE


### PR DESCRIPTION
## Summary

The project now deploys via self-hosted systemd (`make redeploy` / `deploy/server`) and no longer uses Fly.io, but several Fly.io leftovers remained. This removes the dead `make deploy` target and updates stale Fly-specific comments/examples.

- **Makefile:** removed the dead `deploy` target (`fly deploy`) and its `.PHONY` entry. No `fly.toml` exists; the real deploy path is `make redeploy`.
- **Dockerfile:** fixed the comment that referenced `[build.args] in fly.toml`.
- **`api/rate_limit_middleware.go` / `api/router.go`:** updated `Fly-Client-IP`/`Fly.io` comment examples to `X-Forwarded-For`, matching the actual runtime default (`main.go` defaults `TRUSTED_PROXY_HEADER` to `X-Forwarded-For`).
- **`api/rate_limit_middleware_test.go`:** switched the custom-proxy-header tests from `Fly-Client-IP` to a generic `X-Real-IP` so they still exercise an arbitrary trusted header (distinct from the existing `X-Forwarded-For` tests).

The generic `TrustedProxyHeader`/`clientIP` mechanism itself is unchanged — it still works behind any reverse proxy. `deploy/server` is **not** a Fly artifact (it's the systemd self-hosted deploy script) and is left intact.

## Test plan

- `gofmt -l` clean on all changed Go files.
- Repo-wide sweep confirms no `fly.io` / `fly.toml` / `flyctl` / `fly deploy` / `Fly-Client-IP` references remain.
- Backend tests (`make test-backend`) could not run in the sandbox (known Go 1.25+ transitive-dependency block documented in CLAUDE.md); relying on CI for the full `go test` pass. Changes are comment/test-string only plus a Makefile target removal — no runtime logic changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxJMaRpGvNg76qbTQ2qjGh)_