### PR TITLE
Surface action risk in Add Action Configuration dialog

### DIFF
--- a/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +31,12 @@ import {
   type ParamMode,
 } from "./ActionConfigFormFields";
 import { TemplatePicker } from "./TemplatePicker";
+import {
+  RiskBadge,
+  riskBlurb,
+  riskCardClass,
+  riskDialogAccentClass,
+} from "./RiskBadge";
 import type { ApprovalMode } from "./RecommendedTemplatesDialog";
 
 const approvalModeOptions: { label: string; value: ApprovalMode }[] = [
@@ -81,6 +87,9 @@ export function AddActionConfigDialog({
     () => actions.find((a) => a.action_type === selectedActionType) ?? null,
     [actions, selectedActionType],
   );
+
+  const riskLevel = selectedAction?.risk_level;
+  const isElevatedRisk = riskLevel === "high" || riskLevel === "medium";
 
   const schema = useMemo(
     // Cast is safe: parameters_schema is typed as `{ [key: string]: unknown }` in
@@ -253,7 +262,9 @@ export function AddActionConfigDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+      <DialogContent
+        className={`max-h-[85dvh] overflow-y-auto sm:max-w-lg ${riskDialogAccentClass(riskLevel)}`}
+      >
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Add Action Configuration</DialogTitle>
@@ -271,6 +282,17 @@ export function AddActionConfigDialog({
               actions={actions}
               disabled={isPending}
             />
+
+            {selectedAction && (
+              <div
+                className={`flex items-start gap-3 rounded-lg border p-3 ${riskCardClass(riskLevel)}`}
+              >
+                <RiskBadge level={riskLevel} />
+                <p className="text-muted-foreground text-sm">
+                  {riskBlurb(riskLevel)}
+                </p>
+              </div>
+            )}
 
             {selectedActionType && (
               <TemplatePicker
@@ -296,6 +318,22 @@ export function AddActionConfigDialog({
                   ? "A standing approval will be created so matching requests run automatically."
                   : "Each request will require your explicit approval before it runs."}
               </p>
+              {approvalMode === "auto_approve" && isElevatedRisk && (
+                <div
+                  role="alert"
+                  className="bg-destructive/10 border-destructive/20 flex items-start gap-2 rounded-lg border p-3"
+                >
+                  <AlertTriangle
+                    className="text-destructive mt-0.5 size-4 shrink-0"
+                    aria-hidden="true"
+                  />
+                  <p className="text-destructive text-sm">
+                    Auto-approving a {riskLevel}-risk action lets this agent run
+                    it without your review every time. Make sure that's what you
+                    want.
+                  </p>
+                </div>
+              )}
             </div>
 
             <NameField

--- a/frontend/src/pages/agents/connectors/ConnectorActionsSection.tsx
+++ b/frontend/src/pages/agents/connectors/ConnectorActionsSection.tsx
@@ -1,5 +1,3 @@
-import { Shield, ShieldAlert, ShieldCheck } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardHeader,
@@ -15,6 +13,7 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import type { ConnectorAction } from "@/hooks/useConnectorDetail";
+import { RiskBadge } from "./RiskBadge";
 
 interface ConnectorActionsSectionProps {
   actions: ConnectorAction[];
@@ -107,43 +106,4 @@ export function ActionRow({ action }: { action: ConnectorAction }) {
       </TableCell>
     </TableRow>
   );
-}
-
-export function RiskBadge({ level }: { level?: "low" | "medium" | "high" }) {
-  switch (level) {
-    case "low":
-      return (
-        <Badge
-          variant="secondary"
-          className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-        >
-          <ShieldCheck className="size-3" />
-          Low
-        </Badge>
-      );
-    case "medium":
-      return (
-        <Badge
-          variant="secondary"
-          className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
-        >
-          <Shield className="size-3" />
-          Medium
-        </Badge>
-      );
-    case "high":
-      return (
-        <Badge variant="destructive">
-          <ShieldAlert className="size-3" />
-          High
-        </Badge>
-      );
-    default:
-      return (
-        <Badge variant="outline">
-          <Shield className="size-3" />
-          Unknown
-        </Badge>
-      );
-  }
 }

--- a/frontend/src/pages/agents/connectors/RiskBadge.tsx
+++ b/frontend/src/pages/agents/connectors/RiskBadge.tsx
@@ -1,0 +1,85 @@
+import { Shield, ShieldAlert, ShieldCheck } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export function RiskBadge({ level }: { level?: RiskLevel }) {
+  switch (level) {
+    case "low":
+      return (
+        <Badge
+          variant="secondary"
+          className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+        >
+          <ShieldCheck className="size-3" />
+          Low
+        </Badge>
+      );
+    case "medium":
+      return (
+        <Badge
+          variant="secondary"
+          className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
+        >
+          <Shield className="size-3" />
+          Medium
+        </Badge>
+      );
+    case "high":
+      return (
+        <Badge variant="destructive">
+          <ShieldAlert className="size-3" />
+          High
+        </Badge>
+      );
+    default:
+      return (
+        <Badge variant="outline">
+          <Shield className="size-3" />
+          Unknown
+        </Badge>
+      );
+  }
+}
+
+/** One-line, risk-aware explanation of what selecting this action means. */
+export function riskBlurb(level?: RiskLevel): string {
+  switch (level) {
+    case "high":
+      return "High-risk: this action can make irreversible or externally-visible changes (e.g. sending email). Review carefully.";
+    case "medium":
+      return "Medium-risk: this action modifies state and may be hard to undo.";
+    case "low":
+      return "Low-risk: this is a read-only or low-impact action.";
+    default:
+      return "Risk level for this action is unknown.";
+  }
+}
+
+/** Accent border for the whole dialog so the risk tier is ambient while editing. */
+export function riskDialogAccentClass(level?: RiskLevel): string {
+  switch (level) {
+    case "high":
+      return "border-t-4 border-t-destructive";
+    case "medium":
+      return "border-t-4 border-t-yellow-500";
+    case "low":
+      return "border-t-4 border-t-green-500";
+    default:
+      return "";
+  }
+}
+
+/** Background/border tint for the inline risk info card. */
+export function riskCardClass(level?: RiskLevel): string {
+  switch (level) {
+    case "high":
+      return "bg-destructive/10 border-destructive/20";
+    case "medium":
+      return "bg-yellow-100/50 border-yellow-300 dark:bg-yellow-900/20 dark:border-yellow-900/40";
+    case "low":
+      return "bg-green-100/40 border-green-300 dark:bg-green-900/20 dark:border-green-900/40";
+    default:
+      return "bg-muted/50";
+  }
+}


### PR DESCRIPTION
## Summary

Makes it obvious when an action configuration is medium/high risk while you're creating it, so it's harder to auto-approve something dangerous (e.g. sending email) by accident. The risk data already existed on every action (`ConnectorAction.risk_level`) but the Add Action Configuration dialog showed none of it.

Three changes to the dialog:

1. **Risk surfaced on selection** — the moment you pick an action, a tinted info card appears under the dropdown with a `RiskBadge` (🔴 High / 🟡 Medium / 🟢 Low) and a plain-language blurb explaining why it's risky.
2. **Dangerous-combo warning** — when a medium/high-risk action is set to **Auto-approve**, an inline alert appears at the toggle warning that the agent can run it without review. Styled to match the existing high-risk banner in the approval review dialog.
3. **Ambient dialog tint** — the dialog's top border is colored by risk tier so the tier stays visible while filling out the form.

`RiskBadge` was extracted from `ConnectorActionsSection` into its own file (nothing else imported it from there) so the actions list and the dialog share one source of truth, alongside small risk-presentation helpers (`riskBlurb`, `riskDialogAccentClass`, `riskCardClass`).

## Files
- `frontend/src/pages/agents/connectors/RiskBadge.tsx` (new — extracted badge + helpers)
- `frontend/src/pages/agents/connectors/AddActionConfigDialog.tsx` (risk treatments)
- `frontend/src/pages/agents/connectors/ConnectorActionsSection.tsx` (import swap only)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/pages/agents/connectors` — 210 tests pass
- [ ] Visual review of the dialog with a high-risk action (e.g. `protonmail.send_email`) selected and Auto-approve toggled

https://claude.ai/code/session_01XcTkvjuWXADSKJym7VzZgp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcTkvjuWXADSKJym7VzZgp)_