### PR TITLE
Proton Mail: stable IMAP UID message handles

### DIFF
--- a/api/connector_execution.go
+++ b/api/connector_execution.go
@@ -51,11 +51,11 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 
 	connectorID := strings.SplitN(actionType, ".", 2)[0]
 
-	var creds connectors.Credentials
-	creds, err = resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
+	resolved, err := resolveCredentialsForExecution(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
 	if err != nil {
 		return nil, err
 	}
+	creds := resolved.Credentials
 
 	// Validate credentials before executing the action.
 	if conn, ok := deps.Connectors.Get(connectorID); ok {
@@ -103,13 +103,18 @@ func executeConnectorAction(ctx context.Context, deps *Deps, agentID int64, user
 		}
 	}
 
-	result, err := action.Execute(ctx, connectors.ActionRequest{
+	actionReq := connectors.ActionRequest{
 		ActionType:  actionType,
 		Parameters:  parameters,
 		Credentials: creds,
 		Payment:     paymentInfo,
 		UserEmail:   userEmail,
-	})
+	}
+	if connectorID == "protonmail" {
+		actionReq.MailboxUIDValidity = newProtonmailUIDValidityStore(ctx, deps, resolved.CredentialID)
+	}
+
+	result, err := action.Execute(ctx, actionReq)
 	if err != nil {
 		return nil, err
 	}
@@ -237,6 +242,87 @@ func validatePaymentMethod(ctx context.Context, deps *Deps, userID string, pp *p
 	}, nil
 }
 
+type credentialResolution struct {
+	Credentials  connectors.Credentials
+	CredentialID string // static credential ID when bound; empty for OAuth
+}
+
+// resolveCredentialsForExecution resolves credentials and returns binding metadata
+// needed during connector execution (e.g. Proton Mail UIDVALIDITY persistence).
+func resolveCredentialsForExecution(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string, reqCreds []db.RequiredCredential) (credentialResolution, error) {
+	var zero credentialResolution
+	if len(reqCreds) == 0 {
+		return credentialResolution{Credentials: connectors.NewCredentials(nil)}, nil
+	}
+
+	if agentID == 0 {
+		return zero, &connectors.ValidationError{
+			Message: "no credential assigned — assign a credential to this connector before running actions",
+		}
+	}
+
+	var binding *db.AgentConnectorCredential
+	var err error
+	if connectorInstanceID != "" {
+		binding, err = db.GetAgentConnectorCredentialByInstance(ctx, deps.DB, agentID, connectorID, connectorInstanceID)
+	} else {
+		binding, err = db.GetAgentConnectorCredential(ctx, deps.DB, agentID, connectorID)
+	}
+	if err != nil {
+		return zero, fmt.Errorf("look up agent connector credential: %w", err)
+	}
+	return resolveCredentialsFromBinding(ctx, deps, userID, binding)
+}
+
+func resolveCredentialsFromBinding(ctx context.Context, deps *Deps, userID string, binding *db.AgentConnectorCredential) (credentialResolution, error) {
+	var zero credentialResolution
+	if binding == nil {
+		return zero, &connectors.ValidationError{
+			Message: "no credential assigned — go to the agent's connector settings and assign a credential",
+		}
+	}
+
+	if binding.OAuthConnectionID != nil {
+		creds, err := resolveOAuthCredentialsFromBinding(ctx, deps, userID, binding)
+		if err != nil {
+			return zero, err
+		}
+		return credentialResolution{Credentials: creds}, nil
+	}
+	if binding.CredentialID != nil {
+		creds, err := resolveStaticCredentialByID(ctx, deps, userID, *binding.CredentialID)
+		if err != nil {
+			return zero, err
+		}
+		return credentialResolution{
+			Credentials:  creds,
+			CredentialID: *binding.CredentialID,
+		}, nil
+	}
+
+	return zero, &connectors.ValidationError{
+		Message: "credential binding is incomplete — reassign a credential for this connector",
+	}
+}
+
+func resolveOAuthCredentialsFromBinding(ctx context.Context, deps *Deps, userID string, binding *db.AgentConnectorCredential) (connectors.Credentials, error) {
+	conn, oauthErr := db.GetOAuthConnectionByID(ctx, deps.DB, *binding.OAuthConnectionID)
+	if oauthErr != nil {
+		return connectors.Credentials{}, fmt.Errorf("look up bound OAuth connection: %w", oauthErr)
+	}
+	if conn == nil {
+		return connectors.Credentials{}, &connectors.ValidationError{
+			Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
+		}
+	}
+	if conn.UserID != userID {
+		return connectors.Credentials{}, &connectors.ValidationError{
+			Message: "bound OAuth connection does not belong to this user",
+		}
+	}
+	return resolveOAuthCredentialsFromConnection(ctx, deps, conn)
+}
+
 // resolveCredentialsWithFallback resolves credentials for a connector action.
 // It requires an explicit credential binding on the agent — no auto-resolve.
 // If no binding exists, it returns a validation error prompting the user to
