### PR TITLE
Allow editing stored credentials in place

### DIFF
--- a/api/credentials.go
+++ b/api/credentials.go
@@ -37,6 +37,12 @@ type deleteCredentialResponse struct {
 	DeletedAt time.Time `json:"deleted_at"`
 }
 
+// updateCredentialRequestRaw uses json.RawMessage for PATCH semantics.
+type updateCredentialRequestRaw struct {
+	Label       json.RawMessage `json:"label"`
+	Credentials json.RawMessage `json:"credentials"`
+}
+
 // --- Validation ---
 
 var servicePattern = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
@@ -52,6 +58,7 @@ func RegisterCredentialRoutes(mux *http.ServeMux, deps *Deps) {
 	requireProfile := RequireProfile(deps)
 	mux.Handle("GET /credentials", requireProfile(handleListCredentials(deps)))
 	mux.Handle("POST /credentials", requireProfile(handleStoreCredential(deps)))
+	mux.Handle("PATCH /credentials/{credential_id}", requireProfile(handleUpdateCredential(deps)))
 	mux.Handle("DELETE /credentials/{credential_id}", requireProfile(handleDeleteCredential(deps)))
 }
 
@@ -193,6 +200,192 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 		}
 
 		RespondJSON(w, http.StatusCreated, toCredentialSummary(*cred))
