### PR TITLE
Fix "Failed to list approvals" on databases predating the denial-dedup change

### DIFF
--- a/db/00004_add_denial_dedup_columns.go
+++ b/db/00004_add_denial_dedup_columns.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+// Migration 00004 reconciles the denial-dedup schema onto pre-existing
+// databases.
+//
+// Background: denial_reason, action_fingerprint, and the
+// idx_approvals_denial_dedup index were originally introduced by editing the
+// squashed 00001_init.sql in place (PR #1286). goose only ever runs 00001
+// once, so any database created before that edit never received them. Every
+// query that selects the full approvals column set (e.g.
+// ListApprovalsByApproverPaginated) then fails with
+// "no such column: denial_reason", which surfaces to clients as a 500
+// "Failed to list approvals" — breaking the pending-approvals list on both web
+// and mobile.
+//
+// Fresh databases already get these objects from 00001_init.sql, so this
+// migration is written to be idempotent: it only adds what is missing. That
+// keeps it safe on both upgraded installs (columns absent) and fresh installs
+// (columns already present), since both kinds of database exist in the wild.
+//
+// This is a Go migration rather than SQL because SQLite has no
+// "ADD COLUMN IF NOT EXISTS" and a single unconditional ALTER would crash
+// whichever set of databases doesn't match it.
+func init() {
+	goose.AddMigrationContext(upAddDenialDedupColumns, downAddDenialDedupColumns)
+}
+
+func upAddDenialDedupColumns(ctx context.Context, tx *sql.Tx) error {
+	if err := addApprovalsColumnIfMissing(ctx, tx, "denial_reason",
+		`ALTER TABLE approvals ADD COLUMN denial_reason TEXT `+
+			`CHECK (denial_reason IS NULL OR length(denial_reason) <= 500)`); err != nil {
+		return err
+	}
+	if err := addApprovalsColumnIfMissing(ctx, tx, "action_fingerprint",
+		`ALTER TABLE approvals ADD COLUMN action_fingerprint TEXT `+
+			`CHECK (action_fingerprint IS NULL OR length(action_fingerprint) <= 64)`); err != nil {
+		return err
+	}
+	// Partial index used by the denial-dedup lookup (db/approval_dedup.go).
+	// action_fingerprint is guaranteed to exist by this point.
+	if _, err := tx.ExecContext(ctx,
+		`CREATE INDEX IF NOT EXISTS idx_approvals_denial_dedup `+
+			`ON approvals(agent_id, approver_id, action_fingerprint, denied_at DESC) `+
+			`WHERE status = 'denied'`); err != nil {
+		return fmt.Errorf("create idx_approvals_denial_dedup: %w", err)
+	}
+	return nil
+}
+
+func downAddDenialDedupColumns(ctx context.Context, tx *sql.Tx) error {
+	// Only the index is dropped on the way down. The columns are nullable and
+	// harmless to leave in place, and SQLite cannot DROP a column referenced by
+	// a CHECK constraint without a full table rebuild. Down migrations are a
+	// dev-only convenience here, so this stays simple and non-destructive.
+	if _, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS idx_approvals_denial_dedup`); err != nil {
+		return fmt.Errorf("drop idx_approvals_denial_dedup: %w", err)
+	}
+	return nil
+}
+
+// addApprovalsColumnIfMissing runs alterSQL only when the named column is absent
+// from the approvals table, making column additions idempotent across fresh and
+// upgraded databases.
+func addApprovalsColumnIfMissing(ctx context.Context, tx *sql.Tx, column, alterSQL string) error {
+	exists, err := approvalsColumnExists(ctx, tx, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, alterSQL); err != nil {
+		return fmt.Errorf("add approvals column %s: %w", column, err)
+	}
+	return nil
+}
+
+// approvalsColumnExists reports whether the approvals table already has a column
+// with the given name.
+func approvalsColumnExists(ctx context.Context, tx *sql.Tx, column string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name FROM pragma_table_info('approvals')`)
+	if err != nil {
+		return false, fmt.Errorf("inspect approvals columns: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}

--- a/db/00004_add_denial_dedup_columns_test.go
+++ b/db/00004_add_denial_dedup_columns_test.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestMigration00004ReconcilesDenialDedupColumns simulates the exact state of a
+// database created before PR #1286 (which added denial_reason /
+// action_fingerprint by editing the squashed 00001_init.sql in place, so goose
+// never re-applied them). It verifies that running the 00004 up migration adds
+// the missing columns, that the full approvals projection then loads without a
+// "no such column" error — the failure behind the 500 "Failed to list
+// approvals" — and that re-running the migration is a no-op on a database that
+// already has the columns.
+func TestMigration00004ReconcilesDenialDedupColumns(t *testing.T) {
+	ctx := context.Background()
+	conn := openPreDenialDedupApprovalsDB(t)
+
+	// Precondition: the columns are absent, reproducing the broken install.
+	for _, col := range []string{"denial_reason", "action_fingerprint"} {
+		if approvalsColumnExistsDB(t, conn, col) {
+			t.Fatalf("precondition failed: column %q should be absent before migration", col)
+		}
+	}
+
+	runUp00004(t, conn)
+
+	for _, col := range []string{"denial_reason", "action_fingerprint"} {
+		if !approvalsColumnExistsDB(t, conn, col) {
+			t.Errorf("expected column %q to exist after migration", col)
+		}
+	}
+
+	// The full projection used by every approvals list/get query must now load.
+	rows, err := conn.QueryContext(ctx, `SELECT `+approvalColumns+` FROM approvals`)
+	if err != nil {
+		t.Fatalf("select full approvals projection after migration: %v", err)
+	}
+	defer rows.Close()
+	var count int
+	for rows.Next() {
+		if _, err := scanApproval(rows); err != nil {
+			t.Fatalf("scanApproval: %v", err)
+		}
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows.Err: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 seeded approval, got %d", count)
+	}
+
+	// Idempotent: a second run (as on a fresh DB where 00001_init.sql already
+	// created these objects) must not error on a duplicate column.
+	runUp00004(t, conn)
+}
+
+// openPreDenialDedupApprovalsDB creates an approvals table matching the schema
+// of a deployment that predates PR #1286: it has bulk_group_id (added later by
+// 00003) but is missing denial_reason and action_fingerprint. A single pending
+// approval is seeded so the projection scan has a row to read.
+func openPreDenialDedupApprovalsDB(t *testing.T) *sql.DB {
+	t.Helper()
+	conn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "pre_denial.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	if _, err := conn.Exec(`
+CREATE TABLE approvals (
+    approval_id TEXT PRIMARY KEY,
+    approver_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    context TEXT NOT NULL,
+    status TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    approved_at TEXT,
+    denied_at TEXT,
+    cancelled_at TEXT,
+    created_at TEXT NOT NULL,
+    agent_id INTEGER NOT NULL,
+    execution_status TEXT,
+    execution_result TEXT,
+    executed_at TEXT,
+    resource_details TEXT,
+    bulk_group_id TEXT
+);`); err != nil {
+		t.Fatalf("create pre-#1286 approvals table: %v", err)
+	}
+
+	if _, err := conn.Exec(
+		`INSERT INTO approvals
+		   (approval_id, approver_id, action, context, status, expires_at, created_at, agent_id)
+		 VALUES ('a1', 'user-1', '{}', '{}', 'pending',
+		   strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '+1 day'),
+		   strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), 1)`); err != nil {
+		t.Fatalf("seed pending approval: %v", err)
+	}
+	return conn
+}
+
+func runUp00004(t *testing.T, conn *sql.DB) {
+	t.Helper()
+	tx, err := conn.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	if err := upAddDenialDedupColumns(context.Background(), tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("upAddDenialDedupColumns: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+func approvalsColumnExistsDB(t *testing.T, conn *sql.DB, column string) bool {
+	t.Helper()
+	tx, err := conn.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	exists, err := approvalsColumnExists(context.Background(), tx, column)
+	if err != nil {
+		t.Fatalf("approvalsColumnExists(%q): %v", column, err)
+	}
+	return exists
+}


### PR DESCRIPTION
The denial_reason and action_fingerprint columns (and the
idx_approvals_denial_dedup index) were introduced by editing the squashed
00001_init.sql in place. goose only runs 00001 once, so any database created
before that edit never received the columns. Every approvals list/get query
selects the full column set, so it failed with "no such column: denial_reason",
surfacing to web and mobile clients as a 500 "Failed to list approvals".

Add an idempotent goose Go migration (00004) that adds the columns and index
only when missing. SQLite has no "ADD COLUMN IF NOT EXISTS", and live databases
exist both with the columns (fresh installs from 00001_init.sql) and without
them (older installs), so a single unconditional ALTER would crash one set —
hence the conditional Go migration. Includes a regression test that reproduces
the pre-edit schema and verifies the columns are reconciled, the full
projection loads, and re-running the migration is a no-op.