@@ -266,46 +352,16 @@ func resolveCredentialsWithFallback(ctx context.Context, deps *Deps, agentID int
 	if err != nil {
 		return connectors.Credentials{}, fmt.Errorf("look up agent connector credential: %w", err)
 	}
-	return resolveCredentialsFromAgentConnectorBinding(ctx, deps, userID, binding)
+	resolved, err := resolveCredentialsFromBinding(ctx, deps, userID, binding)
+	if err != nil {
+		return connectors.Credentials{}, err
+	}
+	return resolved.Credentials, nil
 }
 
 // resolveCredentialsForConnectorInstance resolves credentials for a specific connector instance (same rules as resolveCredentialsWithFallback).
 func resolveCredentialsForConnectorInstance(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string, reqCreds []db.RequiredCredential) (connectors.Credentials, error) {
 	return resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
-}
-
-func resolveCredentialsFromAgentConnectorBinding(ctx context.Context, deps *Deps, userID string, binding *db.AgentConnectorCredential) (connectors.Credentials, error) {
-	if binding == nil {
-		return connectors.Credentials{}, &connectors.ValidationError{
-			Message: "no credential assigned — go to the agent's connector settings and assign a credential",
-		}
-	}
-
-	if binding.OAuthConnectionID != nil {
-		conn, oauthErr := db.GetOAuthConnectionByID(ctx, deps.DB, *binding.OAuthConnectionID)
-		if oauthErr != nil {
-			return connectors.Credentials{}, fmt.Errorf("look up bound OAuth connection: %w", oauthErr)
-		}
-		if conn == nil {
-			return connectors.Credentials{}, &connectors.ValidationError{
-				Message: "bound OAuth connection no longer exists — reassign credentials for this connector",
-			}
-		}
-		// Verify the bound connection belongs to the executing user.
-		if conn.UserID != userID {
-			return connectors.Credentials{}, &connectors.ValidationError{
-				Message: "bound OAuth connection does not belong to this user",
-			}
-		}
-		return resolveOAuthCredentialsFromConnection(ctx, deps, conn)
-	}
-	if binding.CredentialID != nil {
-		return resolveStaticCredentialByID(ctx, deps, userID, *binding.CredentialID)
-	}
-
-	return connectors.Credentials{}, &connectors.ValidationError{
-		Message: "credential binding is incomplete — reassign a credential for this connector",
-	}
 }
 
 // resolveStaticCredentialByID fetches and decrypts a specific credential by its

--- a/api/credential_connector_state.go
+++ b/api/credential_connector_state.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// protonmailUIDValidityStore persists IMAP UIDVALIDITY per folder on a credential.
+type protonmailUIDValidityStore struct {
+	ctx          context.Context
+	deps         *Deps
+	credentialID string
+}
+
+func (s *protonmailUIDValidityStore) UIDValidity(folder string) (uint32, bool) {
+	validity, known, err := db.GetProtonmailUIDValidity(s.ctx, s.deps.DB, s.credentialID, folder)
+	if err != nil {
+		return 0, false
+	}
+	return validity, known
+}
+
+func (s *protonmailUIDValidityStore) SetUIDValidity(folder string, validity uint32) error {
+	return db.SetProtonmailUIDValidity(s.ctx, s.deps.DB, s.credentialID, folder, validity)
+}
+
+func newProtonmailUIDValidityStore(ctx context.Context, deps *Deps, credentialID string) connectors.MailboxUIDValidityStore {
+	if credentialID == "" {
+		return nil
+	}
+	return &protonmailUIDValidityStore{
+		ctx:          ctx,
+		deps:         deps,
+		credentialID: credentialID,
+	}
+}

--- a/connectors/connector.go
+++ b/connectors/connector.go
@@ -86,6 +86,10 @@ type ActionRequest struct {
 	Credentials Credentials     // decrypted at execution time; redacted in logs and JSON
 	Payment     *PaymentInfo    // non-nil when the action requires a payment method
 	UserEmail   string          // email of the Permission Slip user executing the action (may be empty)
+
+	// MailboxUIDValidity optionally tracks IMAP UIDVALIDITY per folder for
+	// connectors that address messages by stable UID (e.g. protonmail).
+	MailboxUIDValidity MailboxUIDValidityStore
 }
 
 // PaymentInfo contains the resolved payment method details passed to connectors
@@ -181,4 +185,3 @@ type UserLister interface {
 	// to look up required credentials for this list call (must exist in the DB).
 	UserListCredentialActionType() string
 }
-

--- a/connectors/mailbox_state.go
+++ b/connectors/mailbox_state.go
@@ -1,0 +1,9 @@
+package connectors
+
+// MailboxUIDValidityStore tracks the last known IMAP UIDVALIDITY per mailbox
+// folder for a credential. Implementations persist across requests so agents
+// can pass stable {folder, uid} handles without carrying UIDVALIDITY.
+type MailboxUIDValidityStore interface {
+	UIDValidity(folder string) (validity uint32, known bool)
+	SetUIDValidity(folder string, validity uint32) error
+}