+	}
+}
+
+func handleUpdateCredential(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+		credID := r.PathValue("credential_id")
+
+		if credID == "" {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "credential_id is required"))
+			return
+		}
+
+		var req updateCredentialRequestRaw
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+
+		newLabel, labelProvided, err := parseOptionalString(req.Label)
+		if err != nil {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label must be a string or null"))
+			return
+		}
+		if labelProvided && newLabel != nil && len(*newLabel) > shared.CredentialLabelMaxLength {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "label exceeds maximum length"))
+			return
+		}
+
+		var credentialUpdates map[string]any
+		credentialsProvided := len(req.Credentials) > 0
+		if credentialsProvided {
+			if isRawJSONNull(req.Credentials) {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "credentials must be an object"))
+				return
+			}
+			if err := json.Unmarshal(req.Credentials, &credentialUpdates); err != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "credentials must be an object"))
+				return
+			}
+		}
+
+		hasCredentialFieldUpdates := false
+		for _, v := range credentialUpdates {
+			s, ok := v.(string)
+			if !ok {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "credential values must be strings"))
+				return
+			}
+			if s != "" {
+				hasCredentialFieldUpdates = true
+				break
+			}
+		}
+
+		if !labelProvided && !hasCredentialFieldUpdates {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "at least one field must be provided"))
+			return
+		}
+
+		if hasCredentialFieldUpdates && deps.Vault == nil {
+			RespondError(w, r, http.StatusServiceUnavailable, ServiceUnavailable("Credential vault not available"))
+			return
+		}
+
+		tx, txOwned, err := db.BeginOrContinue(r.Context(), deps.DB)
+		if err != nil {
+			log.Printf("[%s] UpdateCredential: begin tx: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+			return
+		}
+		if txOwned {
+			defer db.RollbackTx(r.Context(), tx) //nolint:errcheck // best-effort cleanup
+		}
+
+		ownedCred, err := db.GetOwnedCredential(r.Context(), tx, credID, profile.ID)
+		if err != nil {
+			var credErr *db.CredentialError
+			if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "Credential not found"))
+				return
+			}
+			log.Printf("[%s] UpdateCredential: load: %v", TraceID(r.Context()), err)
+			CaptureError(r.Context(), err)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+			return
+		}
+
+		result := ownedCred.Credential
+
+		if hasCredentialFieldUpdates {
+			raw, err := deps.Vault.ReadSecret(r.Context(), tx, ownedCred.VaultSecretID)
+			if err != nil {
+				log.Printf("[%s] UpdateCredential: vault read: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+
+			var existing map[string]string
+			if err := json.Unmarshal(raw, &existing); err != nil {
+				log.Printf("[%s] UpdateCredential: unmarshal existing: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+
+			merged := make(map[string]any, len(existing))
+			for k, v := range existing {
+				merged[k] = v
+			}
+			for k, v := range credentialUpdates {
+				s, ok := v.(string)
+				if !ok || s == "" {
+					continue
+				}
+				merged[k] = s
+			}
+
+			candidates, err := db.GetRequiredCredentialsByService(r.Context(), tx, ownedCred.Service)
+			if err != nil {
+				log.Printf("[%s] UpdateCredential: list required credentials: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+			credStrings, pickErr := resolveAndValidateCredentialPayload(ownedCred.Service, candidates, merged)
+			if pickErr != nil {
+				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pickErr.Error()))
+				return
+			}
+			credJSON, err := json.Marshal(credStrings)
+			if err != nil {
+				log.Printf("[%s] UpdateCredential: marshal credentials: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+
+			if err := deps.Vault.UpdateSecret(r.Context(), tx, ownedCred.VaultSecretID, credJSON); err != nil {
+				log.Printf("[%s] UpdateCredential: vault update: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+		}
+
+		if labelProvided {
+			updated, err := db.UpdateCredentialLabel(r.Context(), tx, credID, profile.ID, newLabel)
+			if err != nil {
+				var credErr *db.CredentialError
+				if errors.As(err, &credErr) {
+					switch credErr.Code {
+					case db.CredentialErrNotFound:
+						RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "Credential not found"))
+						return
+					case db.CredentialErrDuplicate:
+						resp := Conflict(ErrDuplicateCredential, "Credentials already stored for this service with this label")
+						resp.Error.Details = map[string]any{
+							"service": ownedCred.Service,
+						}
+						if newLabel != nil {
+							resp.Error.Details["label"] = *newLabel
+						}
+						RespondError(w, r, http.StatusConflict, resp)
+						return
+					}
+				}
+				log.Printf("[%s] UpdateCredential: label: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+			result = *updated
+		}
+
+		if txOwned {
+			if err := db.CommitTx(r.Context(), tx); err != nil {
+				log.Printf("[%s] UpdateCredential: commit: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Failed to update credential"))
+				return
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, toCredentialSummary(result))
 	}
 }
 

--- a/api/credentials_test.go
+++ b/api/credentials_test.go
@@ -411,6 +411,236 @@ func TestStoreCredential_ServiceTooLong(t *testing.T) {
 	}
 }
 
+// ── PATCH /credentials/{credential_id} ────────────────────────────────────────
+
+func storeTestCredential(t *testing.T, router http.Handler, uid, body string) credentialSummary {
+	t.Helper()
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("store: expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	return decodeStoreCredential(t, w.Body.Bytes())
+}
+
+func patchCredential(t *testing.T, router http.Handler, uid, credID, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := authenticatedJSONRequest(t, http.MethodPatch, fmt.Sprintf("/credentials/%s", credID), uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	return w
+}
+
+func TestUpdateCredential_RenameLabel(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid, `{"service": "github", "credentials": {"api_key": "ghp_test"}, "label": "work"}`)
+
+	w := patchCredential(t, router, uid, stored.ID, `{"label": "personal"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeStoreCredential(t, w.Body.Bytes())
+	if resp.Label == nil || *resp.Label != "personal" {
+		t.Errorf("expected label 'personal', got %v", resp.Label)
+	}
+	if resp.ID != stored.ID {
+		t.Errorf("expected same credential id %q, got %q", stored.ID, resp.ID)
+	}
+}
+
+func TestUpdateCredential_ClearLabel(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid, `{"service": "github", "credentials": {"api_key": "ghp_test"}, "label": "work"}`)
+
+	w := patchCredential(t, router, uid, stored.ID, `{"label": null}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeStoreCredential(t, w.Body.Bytes())
+	if resp.Label != nil {
+		t.Errorf("expected nil label, got %v", resp.Label)
+	}
+}
+
+func TestUpdateCredential_UpdateSecret(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	fields := []byte(`[{"key":"username","label":"Username","secret":false,"required":true},{"key":"password","label":"Password","secret":true,"required":true}]`)
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "proton", "proton", "custom", fields)
+
+	mockVault := vault.NewMockVaultStore()
+	deps := &Deps{DB: tx, Vault: mockVault, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid, `{"service": "proton", "credentials": {"username": "alice", "password": "oldpass"}}`)
+
+	w := patchCredential(t, router, uid, stored.ID, `{"credentials": {"password": "newpass"}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	vaultID, err := db.GetVaultSecretIDByCredentialID(context.Background(), tx, stored.ID)
+	if err != nil {
+		t.Fatalf("GetVaultSecretIDByCredentialID: %v", err)
+	}
+	raw, err := mockVault.ReadSecret(context.Background(), tx, vaultID)
+	if err != nil {
+		t.Fatalf("ReadSecret: %v", err)
+	}
+	var creds map[string]string
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if creds["username"] != "alice" {
+		t.Errorf("expected username unchanged 'alice', got %q", creds["username"])
+	}
+	if creds["password"] != "newpass" {
+		t.Errorf("expected password 'newpass', got %q", creds["password"])
+	}
+}
+
+func TestUpdateCredential_PartialFieldMerge(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	fields := []byte(`[{"key":"host","label":"Host","secret":false,"required":true},{"key":"port","label":"Port","secret":false,"required":true},{"key":"password","label":"Password","secret":true,"required":true}]`)
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "bridge", "bridge", "custom", fields)
+
+	mockVault := vault.NewMockVaultStore()
+	deps := &Deps{DB: tx, Vault: mockVault, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid, `{"service": "bridge", "credentials": {"host": "127.0.0.1", "port": "1143", "password": "secret"}}`)
+
+	w := patchCredential(t, router, uid, stored.ID, `{"credentials": {"host": "", "port": "1025", "password": ""}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	vaultID, err := db.GetVaultSecretIDByCredentialID(context.Background(), tx, stored.ID)
+	if err != nil {
+		t.Fatalf("GetVaultSecretIDByCredentialID: %v", err)
+	}
+	raw, err := mockVault.ReadSecret(context.Background(), tx, vaultID)
+	if err != nil {
+		t.Fatalf("ReadSecret: %v", err)
+	}
+	var creds map[string]string
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if creds["host"] != "127.0.0.1" {
+		t.Errorf("expected host unchanged, got %q", creds["host"])
+	}
+	if creds["port"] != "1025" {
+		t.Errorf("expected port '1025', got %q", creds["port"])
+	}
+	if creds["password"] != "secret" {
+		t.Errorf("expected password unchanged, got %q", creds["password"])
+	}
+}
+
+func TestUpdateCredential_NoOpRejected(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid, `{"service": "github", "credentials": {"api_key": "ghp_test"}}`)
+
+	w := patchCredential(t, router, uid, stored.ID, `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	w2 := patchCredential(t, router, uid, stored.ID, `{"credentials": {"api_key": ""}}`)
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for blank-only credentials, got %d: %s", w2.Code, w2.Body.String())
+	}
+}
+
+func TestUpdateCredential_NotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	w := patchCredential(t, router, uid, "cred_nonexistent", `{"label": "work"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateCredential_OtherUserSeesNotFound(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid1 := testhelper.GenerateUID(t)
+	uid2 := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid1, "u_"+uid1[:8])
+	testhelper.InsertUser(t, tx, uid2, "u_"+uid2[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	stored := storeTestCredential(t, router, uid1, `{"service": "github", "credentials": {"api_key": "ghp_test"}, "label": "work"}`)
+
+	w := patchCredential(t, router, uid2, stored.ID, `{"label": "hijack"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateCredential_LabelCollision(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertConnectorWithStaticCredential(t, tx, "github", "github", "api_key", nil)
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	storeTestCredential(t, router, uid, `{"service": "github", "credentials": {"api_key": "ghp_1"}, "label": "work"}`)
+	stored2 := storeTestCredential(t, router, uid, `{"service": "github", "credentials": {"api_key": "ghp_2"}, "label": "personal"}`)
+
+	w := patchCredential(t, router, uid, stored2.ID, `{"label": "work"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	errResp := decodeErrorResponse(t, w.Body.Bytes())
+	if errResp.Error.Code != ErrDuplicateCredential {
+		t.Errorf("expected error code %q, got %q", ErrDuplicateCredential, errResp.Error.Code)
+	}
+}
+
 // ── DELETE /credentials/{credential_id} ─────────────────────────────────────
 
 func TestDeleteCredential_Success(t *testing.T) {
@@ -723,6 +953,9 @@ func (f *failingVaultStore) CreateSecret(_ context.Context, _ db.DBTX, _ string,
 }
 func (f *failingVaultStore) ReadSecret(_ context.Context, _ db.DBTX, _ string) ([]byte, error) {
 	return nil, fmt.Errorf("vault unavailable")
+}
+func (f *failingVaultStore) UpdateSecret(_ context.Context, _ db.DBTX, _ string, _ []byte) error {
+	return fmt.Errorf("vault unavailable")
 }
 func (f *failingVaultStore) DeleteSecret(_ context.Context, _ db.DBTX, _ string) error {
 	return fmt.Errorf("vault unavailable")

--- a/db/credentials.go
+++ b/db/credentials.go
@@ -1,13 +1,12 @@
 package db
 
 import (
-	"database/sql"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
-
 )
 
 // Credential represents the metadata of a stored credential (secrets are never returned).
@@ -228,6 +227,63 @@ func GetDecryptedCredentials(
 		return nil, fmt.Errorf("unmarshal decrypted credentials: %w", err)
 	}
 	return creds, nil
+}
+
+// OwnedCredential is credential metadata plus the vault secret reference.
+type OwnedCredential struct {
+	Credential
+	VaultSecretID string
+}
+
+// GetOwnedCredential returns credential metadata for a user-owned credential,
+// including vault_secret_id. Returns CredentialErrNotFound when the row is
+// missing or belongs to another user.
+func GetOwnedCredential(ctx context.Context, db DBTX, credID, userID string) (*OwnedCredential, error) {
+	var c Credential
+	var createdAt sql.NullString
+	var vaultSecretID string
+	err := db.QueryRow(ctx, `
+		SELECT id, user_id, service, label, created_at, vault_secret_id
+		FROM credentials
+		WHERE id = $1 AND user_id = $2`,
+		credID, userID,
+	).Scan(&c.ID, &c.UserID, &c.Service, &c.Label, &createdAt, &vaultSecretID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, &CredentialError{Code: CredentialErrNotFound, Message: "Credential not found"}
+	}
+	if err != nil {
+		return nil, err
+	}
+	c.CreatedAt, err = sqliteTimeRequired(createdAt)
+	if err != nil {
+		return nil, err
+	}
+	return &OwnedCredential{
+		Credential:    c,
+		VaultSecretID: vaultSecretID,
+	}, nil
+}
+
+// UpdateCredentialLabel updates the label for a user-owned credential.
+// Pass nil label to clear it back to NULL. Returns CredentialErrNotFound when
+// no owned row matches, or CredentialErrDuplicate on unique constraint violation.
+func UpdateCredentialLabel(ctx context.Context, db DBTX, credID, userID string, label *string) (*Credential, error) {
+	c, err := scanCredential(db.QueryRow(ctx, `
+		UPDATE credentials SET label = $3
+		WHERE id = $1 AND user_id = $2
+		RETURNING id, user_id, service, label, created_at`,
+		credID, userID, label,
+	))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, &CredentialError{Code: CredentialErrNotFound, Message: "Credential not found"}
+	}
+	if err != nil {
+		if IsUniqueViolation(err) {
+			return nil, &CredentialError{Code: CredentialErrDuplicate, Message: "Credentials already stored for this service with this label"}
+		}
+		return nil, err
+	}
+	return c, nil
 }
 
 // GetCredentialByID returns the credential metadata for the given ID,

--- a/frontend/src/hooks/__tests__/useUpdateCredential.test.tsx
+++ b/frontend/src/hooks/__tests__/useUpdateCredential.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks, settleAuthHydration } from "../../auth/__tests__/fixtures";
+import { createAuthWrapper } from "../../test-helpers";
+import { mockPatch, resetClientMocks } from "../../api/__mocks__/client";
+import { useUpdateCredential } from "../useUpdateCredential";
+
+vi.mock("../../api/client");
+
+describe("useUpdateCredential", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    wrapper = createAuthWrapper();
+  });
+
+  it("sends patch request with label-only update", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockPatch.mockResolvedValue({
+      data: {
+        id: "cred_abc123",
+        service: "github",
+        label: "Work GitHub",
+        created_at: "2026-02-11T10:00:00Z",
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateCredential(), { wrapper });
+
+    await settleAuthHydration();
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.updateCredential("cred_abc123", {
+        label: "Work GitHub",
+      });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+      headers: { Authorization: expect.stringMatching(/^Bearer /) },
+      params: { path: { credential_id: "cred_abc123" } },
+      body: { label: "Work GitHub" },
+    });
+    expect(response).toEqual({
+      id: "cred_abc123",
+      service: "github",
+      label: "Work GitHub",
+      created_at: "2026-02-11T10:00:00Z",
+    });
+  });
+
+  it("sends patch request to clear label", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockPatch.mockResolvedValue({
+      data: {
+        id: "cred_abc123",
+        service: "github",
+        created_at: "2026-02-11T10:00:00Z",
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateCredential(), { wrapper });
+
+    await settleAuthHydration();
+    await act(async () => {
+      await result.current.updateCredential("cred_abc123", { label: null });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+      headers: { Authorization: expect.stringMatching(/^Bearer /) },
+      params: { path: { credential_id: "cred_abc123" } },
+      body: { label: null },
+    });
+  });
+
+  it("sends patch request with partial credential fields", async () => {
+    setupAuthMocks({ authenticated: true });
+    mockPatch.mockResolvedValue({
+      data: {
+        id: "cred_abc123",
+        service: "proton",
+        created_at: "2026-02-11T10:00:00Z",
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateCredential(), { wrapper });
+
+    await settleAuthHydration();
+    await act(async () => {
+      await result.current.updateCredential("cred_abc123", {
+        credentials: { password: "new-secret" },
+      });
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+      headers: { Authorization: expect.stringMatching(/^Bearer /) },
+      params: { path: { credential_id: "cred_abc123" } },
+      body: { credentials: { password: "new-secret" } },
+    });
+  });
+
+  it("throws when not authenticated", async () => {
+    setupAuthMocks({ authenticated: false });
+
+    const { result } = renderHook(() => useUpdateCredential(), { wrapper });
+
+    await settleAuthHydration();
+    await expect(
+      result.current.updateCredential("cred_abc123", { label: "Work" }),
+    ).rejects.toThrow("Not authenticated");
+  });
+});

--- a/frontend/src/hooks/useUpdateCredential.ts
+++ b/frontend/src/hooks/useUpdateCredential.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+import type { components } from "@/api/schema";
+
+type UpdateRequest = components["schemas"]["UpdateCredentialRequest"];
+
+export function useUpdateCredential() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async ({
+      credentialId,
+      body,
+    }: {
+      credentialId: string;
+      body: UpdateRequest;
+    }) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.PATCH(
+        "/v1/credentials/{credential_id}",
+        {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+          params: { path: { credential_id: credentialId } },
+          body,
+        },
+      );
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Failed to update credential"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["credentials"] });
+    },
+  });
+
+  return {
+    updateCredential: (credentialId: string, body: UpdateRequest) =>
+      mutation.mutateAsync({ credentialId, body }),
+    isLoading: mutation.isPending,
+  };
+}

--- a/frontend/src/pages/agents/connectors/EditCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditCredentialDialog.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { CredentialSummary } from "@/hooks/useCredentials";
+import { useUpdateCredential } from "@/hooks/useUpdateCredential";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import validation from "@/lib/validation";
+import { resolveStaticCredentialFields } from "./credentialFields";
+
+interface EditCredentialDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  credential: RequiredCredential;
+  storedCredential: CredentialSummary;
+  onSuccess?: () => void;
+}
+
+const BLANK_FIELD_HINT = "Leave blank to keep current value";
+
+export function EditCredentialDialog({
+  open,
+  onOpenChange,
+  credential,
+  storedCredential,
+  onSuccess,
+}: EditCredentialDialogProps) {
+  const { updateCredential, isLoading } = useUpdateCredential();
+  const [label, setLabel] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+
+  const staticFields = useMemo(
+    () => resolveStaticCredentialFields(credential),
+    [credential],
+  );
+
+  const staticFieldSig = useMemo(
+    () => staticFields.map((f) => f.key).join("\x1e"),
+    [staticFields],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setLabel(storedCredential.label ?? "");
+    setUsername("");
+    setPassword("");
+    const next: Record<string, string> = {};
+    for (const f of staticFields) {
+      next[f.key] = "";
+    }
+    setFieldValues(next);
+  }, [open, storedCredential.id, storedCredential.label, staticFieldSig, staticFields]);
+
+  function resetForm() {
+    setLabel(storedCredential.label ?? "");
+    setUsername("");
+    setPassword("");
+    const cleared: Record<string, string> = {};
+    for (const f of staticFields) {
+      cleared[f.key] = "";
+    }
+    setFieldValues(cleared);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) resetForm();
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const body: {
+      label?: string | null;
+      credentials?: Record<string, string>;
+    } = {};
+
+    const trimmedLabel = label.trim();
+    const originalLabel = storedCredential.label ?? "";
+    if (trimmedLabel !== originalLabel) {
+      body.label = trimmedLabel === "" ? null : trimmedLabel;
+    }
+
+    const credentialUpdates = buildCredentialUpdates();
+    if (credentialUpdates && Object.keys(credentialUpdates).length > 0) {
+      body.credentials = credentialUpdates;
+    }
+
+    if (body.label === undefined && body.credentials === undefined) {
+      toast.error("Change at least one field to save");
+      return;
+    }
+
+    try {
+      await updateCredential(storedCredential.id, body);
+      toast.success(`Credentials updated for ${credential.service}`);
+      resetForm();
+      onOpenChange(false);
+      onSuccess?.();
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : `Failed to update credentials for ${credential.service}`,
+      );
+    }
+  }
+
+  function buildCredentialUpdates(): Record<string, string> | null {
+    if (credential.auth_type === "basic") {
+      const updates: Record<string, string> = {};
+      if (username.trim()) updates.username = username.trim();
+      if (password.trim()) updates.password = password.trim();
+      return updates;
+    }
+
+    const updates: Record<string, string> = {};
+    for (const f of staticFields) {
+      const v = (fieldValues[f.key] ?? "").trim();
+      if (v) {
+        updates[f.key] = v;
+      }
+    }
+    return updates;
+  }
+
+  const isBasic = credential.auth_type === "basic";
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Edit Credential</DialogTitle>
+            <DialogDescription>
+              Update credentials for <strong>{credential.service}</strong>.
+              Secret values are never shown — leave fields blank to keep the
+              current value.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-cred-label">Label (optional)</Label>
+              <Input
+                id="edit-cred-label"
+                placeholder={`e.g. Personal ${credential.service}`}
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                maxLength={validation.credentialLabel.maxLength}
+                disabled={isLoading}
+              />
+              <p className="text-muted-foreground text-xs">
+                Clear the label to remove it.
+              </p>
+            </div>
+            {isBasic ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-cred-username">Username</Label>
+                  <Input
+                    id="edit-cred-username"
+                    placeholder="Username or email"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    disabled={isLoading}
+                    autoComplete="off"
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    {BLANK_FIELD_HINT}
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-cred-password">Password / API Token</Label>
+                  <Input
+                    id="edit-cred-password"
+                    type="password"
+                    placeholder="Enter new password or token"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    disabled={isLoading}
+                    autoComplete="off"
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    {BLANK_FIELD_HINT}
+                  </p>
+                </div>
+              </>
+            ) : (
+              staticFields.map((f) => (
+                <div key={f.key} className="space-y-2">
+                  <Label htmlFor={`edit-cred-field-${f.key}`}>{f.label}</Label>
+                  <Input
+                    id={`edit-cred-field-${f.key}`}
+                    type={f.secret ? "password" : "text"}
+                    placeholder={f.placeholder || undefined}
+                    value={fieldValues[f.key] ?? ""}
+                    onChange={(e) =>
+                      setFieldValues((prev) => ({
+                        ...prev,
+                        [f.key]: e.target.value,
+                      }))
+                    }
+                    disabled={isLoading}
+                    autoComplete="off"
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    {BLANK_FIELD_HINT}
+                  </p>
+                  {f.helpText ? (
+                    <p className="text-muted-foreground text-xs">{f.helpText}</p>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading && <Loader2 className="animate-spin" />}
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Loader2,
   LogIn,
+  Pencil,
   Plus,
   Trash2,
   Unplug,
@@ -34,6 +35,7 @@ import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
 import { AddCredentialDialog } from "./AddCredentialDialog";
+import { EditCredentialDialog } from "./EditCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
 import { DisconnectOAuthDialog } from "./DisconnectOAuthDialog";
 import {
@@ -541,6 +543,7 @@ function StaticCredentialRow({
   connectorId: string;
 }) {
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<CredentialSummary | null>(null);
   const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
   const { tryAssign } = useTryAutoAssign(agentId, connectorId);
 
@@ -619,15 +622,25 @@ function StaticCredentialRow({
                     Added {new Date(cred.created_at).toLocaleDateString()}
                   </p>
                 </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-destructive hover:text-destructive"
-                  onClick={() => setRemoveTarget(cred)}
-                  aria-label={`Remove credential ${cred.label ?? cred.service}`}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditTarget(cred)}
+                    aria-label={`Edit credential ${cred.label ?? cred.service}`}
+                  >
+                    <Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-destructive hover:text-destructive"
+                    onClick={() => setRemoveTarget(cred)}
+                    aria-label={`Remove credential ${cred.label ?? cred.service}`}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
               </div>
             ))}
           </div>
@@ -642,6 +655,17 @@ function StaticCredentialRow({
           tryAssign({ credentialId });
         }}
       />
+
+      {editTarget && (
+        <EditCredentialDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setEditTarget(null);
+          }}
+          credential={requiredCredential}
+          storedCredential={editTarget}
+        />
+      )}
 
       {removeTarget && (
         <RemoveCredentialDialog

--- a/frontend/src/pages/agents/connectors/__tests__/EditCredentialDialog.test.tsx
+++ b/frontend/src/pages/agents/connectors/__tests__/EditCredentialDialog.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setupAuthMocks } from "@/auth/__tests__/fixtures";
+import { createAuthWrapper } from "@/test-helpers";
+import { mockPatch, resetClientMocks } from "@/api/__mocks__/client";
+import { EditCredentialDialog } from "../EditCredentialDialog";
+import type { RequiredCredential } from "@/hooks/useConnectorDetail";
+import type { CredentialSummary } from "@/hooks/useCredentials";
+
+vi.mock("@/api/client");
+
+const staticCredential: RequiredCredential = {
+  service: "proton",
+  auth_type: "custom",
+  fields: [
+    {
+      key: "username",
+      label: "Username",
+      secret: false,
+      required: true,
+      placeholder: "Bridge username",
+    },
+    {
+      key: "password",
+      label: "Password",
+      secret: true,
+      required: true,
+      placeholder: "Bridge password",
+    },
+  ],
+};
+
+const storedCredential: CredentialSummary = {
+  id: "cred_abc123",
+  service: "proton",
+  label: "Work Proton",
+  created_at: "2026-02-11T10:00:00Z",
+};
+
+describe("EditCredentialDialog", () => {
+  let wrapper: ReturnType<typeof createAuthWrapper>;
+  const onOpenChange = vi.fn();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetClientMocks();
+    setupAuthMocks({ authenticated: true });
+    wrapper = createAuthWrapper();
+    onOpenChange.mockReset();
+    mockPatch.mockResolvedValue({
+      data: {
+        id: storedCredential.id,
+        service: storedCredential.service,
+        label: "Work Proton",
+        created_at: storedCredential.created_at,
+      },
+    });
+  });
+
+  it("prefills the label and shows blank-field hints", () => {
+    render(
+      <EditCredentialDialog
+        open
+        onOpenChange={onOpenChange}
+        credential={staticCredential}
+        storedCredential={storedCredential}
+      />,
+      { wrapper },
+    );
+
+    expect(screen.getByLabelText(/Label/)).toHaveValue("Work Proton");
+    expect(
+      screen.getAllByText("Leave blank to keep current value").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("submits label-only edit", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditCredentialDialog
+        open
+        onOpenChange={onOpenChange}
+        credential={staticCredential}
+        storedCredential={storedCredential}
+      />,
+      { wrapper },
+    );
+
+    const labelInput = screen.getByLabelText(/Label/);
+    await user.clear(labelInput);
+    await user.type(labelInput, "Personal Proton");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+        headers: { Authorization: expect.stringMatching(/^Bearer /) },
+        params: { path: { credential_id: "cred_abc123" } },
+        body: { label: "Personal Proton" },
+      });
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("submits clear label when label is emptied", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditCredentialDialog
+        open
+        onOpenChange={onOpenChange}
+        credential={staticCredential}
+        storedCredential={storedCredential}
+      />,
+      { wrapper },
+    );
+
+    await user.clear(screen.getByLabelText(/Label/));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+        headers: { Authorization: expect.stringMatching(/^Bearer /) },
+        params: { path: { credential_id: "cred_abc123" } },
+        body: { label: null },
+      });
+    });
+  });
+
+  it("submits only non-blank credential fields", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditCredentialDialog
+        open
+        onOpenChange={onOpenChange}
+        credential={staticCredential}
+        storedCredential={storedCredential}
+      />,
+      { wrapper },
+    );
+
+    await user.type(screen.getByLabelText("Password"), "new-bridge-password");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/v1/credentials/{credential_id}", {
+        headers: { Authorization: expect.stringMatching(/^Bearer /) },
+        params: { path: { credential_id: "cred_abc123" } },
+        body: { credentials: { password: "new-bridge-password" } },
+      });
+    });
+  });
+});

--- a/spec/openapi/components/paths/credentials.yaml
+++ b/spec/openapi/components/paths/credentials.yaml
@@ -162,6 +162,116 @@ credentials:
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
 credentialById:
+  patch:
+    operationId: updateCredential
+    summary: Update Stored Credentials
+    description: |
+      Update a stored credential in place, keeping the same credential ID so existing
+      agent and connector bindings remain intact.
+
+      ## Partial updates
+
+      - **Label**: set a new label, or pass null/empty to clear it back to none.
+      - **Credentials**: only fields you include are changed; blank values keep the
+        current secret. The backend merges submitted values over the decrypted secret,
+        re-validates against the connector schema, and re-encrypts under the same
+        vault secret id.
+
+      ## Security
+
+      - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+      - Only the user who stored the credentials can update them
+      - Secrets are never included in responses
+
+    tags:
+      - Credentials
+
+    security:
+      - SupabaseSession: []
+
+    parameters:
+      - $ref: '../parameters/common.yaml#/CredentialId'
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/credentials.yaml#/UpdateCredentialRequest'
+          examples:
+            rename_label:
+              summary: Rename credential label
+              value:
+                label: "Work GitHub"
+            clear_label:
+              summary: Clear label back to none
+              value:
+                label: null
+            update_password:
+              summary: Update one credential field
+              value:
+                credentials:
+                  password: "new-bridge-password"
+
+    responses:
+      '200':
+        description: Credential updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/credentials.yaml#/CredentialSummary'
+            example:
+              id: "cred_abc123"
+              service: "proton"
+              label: "Work GitHub"
+              created_at: "2026-02-11T10:00:00Z"
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Credential not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "credential_not_found"
+                message: "Credential not found"
+                retryable: false
+                details:
+                  credential_id: "cred_abc123"
+                trace_id: "trace_xyz789"
+
+      '409':
+        description: Label collides with the unique (user_id, service, label) constraint
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+            example:
+              error:
+                code: "duplicate_credential"
+                message: "Credentials already stored for this service with this label"
+                retryable: false
+                details:
+                  service: "github"
+                  label: "Work GitHub"
+                trace_id: "trace_xyz789"
+
+      '429':
+        $ref: '../responses/errors.yaml#/TooManyRequests'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
+      '503':
+        $ref: '../responses/errors.yaml#/ServiceUnavailable'
+
   delete:
     operationId: deleteCredential
     summary: Delete Stored Credentials