--- a/connectors/protonmail/archive_email.go
+++ b/connectors/protonmail/archive_email.go
@@ -15,7 +15,7 @@ import (
 const archiveMailbox = "Archive"
 
 // archiveEmailAction moves one or more emails to the Archive folder via IMAP
-// MOVE (RFC 6851). Both Bridge and hydroxide support MOVE.
+// UID MOVE (RFC 6851). Both Bridge and hydroxide support MOVE.
 type archiveEmailAction struct {
 	conn *ProtonMailConnector
 }
@@ -45,14 +45,12 @@ func parseArchiveParams(raw []byte) (*archiveEmailParams, error) {
 
 	params := &archiveEmailParams{Folder: r.Folder}
 
-	// Prefer message_ids array if provided.
 	if len(r.MessageIDs) > 0 && string(r.MessageIDs) != "null" {
 		if err := json.Unmarshal(r.MessageIDs, &params.MessageIDs); err != nil {
 			return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid message_ids: %v", err)}
 		}
 	}
 
-	// Also append message_id if provided; allows combining both fields.
 	if r.MessageID != nil {
 		params.MessageIDs = append(params.MessageIDs, *r.MessageID)
 	}
@@ -65,7 +63,6 @@ func (p *archiveEmailParams) validate() error {
 		return &connectors.ValidationError{Message: "missing required parameter: provide message_id (single) or message_ids (array)"}
 	}
 
-	// Deduplicate: callers may accidentally pass the same ID twice.
 	p.MessageIDs = deduplicateUint32(p.MessageIDs)
 
 	if len(p.MessageIDs) > maxLimit {
@@ -114,36 +111,31 @@ func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 	defer session.close()
 
-	// Open the source folder in read-write mode so we can move messages.
 	mboxData, err := session.selectMailboxReadWrite(params.Folder)
 	if err != nil {
 		return nil, err
 	}
-
-	// Best-effort bounds check against the message count at SELECT time.
-	// Concurrent EXPUNGE responses can make this stale, but it catches
-	// obviously invalid IDs before hitting the server.
-	for _, id := range params.MessageIDs {
-		if id > mboxData.NumMessages {
-			return nil, &connectors.ValidationError{
-				Message: fmt.Sprintf("message_id %d not found (mailbox has %d messages)", id, mboxData.NumMessages),
-			}
-		}
+	if err := syncUIDValidity(params.Folder, mboxData, req.MailboxUIDValidity, uidValidityVerify); err != nil {
+		return nil, err
 	}
 
-	var seqSet imap.SeqSet
+	var uidSet imap.UIDSet
 	for _, id := range params.MessageIDs {
-		seqSet.AddNum(id)
+		uidSet.AddNum(imap.UID(id))
 	}
 
-	// MOVE messages to the Archive folder (RFC 6851).
-	moveCmd := session.client.Move(seqSet, archiveMailbox)
+	moveCmd := session.client.Move(uidSet, archiveMailbox)
 	if _, err := moveCmd.Wait(); err != nil {
 		imapErr := mapIMAPError(err)
-		// Provide a helpful hint if the Archive folder doesn't exist.
-		if strings.Contains(err.Error(), "TRYCREATE") || strings.Contains(err.Error(), "Mailbox doesn't exist") {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "TRYCREATE") || strings.Contains(errMsg, "Mailbox doesn't exist") {
 			return nil, &connectors.ExternalError{
 				Message: fmt.Sprintf("Archive folder not found on server — the mailbox %q may not exist. Ensure your local Proton IMAP/SMTP proxy (Bridge or hydroxide) is configured correctly and exposes an Archive folder: %v", archiveMailbox, err),
+			}
+		}
+		if strings.Contains(strings.ToUpper(errMsg), "UID") || strings.Contains(strings.ToLower(errMsg), "not found") {
+			return nil, &connectors.ValidationError{
+				Message: fmt.Sprintf("one or more message UIDs not found in folder %q", params.Folder),
 			}
 		}
 		return nil, imapErr

--- a/connectors/protonmail/imap_helpers.go
+++ b/connectors/protonmail/imap_helpers.go
@@ -131,28 +131,16 @@ func validateLimit(limit *int) error {
 	return nil
 }
 
-// emptyEmailResult returns a JSON result with an empty email list.
-func emptyEmailResult() (*connectors.ActionResult, error) {
-	return connectors.JSONResult(map[string]any{
-		"emails": []emailSummary{},
-		"total":  0,
-	})
-}
+// fetchEnvelopesByUID fetches message envelopes for the given UID set.
+func fetchEnvelopesByUID(session *imapSession, uidSet imap.UIDSet) ([]emailSummary, error) {
+	if len(uidSet) == 0 {
+		return nil, nil
+	}
 
-// emailListResult returns a JSON result wrapping the given email summaries.
-func emailListResult(emails []emailSummary) (*connectors.ActionResult, error) {
-	return connectors.JSONResult(map[string]any{
-		"emails": emails,
-		"total":  len(emails),
-	})
-}
-
-// fetchEnvelopes fetches message envelopes for the given sequence set and
-// returns them as email summaries.
-func fetchEnvelopes(session *imapSession, seqSet imap.SeqSet) ([]emailSummary, error) {
-	fetchCmd := session.client.Fetch(seqSet, &imap.FetchOptions{
+	fetchCmd := session.client.Fetch(uidSet, &imap.FetchOptions{
 		Envelope: true,
 		Flags:    true,
+		UID:      true,
 	})
 	defer fetchCmd.Close()
 
@@ -166,8 +154,36 @@ func fetchEnvelopes(session *imapSession, seqSet imap.SeqSet) ([]emailSummary, e
 		if err != nil {
 			return nil, mapIMAPError(err)
 		}
-		if buf.Envelope != nil {
-			emails = append(emails, envelopeToSummary(buf.SeqNum, buf.Envelope, buf.Flags))
+		if buf.Envelope != nil && buf.UID != 0 {
+			emails = append(emails, envelopeToSummary(buf.UID, buf.Envelope, buf.Flags))
+		}
+	}
+	return emails, nil
+}
+
+// fetchRecentEnvelopesBySeq fetches the last messages by sequence number but
+// returns summaries keyed by stable UID. Sequence numbers are only used to
+// locate recent messages; they are never exposed to agents.
+func fetchRecentEnvelopesBySeq(session *imapSession, seqSet imap.SeqSet) ([]emailSummary, error) {
+	fetchCmd := session.client.Fetch(seqSet, &imap.FetchOptions{
+		Envelope: true,
+		Flags:    true,
+		UID:      true,
+	})
+	defer fetchCmd.Close()
+
+	var emails []emailSummary
+	for {
+		msg := fetchCmd.Next()
+		if msg == nil {
+			break
+		}
+		buf, err := msg.Collect()
+		if err != nil {
+			return nil, mapIMAPError(err)
+		}
+		if buf.Envelope != nil && buf.UID != 0 {
+			emails = append(emails, envelopeToSummary(buf.UID, buf.Envelope, buf.Flags))
 		}
 	}
 	return emails, nil
@@ -175,12 +191,13 @@ func fetchEnvelopes(session *imapSession, seqSet imap.SeqSet) ([]emailSummary, e
 
 // emailSummary is the JSON representation of an email summary.
 type emailSummary struct {
-	SeqNum  uint32   `json:"seq_num"`
-	Subject string   `json:"subject"`
-	From    []string `json:"from"`
-	To      []string `json:"to"`
-	Date    string   `json:"date"`
-	Flags   []string `json:"flags"`
+	UID             uint32   `json:"uid"`
+	Subject         string   `json:"subject"`
+	From            []string `json:"from"`
+	To              []string `json:"to"`
+	Date            string   `json:"date"`
+	Flags           []string `json:"flags"`
+	MessageIDHeader string   `json:"message_id_header,omitempty"`
 }
 
 // formatAddresses formats IMAP addresses as human-readable strings.
@@ -202,18 +219,29 @@ func formatAddresses(addrs []imap.Address) []string {
 }
 
 // envelopeToSummary converts an IMAP envelope to our JSON summary format.
-func envelopeToSummary(seqNum uint32, env *imap.Envelope, flags []imap.Flag) emailSummary {
+func envelopeToSummary(uid imap.UID, env *imap.Envelope, flags []imap.Flag) emailSummary {
 	summary := emailSummary{
-		SeqNum:  seqNum,
-		Subject: env.Subject,
-		Date:    env.Date.Format(time.RFC3339),
-		From:    formatAddresses(env.From),
-		To:      formatAddresses(env.To),
+		UID:             uint32(uid),
+		Subject:         env.Subject,
+		Date:            env.Date.Format(time.RFC3339),
+		From:            formatAddresses(env.From),
+		To:              formatAddresses(env.To),
+		MessageIDHeader: env.MessageID,
 	}
 	for _, f := range flags {
 		summary.Flags = append(summary.Flags, string(f))
 	}
 	return summary
+}
+
+// emailListResultWithFolder returns list results including the folder name so
+// agents can pair returned UIDs with their mailbox scope.
+func emailListResultWithFolder(folder string, emails []emailSummary) (*connectors.ActionResult, error) {
+	return connectors.JSONResult(map[string]any{
+		"folder": folder,
+		"emails": emails,
+		"total":  len(emails),
+	})
 }
 
 // mapIMAPError translates raw IMAP errors into typed connector errors so the

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -136,7 +136,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 			{
 				ActionType:  "protonmail.read_email",
 				Name:        "Read Email",
-				Description: "Fetch a specific email by sequence number with full body",
+				Description: "Fetch a specific email by stable IMAP UID with full body",
 				RiskLevel:   "low",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
@@ -145,7 +145,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						"message_id": {
 							"type": "integer",
 							"minimum": 1,
-							"description": "The sequence number of the email to read"
+							"description": "Stable IMAP UID of the email within the folder (from read_inbox or search_emails results)"
 						},
 						"folder": {
 							"type": "string",
@@ -170,14 +170,14 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						"message_id": {
 							"type": "integer",
 							"minimum": 1,
-							"description": "Sequence number of a single email to archive (shorthand for message_ids with one item)"
+							"description": "Stable IMAP UID of a single email to archive (shorthand for message_ids with one item)"
 						},
 						"message_ids": {
 							"type": "array",
 							"items": {"type": "integer", "minimum": 1},
 							"minItems": 1,
 							"maxItems": 50,
-							"description": "Sequence numbers of emails to archive (batch). Combined unique count of message_id + message_ids must not exceed 50."
+							"description": "Stable IMAP UIDs of emails to archive (batch). Combined unique count of message_id + message_ids must not exceed 50."
 						},
 						"folder": {
 							"type": "string",

--- a/connectors/protonmail/read_email.go
+++ b/connectors/protonmail/read_email.go
@@ -19,8 +19,8 @@ import (
 // suffix so consumers know the content is incomplete.
 const maxBodySize = 1024 * 1024
 
-// readEmailAction fetches a single email by sequence number, returning the
-// full body, headers, and attachment metadata (but not attachment content).
+// readEmailAction fetches a single email by stable UID, returning the full
+// body, headers, and attachment metadata (but not attachment content).
 type readEmailAction struct {
 	conn *ProtonMailConnector
 }
@@ -41,18 +41,19 @@ func (p *readEmailParams) validate() error {
 }
 
 type emailDetail struct {
-	SeqNum      uint32           `json:"seq_num"`
-	Subject     string           `json:"subject"`
-	From        []string         `json:"from"`
-	To          []string         `json:"to"`
-	Cc          []string         `json:"cc,omitempty"`
-	ReplyTo     []string         `json:"reply_to,omitempty"`
-	Date        string           `json:"date"`
-	MessageID   string           `json:"message_id_header,omitempty"`
-	Flags       []string         `json:"flags"`
-	ContentType string           `json:"content_type"`
-	Body        string           `json:"body"`
-	Attachments []attachmentInfo `json:"attachments,omitempty"`
+	UID             uint32           `json:"uid"`
+	Folder          string           `json:"folder"`
+	Subject         string           `json:"subject"`
+	From            []string         `json:"from"`
+	To              []string         `json:"to"`
+	Cc              []string         `json:"cc,omitempty"`
+	ReplyTo         []string         `json:"reply_to,omitempty"`
+	Date            string           `json:"date"`
+	MessageIDHeader string           `json:"message_id_header,omitempty"`
+	Flags           []string         `json:"flags"`
+	ContentType     string           `json:"content_type"`
+	Body            string           `json:"body"`
+	Attachments     []attachmentInfo `json:"attachments,omitempty"`
 }
 
 type attachmentInfo struct {
@@ -80,28 +81,21 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 	if err != nil {
 		return nil, err
 	}
-
-	if params.MessageID > mboxData.NumMessages {
-		return nil, &connectors.ValidationError{
-			Message: fmt.Sprintf("message_id %d not found (mailbox has %d messages)", params.MessageID, mboxData.NumMessages),
-		}
+	if err := syncUIDValidity(params.Folder, mboxData, req.MailboxUIDValidity, uidValidityVerify); err != nil {
+		return nil, err
 	}
 
-	// Fetch the full message body.
-	var seqSet imap.SeqSet
-	seqSet.AddNum(params.MessageID)
+	uidSet := imap.UIDSetNum(imap.UID(params.MessageID))
 
 	bodySection := &imap.FetchItemBodySection{
-		Peek: true, // don't mark as read
-		// Limit the download at the IMAP protocol level to avoid pulling
-		// multi-MB attachments into memory. We request maxBodySize+1 so
-		// parseBody can detect truncation.
+		Peek:    true,
 		Partial: &imap.SectionPartial{Offset: 0, Size: int64(maxBodySize) + 1},
 	}
 
-	fetchCmd := session.client.Fetch(seqSet, &imap.FetchOptions{
+	fetchCmd := session.client.Fetch(uidSet, &imap.FetchOptions{
 		Envelope: true,
 		Flags:    true,
+		UID:      true,
 		BodySection: []*imap.FetchItemBodySection{
 			bodySection,
 		},
@@ -111,22 +105,30 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 
 	msg := fetchCmd.Next()
 	if msg == nil {
-		return nil, &connectors.ExternalError{Message: fmt.Sprintf("message %d not found", params.MessageID)}
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("message uid %d not found in folder %q", params.MessageID, params.Folder),
+		}
 	}
 
 	buf, err := msg.Collect()
 	if err != nil {
 		return nil, mapIMAPError(err)
 	}
+	if buf.UID == 0 {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("message uid %d not found in folder %q", params.MessageID, params.Folder),
+		}
+	}
 
 	detail := emailDetail{
-		SeqNum: buf.SeqNum,
+		UID:    uint32(buf.UID),
+		Folder: params.Folder,
 	}
 
 	if buf.Envelope != nil {
 		detail.Subject = buf.Envelope.Subject
 		detail.Date = buf.Envelope.Date.Format(time.RFC3339)
-		detail.MessageID = buf.Envelope.MessageID
+		detail.MessageIDHeader = buf.Envelope.MessageID
 		detail.From = formatAddresses(buf.Envelope.From)
 		detail.To = formatAddresses(buf.Envelope.To)
 		detail.Cc = formatAddresses(buf.Envelope.Cc)
@@ -137,7 +139,6 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		detail.Flags = append(detail.Flags, string(f))
 	}
 
-	// Collect attachment info from body structure.
 	if buf.BodyStructure != nil {
 		buf.BodyStructure.Walk(func(path []int, part imap.BodyStructure) bool {
 			if sp, ok := part.(*imap.BodyStructureSinglePart); ok {
@@ -153,7 +154,6 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 		})
 	}
 
-	// Parse the body content.
 	rawBody := buf.FindBodySection(bodySection)
 	if rawBody != nil {
 		body, contentType := parseBody(rawBody)
@@ -170,7 +170,6 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 func parseBody(rawBody []byte) (body, contentType string) {
 	mr, err := mail.CreateReader(bytes.NewReader(rawBody))
 	if err != nil {
-		// Fall back to raw body if we can't parse it.
 		return truncateBody(string(rawBody)), "text/plain"
 	}
 	defer mr.Close()
@@ -186,7 +185,6 @@ func parseBody(rawBody []byte) (body, contentType string) {
 			h := part.Header.(*mail.InlineHeader)
 			ct, _, _ := h.ContentType()
 			if strings.HasPrefix(ct, "text/plain") || strings.HasPrefix(ct, "text/html") {
-				// Read maxBodySize+1 to detect if content was truncated.
 				b, err := io.ReadAll(io.LimitReader(part.Body, maxBodySize+1))
 				if err == nil {
 					if len(b) > maxBodySize {
@@ -197,7 +195,6 @@ func parseBody(rawBody []byte) (body, contentType string) {
 					contentType = ct
 				}
 				if strings.HasPrefix(ct, "text/plain") {
-					// Prefer text/plain; if found, stop looking.
 					return body, contentType
 				}
 			}

--- a/connectors/protonmail/read_inbox.go
+++ b/connectors/protonmail/read_inbox.go
@@ -45,50 +45,55 @@ func (a *readInboxAction) Execute(ctx context.Context, req connectors.ActionRequ
 	if err != nil {
 		return nil, err
 	}
-
-	if mboxData.NumMessages == 0 {
-		return emptyEmailResult()
+	if err := syncUIDValidity(params.Folder, mboxData, req.MailboxUIDValidity, uidValidityRecord); err != nil {
+		return nil, err
 	}
 
-	// If unread_only, search for unseen messages first.
-	var seqNums []uint32
+	if mboxData.NumMessages == 0 {
+		return emailListResultWithFolder(params.Folder, nil)
+	}
+
+	var emails []emailSummary
 	if params.UnreadOnly {
 		criteria := &imap.SearchCriteria{
 			NotFlag: []imap.Flag{imap.FlagSeen},
 		}
-		searchData, err := session.client.Search(criteria, nil).Wait()
+		searchData, err := session.client.UIDSearch(criteria, nil).Wait()
 		if err != nil {
 			return nil, mapIMAPError(err)
 		}
-		seqNums = searchData.AllSeqNums()
-	}
+		uids := searchData.AllUIDs()
+		if len(uids) == 0 {
+			return emailListResultWithFolder(params.Folder, nil)
+		}
 
-	// Determine which messages to fetch.
-	var seqSet imap.SeqSet
-	if params.UnreadOnly {
-		if len(seqNums) == 0 {
-			return emptyEmailResult()
-		}
-		// Take only the last `limit` unread messages (most recent).
 		start := 0
-		if len(seqNums) > params.Limit {
-			start = len(seqNums) - params.Limit
+		if len(uids) > params.Limit {
+			start = len(uids) - params.Limit
 		}
-		for _, n := range seqNums[start:] {
-			seqSet.AddNum(n)
+		limited := uids[start:]
+
+		var uidSet imap.UIDSet
+		for _, uid := range limited {
+			uidSet.AddNum(uid)
+		}
+		emails, err = fetchEnvelopesByUID(session, uidSet)
+		if err != nil {
+			return nil, err
 		}
 	} else {
-		// Fetch the last `limit` messages by sequence number.
 		from := uint32(1)
 		if mboxData.NumMessages > uint32(params.Limit) {
 			from = mboxData.NumMessages - uint32(params.Limit) + 1
 		}
+		var seqSet imap.SeqSet
 		seqSet.AddRange(from, mboxData.NumMessages)
+
+		emails, err = fetchRecentEnvelopesBySeq(session, seqSet)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	emails, err := fetchEnvelopes(session, seqSet)
-	if err != nil {
-		return nil, err
-	}
-	return emailListResult(emails)
+	return emailListResultWithFolder(params.Folder, emails)
 }

--- a/connectors/protonmail/search_emails.go
+++ b/connectors/protonmail/search_emails.go
@@ -61,7 +61,11 @@ func (a *searchEmailsAction) Execute(ctx context.Context, req connectors.ActionR
 	}
 	defer session.close()
 
-	if _, err := session.selectMailbox(params.Folder); err != nil {
+	mboxData, err := session.selectMailbox(params.Folder)
+	if err != nil {
+		return nil, err
+	}
+	if err := syncUIDValidity(params.Folder, mboxData, req.MailboxUIDValidity, uidValidityRecord); err != nil {
 		return nil, err
 	}
 
@@ -88,31 +92,30 @@ func (a *searchEmailsAction) Execute(ctx context.Context, req connectors.ActionR
 		criteria.Before = t
 	}
 
-	searchData, err := session.client.Search(criteria, nil).Wait()
+	searchData, err := session.client.UIDSearch(criteria, nil).Wait()
 	if err != nil {
 		return nil, mapIMAPError(err)
 	}
 
-	seqNums := searchData.AllSeqNums()
-	if len(seqNums) == 0 {
-		return emptyEmailResult()
+	uids := searchData.AllUIDs()
+	if len(uids) == 0 {
+		return emailListResultWithFolder(params.Folder, nil)
 	}
 
-	// Limit results (take most recent).
 	start := 0
-	if len(seqNums) > params.Limit {
-		start = len(seqNums) - params.Limit
+	if len(uids) > params.Limit {
+		start = len(uids) - params.Limit
 	}
-	limited := seqNums[start:]
+	limited := uids[start:]
 
-	var seqSet imap.SeqSet
-	for _, n := range limited {
-		seqSet.AddNum(n)
+	var uidSet imap.UIDSet
+	for _, uid := range limited {
+		uidSet.AddNum(uid)
 	}
 
-	emails, err := fetchEnvelopes(session, seqSet)
+	emails, err := fetchEnvelopesByUID(session, uidSet)
 	if err != nil {
 		return nil, err
 	}
-	return emailListResult(emails)
+	return emailListResultWithFolder(params.Folder, emails)
 }

--- a/connectors/protonmail/uidvalidity.go
+++ b/connectors/protonmail/uidvalidity.go
@@ -1,0 +1,48 @@
+package protonmail
+
+import (
+	"fmt"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type uidValidityMode int
+
+const (
+	uidValidityRecord uidValidityMode = iota
+	uidValidityVerify
+)
+
+// syncUIDValidity records or verifies UIDVALIDITY for a folder.
+//
+// List operations use record mode (always update the stored value). Execute
+// operations use verify mode: refuse when the stored value exists and differs
+// from the server, otherwise record on first sight.
+func syncUIDValidity(folder string, mboxData *imap.SelectData, store connectors.MailboxUIDValidityStore, mode uidValidityMode) error {
+	if store == nil || mboxData == nil {
+		return nil
+	}
+
+	current := mboxData.UIDValidity
+	switch mode {
+	case uidValidityRecord:
+		return store.SetUIDValidity(folder, current)
+	case uidValidityVerify:
+		stored, known := store.UIDValidity(folder)
+		if known && stored != current {
+			return &connectors.ValidationError{
+				Message: fmt.Sprintf(
+					"mailbox %q state is no longer valid (UIDVALIDITY changed); re-list messages before acting on them",
+					folder,
+				),
+			}
+		}
+		if !known {
+			return store.SetUIDValidity(folder, current)
+		}
+		return nil
+	default:
+		return nil
+	}
+}

--- a/connectors/protonmail/uidvalidity_test.go
+++ b/connectors/protonmail/uidvalidity_test.go
@@ -1,0 +1,156 @@
+package protonmail
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type memUIDValidityStore struct {
+	mu      sync.Mutex
+	folders map[string]uint32
+}
+
+func newMemUIDValidityStore() *memUIDValidityStore {
+	return &memUIDValidityStore{folders: make(map[string]uint32)}
+}
+
+func (s *memUIDValidityStore) UIDValidity(folder string) (uint32, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.folders[folder]
+	return v, ok
+}
+
+func (s *memUIDValidityStore) SetUIDValidity(folder string, validity uint32) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.folders[folder] = validity
+	return nil
+}
+
+func TestSyncUIDValidity_RecordUpdatesStore(t *testing.T) {
+	t.Parallel()
+
+	store := newMemUIDValidityStore()
+	mbox := &imap.SelectData{UIDValidity: 42}
+
+	if err := syncUIDValidity("INBOX", mbox, store, uidValidityRecord); err != nil {
+		t.Fatalf("syncUIDValidity: %v", err)
+	}
+	got, ok := store.UIDValidity("INBOX")
+	if !ok || got != 42 {
+		t.Fatalf("expected UIDVALIDITY 42, got %d (ok=%v)", got, ok)
+	}
+}
+
+func TestSyncUIDValidity_VerifyRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := newMemUIDValidityStore()
+	_ = store.SetUIDValidity("INBOX", 100)
+
+	err := syncUIDValidity("INBOX", &imap.SelectData{UIDValidity: 200}, store, uidValidityVerify)
+	if err == nil {
+		t.Fatal("expected UIDVALIDITY mismatch error")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestSyncUIDValidity_VerifyAllowsMatch(t *testing.T) {
+	t.Parallel()
+
+	store := newMemUIDValidityStore()
+	_ = store.SetUIDValidity("INBOX", 100)
+
+	if err := syncUIDValidity("INBOX", &imap.SelectData{UIDValidity: 100}, store, uidValidityVerify); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSyncUIDValidity_VerifyRecordsFirstSeen(t *testing.T) {
+	t.Parallel()
+
+	store := newMemUIDValidityStore()
+	if err := syncUIDValidity("INBOX", &imap.SelectData{UIDValidity: 77}, store, uidValidityVerify); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := store.UIDValidity("INBOX")
+	if !ok || got != 77 {
+		t.Fatalf("expected UIDVALIDITY 77, got %d (ok=%v)", got, ok)
+	}
+}
+
+func TestEnvelopeToSummary_UsesUIDAndMessageIDHeader(t *testing.T) {
+	t.Parallel()
+
+	env := &imap.Envelope{
+		Subject:   "Invoice",
+		MessageID: "<abc@example.com>",
+	}
+	summary := envelopeToSummary(123, env, []imap.Flag{imap.FlagSeen})
+
+	if summary.UID != 123 {
+		t.Errorf("UID = %d, want 123", summary.UID)
+	}
+	if summary.MessageIDHeader != "<abc@example.com>" {
+		t.Errorf("MessageIDHeader = %q", summary.MessageIDHeader)
+	}
+}
+
+// TestUIDStabilityAcrossExpunge documents that UIDs remain stable when lower
+// sequence numbers are expunged. Sequence numbers shift; UIDs do not.
+func TestUIDStabilityAcrossExpunge(t *testing.T) {
+	t.Parallel()
+
+	type message struct {
+		seq uint32
+		uid imap.UID
+	}
+	mailbox := []message{
+		{seq: 1, uid: 10},
+		{seq: 2, uid: 20},
+		{seq: 3, uid: 30},
+	}
+
+	// Simulate expunging seq 1: remaining messages shift down by one sequence.
+	afterExpunge := mailbox[1:]
+	if afterExpunge[0].seq == 1 && afterExpunge[0].uid != 20 {
+		t.Fatalf("expected uid 20 at seq 1 after expunge, got uid %d", afterExpunge[0].uid)
+	}
+	if afterExpunge[1].seq == 2 && afterExpunge[1].uid != 30 {
+		t.Fatalf("expected uid 30 at seq 2 after expunge, got uid %d", afterExpunge[1].uid)
+	}
+
+	// Agent targeted uid 30 before expunge; it still resolves after churn.
+	targetUID := imap.UID(30)
+	found := false
+	for _, msg := range afterExpunge {
+		if msg.uid == targetUID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("target UID should remain addressable after unrelated expunge")
+	}
+}
+
+func TestDeduplicateUint32_BatchArchive(t *testing.T) {
+	t.Parallel()
+
+	got := deduplicateUint32([]uint32{30, 10, 30, 20, 10})
+	want := []uint32{30, 10, 20}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/db/00005_add_credentials_connector_state.go
+++ b/db/00005_add_credentials_connector_state.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddCredentialsConnectorState, downAddCredentialsConnectorState)
+}
+
+func upAddCredentialsConnectorState(ctx context.Context, tx *sql.Tx) error {
+	return addCredentialsColumnIfMissing(ctx, tx, "connector_state",
+		`ALTER TABLE credentials ADD COLUMN connector_state TEXT NOT NULL DEFAULT '{}'`)
+}
+
+func downAddCredentialsConnectorState(ctx context.Context, tx *sql.Tx) error {
+	// SQLite cannot drop columns without a table rebuild; leave in place.
+	return nil
+}
+
+func addCredentialsColumnIfMissing(ctx context.Context, tx *sql.Tx, column, alterSQL string) error {
+	exists, err := credentialsColumnExists(ctx, tx, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, alterSQL); err != nil {
+		return fmt.Errorf("add credentials column %s: %w", column, err)
+	}
+	return nil
+}
+
+func credentialsColumnExists(ctx context.Context, tx *sql.Tx, column string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name FROM pragma_table_info('credentials')`)
+	if err != nil {
+		return false, fmt.Errorf("inspect credentials columns: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}

--- a/db/credential_connector_state.go
+++ b/db/credential_connector_state.go
@@ -1,0 +1,83 @@
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ProtonmailConnectorState holds non-secret Proton Mail sync metadata for a credential.
+type ProtonmailConnectorState struct {
+	Folders map[string]ProtonmailFolderState `json:"folders,omitempty"`
+}
+
+// ProtonmailFolderState records IMAP state for a single mailbox folder.
+type ProtonmailFolderState struct {
+	UIDValidity uint32 `json:"uidvalidity"`
+}
+
+type credentialConnectorState struct {
+	Protonmail *ProtonmailConnectorState `json:"protonmail,omitempty"`
+}
+
+// GetProtonmailUIDValidity returns the stored UIDVALIDITY for a folder, or false
+// if none has been recorded yet.
+func GetProtonmailUIDValidity(ctx context.Context, db DBTX, credentialID, folder string) (uint32, bool, error) {
+	state, err := loadCredentialConnectorState(ctx, db, credentialID)
+	if err != nil {
+		return 0, false, err
+	}
+	if state.Protonmail == nil || state.Protonmail.Folders == nil {
+		return 0, false, nil
+	}
+	folderState, ok := state.Protonmail.Folders[folder]
+	if !ok {
+		return 0, false, nil
+	}
+	return folderState.UIDValidity, true, nil
+}
+
+// SetProtonmailUIDValidity records UIDVALIDITY for a folder on the credential.
+func SetProtonmailUIDValidity(ctx context.Context, db DBTX, credentialID, folder string, uidValidity uint32) error {
+	state, err := loadCredentialConnectorState(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+	if state.Protonmail == nil {
+		state.Protonmail = &ProtonmailConnectorState{}
+	}
+	if state.Protonmail.Folders == nil {
+		state.Protonmail.Folders = make(map[string]ProtonmailFolderState)
+	}
+	state.Protonmail.Folders[folder] = ProtonmailFolderState{UIDValidity: uidValidity}
+
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal connector_state: %w", err)
+	}
+
+	_, err = db.Exec(ctx, `
+		UPDATE credentials
+		SET connector_state = $2::jsonb
+		WHERE id = $1`, credentialID, raw)
+	return err
+}
+
+func loadCredentialConnectorState(ctx context.Context, db DBTX, credentialID string) (*credentialConnectorState, error) {
+	var raw []byte
+	err := db.QueryRow(ctx, `
+		SELECT connector_state
+		FROM credentials
+		WHERE id = $1`, credentialID).Scan(&raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return &credentialConnectorState{}, nil
+	}
+	var state credentialConnectorState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal connector_state: %w", err)
+	}
+	return &state, nil
+}

--- a/db/credential_connector_state.go
+++ b/db/credential_connector_state.go
@@ -58,7 +58,7 @@ func SetProtonmailUIDValidity(ctx context.Context, db DBTX, credentialID, folder
 
 	_, err = db.Exec(ctx, `
 		UPDATE credentials
-		SET connector_state = $2::jsonb
+		SET connector_state = $2
 		WHERE id = $1`, credentialID, raw)
 	return err
 }

--- a/db/credential_connector_state_test.go
+++ b/db/credential_connector_state_test.go
@@ -1,0 +1,48 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+func TestProtonmailUIDValidityRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertCredential(t, tx, credID, uid, "protonmail")
+
+	_, known, err := db.GetProtonmailUIDValidity(ctx, tx, credID, "INBOX")
+	if err != nil {
+		t.Fatalf("GetProtonmailUIDValidity: %v", err)
+	}
+	if known {
+		t.Fatal("expected no stored UIDVALIDITY initially")
+	}
+
+	if err := db.SetProtonmailUIDValidity(ctx, tx, credID, "INBOX", 12345); err != nil {
+		t.Fatalf("SetProtonmailUIDValidity: %v", err)
+	}
+
+	got, known, err := db.GetProtonmailUIDValidity(ctx, tx, credID, "INBOX")
+	if err != nil {
+		t.Fatalf("GetProtonmailUIDValidity after set: %v", err)
+	}
+	if !known || got != 12345 {
+		t.Fatalf("got validity %d (known=%v), want 12345", got, known)
+	}
+
+	if err := db.SetProtonmailUIDValidity(ctx, tx, credID, "Archive", 99); err != nil {
+		t.Fatalf("SetProtonmailUIDValidity Archive: %v", err)
+	}
+	got, known, err = db.GetProtonmailUIDValidity(ctx, tx, credID, "INBOX")
+	if err != nil || !known || got != 12345 {
+		t.Fatalf("INBOX validity should be unchanged, got %d (known=%v) err=%v", got, known, err)
+	}
+}

--- a/db/credentials_test.go
+++ b/db/credentials_test.go
@@ -12,7 +12,7 @@ func TestCredentialsSchema(t *testing.T) {
 	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	testhelper.RequireColumns(t, tx, "credentials", []string{
-		"id", "user_id", "service", "label", "vault_secret_id", "created_at",
+		"id", "user_id", "service", "label", "vault_secret_id", "connector_state", "created_at",
 	})
 }
 

--- a/db/migrations/20260609112615_add_credentials_connector_state.sql
+++ b/db/migrations/20260609112615_add_credentials_connector_state.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+
+-- Non-secret connector sync metadata (e.g. Proton Mail UIDVALIDITY per folder).
+-- Secrets remain in the vault; this column is updated during connector execution.
+ALTER TABLE credentials ADD COLUMN connector_state jsonb NOT NULL DEFAULT '{}';
+
+-- +goose Down
+ALTER TABLE credentials DROP COLUMN IF EXISTS connector_state;

--- a/db/migrations_sqlite/00001_init.sql
+++ b/db/migrations_sqlite/00001_init.sql
@@ -236,6 +236,7 @@ CREATE TABLE credentials (
     service TEXT NOT NULL,
     label TEXT,
     vault_secret_id TEXT NOT NULL,
+    connector_state TEXT NOT NULL DEFAULT '{}',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     CONSTRAINT credentials_id_check CHECK (length(id) <= 255),
     CONSTRAINT credentials_label_check CHECK (length(label) <= 255),

--- a/docs/connectors/protonmail.md
+++ b/docs/connectors/protonmail.md
@@ -19,8 +19,18 @@ If you're currently self-hosting on ARM hardware, we recommend running Permissio
 | `protonmail.send_email` | high | Send mail via SMTP through Bridge |
 | `protonmail.read_inbox` | low | List recent messages in a folder |
 | `protonmail.search_emails` | low | Search by subject, sender, or date |
-| `protonmail.read_email` | low | Read one message by sequence number |
-| `protonmail.archive_email` | medium | Move messages to Archive (IMAP MOVE) |
+| `protonmail.read_email` | low | Read one message by stable IMAP UID |
+| `protonmail.archive_email` | medium | Move messages to Archive (IMAP UID MOVE) |
+
+### Message identifiers (breaking change)
+
+`read_inbox` and `search_emails` return each message's **stable IMAP UID** (with its `folder`) instead of volatile sequence numbers. `read_email` and `archive_email` accept that same UID as `message_id` / `message_ids`, scoped by `folder`.
+
+Sequence numbers shift whenever another message is deleted or moved; UIDs do not. Permission Slip records **UIDVALIDITY** server-side per folder so pending approvals still target the same mailbox generation — if the folder is recreated, execution fails safe instead of acting on the wrong message.
+
+RFC `Message-ID` headers are included in list/read responses as read-only `message_id_header` metadata. They are **not** the operational key for IMAP actions.
+
+Agents or automations that still pass raw IMAP sequence numbers must be updated to use `{folder, uid}` from list/search results.
 
 Calendar, Drive, Contacts, VPN, and Pass are **not** available through Bridge (no CalDAV/WebDAV for those products).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1305

Replaces volatile IMAP sequence numbers with stable per-folder UIDs across Proton Mail read/search/archive actions. This prevents pending approvals from targeting the wrong message when the mailbox shifts underneath them.

- `read_inbox` / `search_emails`: return `{folder, uid}` plus read-only `message_id_header`; stop emitting `seq_num`
- `read_email` / `archive_email`: accept `message_id` / `message_ids` as stable UIDs; use UID FETCH / UID MOVE
- UIDVALIDITY is recorded server-side on the credential (`connector_state` JSONB) and verified at execution time; mismatch fails safe
- Manifest schemas and connector docs updated with breaking-change note

## Test plan

- [x] `gofmt` / syntax check on all changed Go files
- [ ] CI: `go test ./connectors/protonmail/...` (UID validity, expunge stability, batch dedup)
- [ ] CI: `go test ./db/... -run TestProtonmailUIDValidity`
- [ ] CI: full backend + frontend test suites

**Note:** Backend tests were not run locally (sandbox Go module resolution limitation); relying on CI for full verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc260d90-3d27-4638-a345-996724ffe4fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc260d90-3d27-4638-a345-996724ffe4fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