--- a/spec/openapi/components/schemas/credentials.yaml
+++ b/spec/openapi/components/schemas/credentials.yaml
@@ -160,6 +160,36 @@ CredentialSummary:
     label: "Personal Access Token"
     created_at: "2026-02-11T10:00:00Z"
 
+UpdateCredentialRequest:
+  type: object
+  description: |
+    Partial update for a stored credential. At least one of `label` or `credentials`
+    must be provided. Secrets are never returned — credential fields left blank in
+    the request keep their current values.
+  properties:
+    label:
+      type: string
+      nullable: true
+      maxLength: 256
+      description: |
+        New label for this credential set. Omit to leave unchanged.
+        Pass null or an empty string to clear the label.
+      example: "Work GitHub"
+
+    credentials:
+      type: object
+      additionalProperties: true
+      description: |
+        Credential field values to update. Omitted keys keep their current values.
+        Leave a field blank (empty string) to keep the stored value unchanged.
+      example:
+        password: "new-bridge-password"
+
+  example:
+    label: "Work GitHub"
+    credentials:
+      password: "new-bridge-password"
+
 DeleteCredentialResponse:
   type: object
   required:

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4445,6 +4445,103 @@ paths:
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
   /v1/credentials/{credential_id}:
+    patch:
+      operationId: updateCredential
+      summary: Update Stored Credentials
+      description: |
+        Update a stored credential in place, keeping the same credential ID so existing
+        agent and connector bindings remain intact.
+
+        ## Partial updates
+
+        - **Label**: set a new label, or pass null/empty to clear it back to none.
+        - **Credentials**: only fields you include are changed; blank values keep the
+          current secret. The backend merges submitted values over the decrypted secret,
+          re-validates against the connector schema, and re-encrypts under the same
+          vault secret id.
+
+        ## Security
+
+        - Request MUST include valid Supabase session JWT (Authorization: Bearer <token>)
+        - Only the user who stored the credentials can update them
+        - Secrets are never included in responses
+      tags:
+        - Credentials
+      security:
+        - SupabaseSession: []
+      parameters:
+        - $ref: '#/components/parameters/CredentialId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCredentialRequest'
+            examples:
+              rename_label:
+                summary: Rename credential label
+                value:
+                  label: Work GitHub
+              clear_label:
+                summary: Clear label back to none
+                value:
+                  label: null
+              update_password:
+                summary: Update one credential field
+                value:
+                  credentials:
+                    password: new-bridge-password
+      responses:
+        '200':
+          description: Credential updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialSummary'
+              example:
+                id: cred_abc123
+                service: proton
+                label: Work GitHub
+                created_at: '2026-02-11T10:00:00Z'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: credential_not_found
+                  message: Credential not found
+                  retryable: false
+                  details:
+                    credential_id: cred_abc123
+                  trace_id: trace_xyz789
+        '409':
+          description: Label collides with the unique (user_id, service, label) constraint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error:
+                  code: duplicate_credential
+                  message: Credentials already stored for this service with this label
+                  retryable: false
+                  details:
+                    service: github
+                    label: Work GitHub
+                  trace_id: trace_xyz789
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
     delete:
       operationId: deleteCredential
       summary: Delete Stored Credentials
@@ -7767,6 +7864,33 @@ components:
         service: github
         label: Personal Access Token
         created_at: '2026-02-11T10:00:00Z'
+    UpdateCredentialRequest:
+      type: object
+      description: |
+        Partial update for a stored credential. At least one of `label` or `credentials`
+        must be provided. Secrets are never returned — credential fields left blank in
+        the request keep their current values.
+      properties:
+        label:
+          type: string
+          nullable: true
+          maxLength: 256
+          description: |
+            New label for this credential set. Omit to leave unchanged.
+            Pass null or an empty string to clear the label.
+          example: Work GitHub
+        credentials:
+          type: object
+          additionalProperties: true
+          description: |
+            Credential field values to update. Omitted keys keep their current values.
+            Leave a field blank (empty string) to keep the stored value unchanged.
+          example:
+            password: new-bridge-password
+      example:
+        label: Work GitHub
+        credentials:
+          password: new-bridge-password
     DeleteCredentialResponse:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -411,6 +411,8 @@ components:
       $ref: './components/schemas/credentials.yaml#/CredentialListResponse'
     CredentialSummary:
       $ref: './components/schemas/credentials.yaml#/CredentialSummary'
+    UpdateCredentialRequest:
+      $ref: './components/schemas/credentials.yaml#/UpdateCredentialRequest'
     DeleteCredentialResponse:
       $ref: './components/schemas/credentials.yaml#/DeleteCredentialResponse'
     

--- a/vault/mock.go
+++ b/vault/mock.go
@@ -61,6 +61,20 @@ func (m *MockVaultStore) ReadSecret(_ context.Context, _ db.DBTX, secretID strin
 	return out, nil
 }
 
+// UpdateSecret overwrites an existing secret in memory.
+func (m *MockVaultStore) UpdateSecret(_ context.Context, _ db.DBTX, secretID string, secret []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.secrets[secretID]; !ok {
+		return fmt.Errorf("vault secret %s not found", secretID)
+	}
+	stored := make([]byte, len(secret))
+	copy(stored, secret)
+	m.secrets[secretID] = stored
+	return nil
+}
+
 // DeleteSecret removes a secret from the in-memory store. Idempotent.
 func (m *MockVaultStore) DeleteSecret(_ context.Context, _ db.DBTX, secretID string) error {
 	m.mu.Lock()

--- a/vault/sqlite.go
+++ b/vault/sqlite.go
@@ -126,6 +126,31 @@ func (v *SQLiteVault) ReadSecret(ctx context.Context, tx db.DBTX, secretID strin
 	return plain, nil
 }
 
+// UpdateSecret re-encrypts secret with a fresh nonce and updates the existing row.
+func (v *SQLiteVault) UpdateSecret(ctx context.Context, tx db.DBTX, secretID string, secret []byte) error {
+	gcm, err := v.gcm()
+	if err != nil {
+		return err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return fmt.Errorf("nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nil, nonce, secret, nil)
+
+	result, err := tx.Exec(ctx,
+		`UPDATE vault_secrets SET nonce = $1, ciphertext = $2 WHERE id = $3`,
+		nonce, ciphertext, secretID,
+	)
+	if err != nil {
+		return fmt.Errorf("vault update: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("vault secret %s not found", secretID)
+	}
+	return nil
+}
+
 // DeleteSecret removes a row from vault_secrets. Idempotent.
 func (v *SQLiteVault) DeleteSecret(ctx context.Context, tx db.DBTX, secretID string) error {
 	_, err := tx.Exec(ctx, `DELETE FROM vault_secrets WHERE id = $1`, secretID)

--- a/vault/sqlite.go
+++ b/vault/sqlite.go
@@ -145,7 +145,7 @@ func (v *SQLiteVault) UpdateSecret(ctx context.Context, tx db.DBTX, secretID str
 	if err != nil {
 		return fmt.Errorf("vault update: %w", err)
 	}
-	if result.RowsAffected() == 0 {
+	if db.RowsAffected(result) == 0 {
 		return fmt.Errorf("vault secret %s not found", secretID)
 	}
 	return nil

--- a/vault/sqlite_test.go
+++ b/vault/sqlite_test.go
@@ -81,6 +81,59 @@ func TestSQLiteVault_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestSQLiteVault_UpdateSecret(t *testing.T) {
+	pool, cleanup := setupVaultTestDB(t)
+	defer cleanup()
+
+	v, err := NewSQLiteVault(testMasterKey(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := t.Context()
+	plain := []byte(`{"token":"original"}`)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := v.CreateSecret(ctx, tx, "cred_test", plain)
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	updated := []byte(`{"token":"rotated"}`)
+	tx2, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.UpdateSecret(ctx, tx2, id, updated); err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	if err := tx2.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := v.ReadSecret(ctx, pool, id)
+	if err != nil {
+		t.Fatalf("ReadSecret: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("expected updated plaintext, got %q", got)
+	}
+
+	tx3, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := v.UpdateSecret(ctx, tx3, "00000000-0000-0000-0000-000000000099", updated); err == nil {
+		t.Fatal("expected error updating missing secret")
+	}
+	_ = tx3.Rollback()
+}
+
 func TestSQLiteVault_TamperedCiphertext(t *testing.T) {
 	pool, cleanup := setupVaultTestDB(t)
 	defer cleanup()

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -24,6 +24,9 @@ type VaultStore interface {
 	// ReadSecret retrieves and decrypts a secret by its vault UUID.
 	ReadSecret(ctx context.Context, tx db.DBTX, secretID string) ([]byte, error)
 
+	// UpdateSecret re-encrypts and overwrites an existing secret in place.
+	UpdateSecret(ctx context.Context, tx db.DBTX, secretID string, secret []byte) error
+
 	// DeleteSecret removes a secret from the vault. Implementations should
 	// be idempotent — deleting a non-existent secret is not an error.
 	DeleteSecret(ctx context.Context, tx db.DBTX, secretID string) error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `PATCH /v1/credentials/{credential_id}` for partial label and secret updates, preserving the same `credential_id` and vault secret id so agent/connector bindings stay intact.
- Extend vault with `UpdateSecret`, add user-scoped `UpdateCredentialLabel` / `GetOwnedCredential` in the DB layer, and cover the handler with API tests (label rename/clear, secret merge, no-op rejection, 404/409).
- Add `useUpdateCredential`, `EditCredentialDialog` (blank fields with "leave blank to keep current"), and a pencil button on static credential rows in the manage-credentials dialog.

Closes #1297

## Test plan

### Claude Code
- [x] `gofmt` on changed Go files
- [x] Frontend: `npx vitest run` for `useUpdateCredential` and `EditCredentialDialog` tests (8 passed)
- [x] Frontend: `npx tsc --noEmit`
- [ ] Backend `go test` — not run locally (sandbox Go 1.24 / bigquery constraint); verified by CI

### OpenClaw
- [ ] Edit a Proton Mail bridge credential password in the manage-connector dialog and confirm the connector still works without re-binding
- [ ] Rename and clear a credential label; confirm duplicate-label 409 when colliding

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03c10e9a-3244-4f28-afc2-bcbdbfeda929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03c10e9a-3244-4f28-afc2-bcbdbfeda929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

