### PR TITLE
Proton Mail: enrich approval prompts with email subject/from/to/date

### DIFF
--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -299,7 +299,8 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 				if conn, ok := deps.Connectors.Get(cid[0]); ok {
 					if resolver, ok := conn.(connectors.ResourceDetailResolver); ok {
 						resolveCtx, resolveCancel := context.WithTimeout(r.Context(), 5*time.Second)
-						details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID))
+						resolveCtx, resolveCreds := resolveResourceDetailsContext(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID)
+						details, resolveErr := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCreds)
 						resolveCancel()
 						if resolveErr != nil {
 							log.Printf("[%s] ResolveResourceDetails: %v", TraceID(r.Context()), resolveErr)
@@ -459,20 +460,22 @@ func approvalDenialCooldown(deps *Deps) time.Duration {
 	return db.DefaultDenialCooldown
 }
 
-// resolveCredentialsForResolver is a best-effort credential resolver for the
-// ResourceDetailResolver call. It mirrors the credential resolution logic from
-// connector execution but returns empty credentials on any failure (since
-// resource detail resolution is non-fatal).
-func resolveCredentialsForResolver(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string) connectors.Credentials {
+// resolveResourceDetailsContext resolves credentials for resource detail lookup
+// and attaches connector-specific runtime state (e.g. Proton Mail UIDVALIDITY).
+// Returns empty credentials on any failure since resolution is non-fatal.
+func resolveResourceDetailsContext(ctx context.Context, deps *Deps, agentID int64, userID, actionType, connectorID, connectorInstanceID string) (context.Context, connectors.Credentials) {
 	reqCreds, err := db.GetRequiredCredentialsByActionType(ctx, deps.DB, actionType)
 	if err != nil || len(reqCreds) == 0 {
-		return connectors.NewCredentials(nil)
+		return ctx, connectors.NewCredentials(nil)
 	}
-	creds, err := resolveCredentialsWithFallback(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
+	resolved, err := resolveCredentialsForExecution(ctx, deps, agentID, userID, actionType, connectorID, connectorInstanceID, reqCreds)
 	if err != nil {
-		return connectors.NewCredentials(nil)
+		return ctx, connectors.NewCredentials(nil)
 	}
-	return creds
+	if connectorID == "protonmail" && resolved.CredentialID != "" {
+		ctx = connectors.ContextWithMailboxUIDValidity(ctx, newProtonmailUIDValidityStore(ctx, deps, resolved.CredentialID))
+	}
+	return ctx, resolved.Credentials
 }
 
 // emitApprovalRequestAuditEvent writes an audit event for a new approval request.

--- a/api/agent_approvals_bulk.go
+++ b/api/agent_approvals_bulk.go
@@ -485,8 +485,8 @@ func resolveResourceDetailsForBulk(ctx context.Context, deps *Deps, agent *db.Ag
 	}
 	resolveCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	details, err := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams,
-		resolveCredentialsForResolver(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID))
+	resolveCtx, resolveCreds := resolveResourceDetailsContext(resolveCtx, deps, agent.AgentID, agent.ApproverID, actionType, cid[0], connectorInstanceID)
+	details, err := resolver.ResolveResourceDetails(resolveCtx, actionType, actionParams, resolveCreds)
 	if err != nil {
 		log.Printf("[%s] BulkRequest ResolveResourceDetails: %v", TraceID(ctx), err)
 		return nil

--- a/connectors/display_template_test.go
+++ b/connectors/display_template_test.go
@@ -40,6 +40,9 @@ var templateParamPattern = regexp.MustCompile(`\{\{(\w+)(?::\w+)?\}\}`)
 //   - document / presentation / workbook → document_title, presentation_title, workbook_title
 //   - calendar / team / channel → calendar_name, team_name, channel_name (channel_name shared with Slack)
 //   - send_email_reply → subject, from, email_thread (via EmailThreadDetailsMap)
+//   - Proton Mail: connectors/protonmail/resolve_resource_details.go
+//   - read_email / single archive → subject, from, to, date
+//   - batch archive → messages (map keyed by UID handle)
 var resourceDetailFields = map[string]bool{
 	// Slack (see connectors/slack/resolve_resource_details.go)
 	"channel_name": true,
@@ -63,6 +66,10 @@ var resourceDetailFields = map[string]bool{
 	"workbook_title": true,
 	"team_name":      true,
 	"email_thread":   true,
+	// Proton Mail (see connectors/protonmail/resolve_resource_details.go)
+	"to":       true,
+	"date":     true,
+	"messages": true,
 }
 
 // TestDisplayTemplateParamsExist validates that every {{param}} reference in a

--- a/connectors/mailbox_state.go
+++ b/connectors/mailbox_state.go
@@ -1,9 +1,29 @@
 package connectors
 
+import "context"
+
 // MailboxUIDValidityStore tracks the last known IMAP UIDVALIDITY per mailbox
 // folder for a credential. Implementations persist across requests so agents
 // can pass stable {folder, uid} handles without carrying UIDVALIDITY.
 type MailboxUIDValidityStore interface {
 	UIDValidity(folder string) (validity uint32, known bool)
 	SetUIDValidity(folder string, validity uint32) error
+}
+
+type mailboxUIDValidityContextKey struct{}
+
+// ContextWithMailboxUIDValidity attaches a UIDVALIDITY store for connectors that
+// need mailbox state during best-effort resource detail resolution.
+func ContextWithMailboxUIDValidity(ctx context.Context, store MailboxUIDValidityStore) context.Context {
+	if store == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, mailboxUIDValidityContextKey{}, store)
+}
+
+// MailboxUIDValidityFromContext returns the store attached by
+// ContextWithMailboxUIDValidity, or nil when absent.
+func MailboxUIDValidityFromContext(ctx context.Context) MailboxUIDValidityStore {
+	store, _ := ctx.Value(mailboxUIDValidityContextKey{}).(MailboxUIDValidityStore)
+	return store
 }

--- a/connectors/protonmail/envelope_metadata.go
+++ b/connectors/protonmail/envelope_metadata.go
@@ -1,0 +1,68 @@
+package protonmail
+
+import (
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// emailEnvelopeMetadata is the approval-safe subset of email metadata exposed
+// via resource_details. Never include body, attachments, or flags.
+type emailEnvelopeMetadata struct {
+	Subject string   `json:"subject"`
+	From    []string `json:"from"`
+	To      []string `json:"to"`
+	Date    string   `json:"date"`
+}
+
+func envelopeToMetadata(env *imap.Envelope) emailEnvelopeMetadata {
+	if env == nil {
+		return emailEnvelopeMetadata{}
+	}
+	return emailEnvelopeMetadata{
+		Subject: env.Subject,
+		Date:    env.Date.Format(time.RFC3339),
+		From:    formatAddresses(env.From),
+		To:      formatAddresses(env.To),
+	}
+}
+
+func (m emailEnvelopeMetadata) asMap() map[string]any {
+	return map[string]any{
+		"subject": m.Subject,
+		"from":    m.From,
+		"to":      m.To,
+		"date":    m.Date,
+	}
+}
+
+// fetchEnvelopeMetadataByUID performs a metadata-only UID FETCH (envelope only;
+// no body, attachments, or flags) so messages are not marked read.
+func fetchEnvelopeMetadataByUID(session *imapSession, uidSet imap.UIDSet) (map[uint32]emailEnvelopeMetadata, error) {
+	if len(uidSet) == 0 {
+		return nil, nil
+	}
+
+	fetchCmd := session.client.Fetch(uidSet, &imap.FetchOptions{
+		Envelope: true,
+		UID:      true,
+	})
+	defer fetchCmd.Close()
+
+	out := make(map[uint32]emailEnvelopeMetadata)
+	for {
+		msg := fetchCmd.Next()
+		if msg == nil {
+			break
+		}
+		buf, err := msg.Collect()
+		if err != nil {
+			return nil, mapIMAPError(err)
+		}
+		if buf.UID == 0 || buf.Envelope == nil {
+			continue
+		}
+		out[uint32(buf.UID)] = envelopeToMetadata(buf.Envelope)
+	}
+	return out, nil
+}

--- a/connectors/protonmail/resolve_resource_details.go
+++ b/connectors/protonmail/resolve_resource_details.go
@@ -1,0 +1,124 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// resolveMessageEnvelopes is the IMAP-backed implementation used by
+// ResolveResourceDetails. Tests may replace it to avoid a live proxy.
+var resolveMessageEnvelopes = resolveMessageEnvelopesIMAP
+
+// ResolveResourceDetails fetches human-readable email metadata for approval
+// prompts. Only subject, from, to, and date are returned. Errors are non-fatal
+// for the approval flow — callers store the approval without details on failure.
+func (c *ProtonMailConnector) ResolveResourceDetails(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	case "protonmail.read_email":
+		return c.resolveReadEmailDetails(ctx, params, creds)
+	case "protonmail.archive_email":
+		return c.resolveArchiveEmailDetails(ctx, params, creds)
+	default:
+		return nil, nil
+	}
+}
+
+func (c *ProtonMailConnector) resolveReadEmailDetails(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	var p readEmailParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, nil
+	}
+	if err := p.validate(); err != nil {
+		return nil, nil
+	}
+
+	metaByUID, err := resolveMessageEnvelopes(ctx, c, creds, p.Folder, []uint32{p.MessageID}, connectors.MailboxUIDValidityFromContext(ctx))
+	if err != nil || len(metaByUID) == 0 {
+		return nil, nil
+	}
+	meta, ok := metaByUID[p.MessageID]
+	if !ok {
+		return nil, nil
+	}
+	return meta.asMap(), nil
+}
+
+func (c *ProtonMailConnector) resolveArchiveEmailDetails(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	archiveParams, err := parseArchiveParams(params)
+	if err != nil {
+		return nil, nil
+	}
+	if err := archiveParams.validate(); err != nil {
+		return nil, nil
+	}
+
+	metaByUID, err := resolveMessageEnvelopes(ctx, c, creds, archiveParams.Folder, archiveParams.MessageIDs, connectors.MailboxUIDValidityFromContext(ctx))
+	if err != nil || len(metaByUID) == 0 {
+		return nil, nil
+	}
+
+	if len(archiveParams.MessageIDs) == 1 {
+		if meta, ok := metaByUID[archiveParams.MessageIDs[0]]; ok {
+			return meta.asMap(), nil
+		}
+		return nil, nil
+	}
+
+	messages := make(map[string]any, len(metaByUID))
+	for _, id := range archiveParams.MessageIDs {
+		if meta, ok := metaByUID[id]; ok {
+			messages[fmt.Sprintf("%d", id)] = meta.asMap()
+		}
+	}
+	if len(messages) == 0 {
+		return nil, nil
+	}
+	return map[string]any{"messages": messages}, nil
+}
+
+func resolveMessageEnvelopesIMAP(ctx context.Context, conn *ProtonMailConnector, creds connectors.Credentials, folder string, uids []uint32, store connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+	if len(uids) == 0 {
+		return nil, nil
+	}
+	if username, ok := creds.Get(credKeyUsername); !ok || username == "" {
+		return nil, nil
+	}
+	if password, ok := creds.Get(credKeyPassword); !ok || password == "" {
+		return nil, nil
+	}
+
+	timeout := conn.timeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+
+	session, err := connectIMAP(creds, timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	mboxData, err := session.selectMailbox(folder)
+	if err != nil {
+		return nil, err
+	}
+	if err := syncUIDValidity(folder, mboxData, store, uidValidityVerify); err != nil {
+		return nil, err
+	}
+
+	var uidSet imap.UIDSet
+	for _, id := range uids {
+		uidSet.AddNum(imap.UID(id))
+	}
+
+	return fetchEnvelopeMetadataByUID(session, uidSet)
+}
+
+var _ connectors.ResourceDetailResolver = (*ProtonMailConnector)(nil)

--- a/connectors/protonmail/resolve_resource_details_test.go
+++ b/connectors/protonmail/resolve_resource_details_test.go
@@ -42,10 +42,10 @@ func TestResolveResourceDetails_ReadEmail_PopulatesMetadata(t *testing.T) {
 	if details["subject"] != "Weekly Update" {
 		t.Errorf("subject = %v", details["subject"])
 	}
-	if !reflect.DeepEqual(details["from"], []any{"alice@example.com"}) {
+	if !reflect.DeepEqual(details["from"], []string{"alice@example.com"}) {
 		t.Errorf("from = %v", details["from"])
 	}
-	if !reflect.DeepEqual(details["to"], []any{"bob@example.com"}) {
+	if !reflect.DeepEqual(details["to"], []string{"bob@example.com"}) {
 		t.Errorf("to = %v", details["to"])
 	}
 	if details["date"] != "2026-01-15T10:00:00Z" {

--- a/connectors/protonmail/resolve_resource_details_test.go
+++ b/connectors/protonmail/resolve_resource_details_test.go
@@ -1,0 +1,225 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestResolveResourceDetails_ReadEmail_PopulatesMetadata(t *testing.T) {
+	t.Parallel()
+
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, folder string, uids []uint32, _ connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		if folder != "INBOX" {
+			t.Fatalf("folder = %q, want INBOX", folder)
+		}
+		if len(uids) != 1 || uids[0] != 10 {
+			t.Fatalf("uids = %v, want [10]", uids)
+		}
+		return map[uint32]emailEnvelopeMetadata{
+			10: {
+				Subject: "Weekly Update",
+				From:    []string{"alice@example.com"},
+				To:      []string{"bob@example.com"},
+				Date:    "2026-01-15T10:00:00Z",
+			},
+		}, nil
+	}
+
+	conn := New()
+	params, _ := json.Marshal(map[string]any{"message_id": 10, "folder": "INBOX"})
+	details, err := conn.ResolveResourceDetails(context.Background(), "protonmail.read_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertEnvelopeMetadataOnly(t, details)
+	if details["subject"] != "Weekly Update" {
+		t.Errorf("subject = %v", details["subject"])
+	}
+	if !reflect.DeepEqual(details["from"], []any{"alice@example.com"}) {
+		t.Errorf("from = %v", details["from"])
+	}
+	if !reflect.DeepEqual(details["to"], []any{"bob@example.com"}) {
+		t.Errorf("to = %v", details["to"])
+	}
+	if details["date"] != "2026-01-15T10:00:00Z" {
+		t.Errorf("date = %v", details["date"])
+	}
+}
+
+func TestResolveResourceDetails_ReadEmail_FailureFallsBack(t *testing.T) {
+	t.Parallel()
+
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	resolveMessageEnvelopes = func(context.Context, *ProtonMailConnector, connectors.Credentials, string, []uint32, connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		return nil, connectors.ExternalError{Message: "proxy down"}
+	}
+
+	conn := New()
+	params, _ := json.Marshal(map[string]any{"message_id": 10})
+	details, err := conn.ResolveResourceDetails(context.Background(), "protonmail.read_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("expected nil error for best-effort fallback, got %v", err)
+	}
+	if details != nil {
+		t.Fatalf("expected nil details on failure, got %v", details)
+	}
+}
+
+func TestResolveResourceDetails_ArchiveEmail_SingleUsesFlatFields(t *testing.T) {
+	t.Parallel()
+
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ string, uids []uint32, _ connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		return map[uint32]emailEnvelopeMetadata{
+			uids[0]: {Subject: "Archive me", From: []string{"sender@example.com"}, To: []string{"me@example.com"}, Date: "2026-02-01T12:00:00Z"},
+		}, nil
+	}
+
+	conn := New()
+	params, _ := json.Marshal(map[string]any{"message_id": 42})
+	details, err := conn.ResolveResourceDetails(context.Background(), "protonmail.archive_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := details["messages"]; ok {
+		t.Fatalf("single archive should not use messages map, got %v", details)
+	}
+	assertEnvelopeMetadataOnly(t, details)
+	if details["subject"] != "Archive me" {
+		t.Errorf("subject = %v", details["subject"])
+	}
+}
+
+func TestResolveResourceDetails_ArchiveEmail_BatchKeyedByHandle(t *testing.T) {
+	t.Parallel()
+
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ string, uids []uint32, _ connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		out := make(map[uint32]emailEnvelopeMetadata, len(uids))
+		for _, uid := range uids {
+			out[uid] = emailEnvelopeMetadata{
+				Subject: "Subject",
+				From:    []string{"from@example.com"},
+				To:      []string{"to@example.com"},
+				Date:    "2026-03-01T09:00:00Z",
+			}
+		}
+		return out, nil
+	}
+
+	conn := New()
+	params, _ := json.Marshal(map[string]any{"message_ids": []int{10, 11}})
+	details, err := conn.ResolveResourceDetails(context.Background(), "protonmail.archive_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rawMessages, ok := details["messages"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected messages map, got %T", details["messages"])
+	}
+	if len(rawMessages) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(rawMessages))
+	}
+	for _, key := range []string{"10", "11"} {
+		meta, ok := rawMessages[key].(map[string]any)
+		if !ok {
+			t.Fatalf("messages[%q] type = %T", key, rawMessages[key])
+		}
+		assertEnvelopeMetadataOnly(t, meta)
+	}
+}
+
+func TestResolveResourceDetails_PassesMailboxStoreFromContext(t *testing.T) {
+	t.Parallel()
+
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	store := &stubUIDValidityStore{validities: map[string]uint32{"INBOX": 1}}
+	var gotStore connectors.MailboxUIDValidityStore
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ string, _ []uint32, mailboxStore connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		gotStore = mailboxStore
+		return nil, nil
+	}
+
+	conn := New()
+	params, _ := json.Marshal(map[string]any{"message_id": 10})
+	ctx := connectors.ContextWithMailboxUIDValidity(context.Background(), store)
+	_, err := conn.ResolveResourceDetails(ctx, "protonmail.read_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStore != store {
+		t.Fatal("expected mailbox UID validity store from context")
+	}
+}
+
+func TestEnvelopeToMetadata_OnlyAllowedFields(t *testing.T) {
+	t.Parallel()
+
+	meta := envelopeToMetadata(nil)
+	if meta.Subject != "" || meta.Date != "" || len(meta.From) != 0 || len(meta.To) != 0 {
+		t.Fatalf("empty envelope should yield zero metadata: %+v", meta)
+	}
+	m := meta.asMap()
+	if len(m) != 4 {
+		t.Fatalf("expected exactly 4 keys, got %d: %v", len(m), m)
+	}
+	for _, key := range []string{"subject", "from", "to", "date"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing key %q", key)
+		}
+	}
+	for _, forbidden := range []string{"body", "attachments", "flags", "uid"} {
+		if _, ok := m[forbidden]; ok {
+			t.Errorf("forbidden key %q present", forbidden)
+		}
+	}
+}
+
+func assertEnvelopeMetadataOnly(t *testing.T, details map[string]any) {
+	t.Helper()
+	if len(details) != 4 {
+		t.Fatalf("expected exactly 4 metadata fields, got %d: %v", len(details), details)
+	}
+	for _, key := range []string{"subject", "from", "to", "date"} {
+		if _, ok := details[key]; !ok {
+			t.Errorf("missing key %q", key)
+		}
+	}
+	for _, forbidden := range []string{"body", "attachments", "flags", "uid"} {
+		if _, ok := details[forbidden]; ok {
+			t.Errorf("forbidden key %q leaked into resource_details", forbidden)
+		}
+	}
+}
+
+type stubUIDValidityStore struct {
+	validities map[string]uint32
+}
+
+func (s *stubUIDValidityStore) UIDValidity(folder string) (uint32, bool) {
+	v, ok := s.validities[folder]
+	return v, ok
+}
+
+func (s *stubUIDValidityStore) SetUIDValidity(folder string, validity uint32) error {
+	if s.validities == nil {
+		s.validities = make(map[string]uint32)
+	}
+	s.validities[folder] = validity
+	return nil
+}

--- a/connectors/protonmail/resolve_resource_details_test.go
+++ b/connectors/protonmail/resolve_resource_details_test.go
@@ -60,7 +60,7 @@ func TestResolveResourceDetails_ReadEmail_FailureFallsBack(t *testing.T) {
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 
 	resolveMessageEnvelopes = func(context.Context, *ProtonMailConnector, connectors.Credentials, string, []uint32, connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
-		return nil, connectors.ExternalError{Message: "proxy down"}
+		return nil, &connectors.ExternalError{Message: "proxy down"}
 	}
 
 	conn := New()

--- a/frontend/src/components/ActionPreviewSummary.stories.tsx
+++ b/frontend/src/components/ActionPreviewSummary.stories.tsx
@@ -94,6 +94,48 @@ export const GoogleReadEmail: Story = {
   },
 };
 
+export const ProtonmailReadEmail: Story = {
+  name: "protonmail.read_email",
+  args: {
+    actionType: "protonmail.read_email",
+    parameters: { message_id: 10, folder: "INBOX" },
+    schema: null,
+    actionName: "Read Email",
+    resourceDetails: {
+      subject: "Vendor contract review",
+      from: ["legal@vendor.com"],
+      to: ["me@proton.me"],
+      date: "2026-03-01T14:30:00Z",
+    },
+  },
+};
+
+export const ProtonmailArchiveEmailBatch: Story = {
+  name: "protonmail.archive_email (batch)",
+  args: {
+    actionType: "protonmail.archive_email",
+    parameters: { message_ids: [10, 11], folder: "INBOX" },
+    schema: null,
+    actionName: "Archive Email",
+    resourceDetails: {
+      messages: {
+        "10": {
+          subject: "March newsletter",
+          from: ["news@example.com"],
+          to: ["me@proton.me"],
+          date: "2026-03-01T09:00:00Z",
+        },
+        "11": {
+          subject: "Receipt for order #4821",
+          from: ["billing@shop.com"],
+          to: ["me@proton.me"],
+          date: "2026-03-02T11:15:00Z",
+        },
+      },
+    },
+  },
+};
+
 // --- Slack ---
 
 export const SlackSendMessage: Story = {

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -375,6 +375,24 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
     if (from) parts.push(text(" from "), val(from));
     return parts;
   },
+
+  // ── Proton Mail ─────────────────────────────────────────────────
+
+  "protonmail.read_email": (_params, rd) => {
+    if (!rd) return null;
+    const summary = protonmailEmailSummaryParts(rd);
+    if (!summary) return null;
+    return [text("Read email "), ...summary];
+  },
+
+  "protonmail.archive_email": (_params, rd) => {
+    if (!rd) return null;
+    const batch = protonmailBatchArchiveSummaryParts(rd);
+    if (batch) return batch;
+    const summary = protonmailEmailSummaryParts(rd);
+    if (!summary) return null;
+    return [text("Archive email "), ...summary];
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -535,6 +553,50 @@ function formatRecipients(v: unknown): string | null {
     return `${strs[0] ?? ""}, ${strs[1] ?? ""}, and ${strs.length - 2} more`;
   }
   return null;
+}
+
+function protonmailEmailSummaryParts(
+  meta: Record<string, unknown>,
+): SummaryPart[] | null {
+  const subject = strVal(meta.subject);
+  if (!subject) return null;
+  const parts: SummaryPart[] = [val(subject)];
+  const from = formatRecipients(meta.from);
+  if (from) parts.push(text(" from "), val(from));
+  return parts;
+}
+
+function protonmailBatchArchiveSummaryParts(
+  rd: Record<string, unknown>,
+): SummaryPart[] | null {
+  const rawMessages = rd.messages;
+  if (rawMessages == null || typeof rawMessages !== "object" || Array.isArray(rawMessages)) {
+    return null;
+  }
+  const entries = Object.entries(rawMessages as Record<string, unknown>);
+  if (entries.length <= 1) {
+    return null;
+  }
+  const subjects = entries
+    .map(([, meta]) =>
+      meta != null && typeof meta === "object"
+        ? strVal((meta as Record<string, unknown>).subject)
+        : null,
+    )
+    .filter((s): s is string => s != null);
+  if (subjects.length === 0) return null;
+
+  const parts: SummaryPart[] = [
+    text("Archive "),
+    val(String(entries.length)),
+    text(" emails"),
+  ];
+  const preview =
+    subjects.length <= 2
+      ? subjects.join("; ")
+      : `${subjects.slice(0, 2).join("; ")} and ${subjects.length - 2} more`;
+  parts.push(text(": "), val(truncate(preview, 80)));
+  return parts;
 }
 
 function formatCurrency(amount: unknown, currency: string): string {

--- a/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
+++ b/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
@@ -428,6 +428,83 @@ describe("buildSummary", () => {
     });
   });
 
+  // ── Proton Mail ─────────────────────────────────────────────────
+
+  describe("protonmail.read_email", () => {
+    it("shows subject and sender from resourceDetails", () => {
+      const result = buildSummary(
+        "protonmail.read_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        null,
+        undefined,
+        { subject: "Weekly Update", from: ["alice@example.com"] },
+      );
+      expect(result).toContain("Read email");
+      expect(result).toContain("Weekly Update");
+      expect(result).toContain("alice@example.com");
+    });
+
+    it("falls back when enrichment is absent", () => {
+      const result = buildSummary(
+        "protonmail.read_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        "Read Email",
+      );
+      expect(result).toContain("Read Email");
+      expect(result).toContain("10");
+    });
+  });
+
+  describe("protonmail.archive_email", () => {
+    it("shows enriched single archive", () => {
+      const result = buildSummary(
+        "protonmail.archive_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        null,
+        undefined,
+        { subject: "Archive me", from: ["sender@example.com"] },
+      );
+      expect(result).toContain("Archive email");
+      expect(result).toContain("Archive me");
+      expect(result).toContain("sender@example.com");
+    });
+
+    it("shows batch archive subjects", () => {
+      const result = buildSummary(
+        "protonmail.archive_email",
+        { message_ids: [10, 11], folder: "INBOX" },
+        null,
+        null,
+        undefined,
+        {
+          messages: {
+            "10": { subject: "First", from: ["a@example.com"], to: [], date: "2026-01-01T00:00:00Z" },
+            "11": { subject: "Second", from: ["b@example.com"], to: [], date: "2026-01-02T00:00:00Z" },
+          },
+        },
+      );
+      expect(result).toContain("Archive");
+      expect(result).toContain("2");
+      expect(result).toContain("emails");
+      expect(result).toContain("First");
+      expect(result).toContain("Second");
+    });
+
+    it("falls back when enrichment is absent", () => {
+      const result = buildSummary(
+        "protonmail.archive_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        "Archive Email",
+      );
+      expect(result).toContain("Archive Email");
+      expect(result).toContain("10");
+    });
+  });
+
   // ── Existing describers still work ──────────────────────────────
 
   describe("generic / unknown action types", () => {

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -133,6 +133,44 @@ describe("buildActionSummary", () => {
     expect(result).toContain("U12345678");
   });
 
+  it("formats protonmail.read_email with enriched metadata", () => {
+    const result = buildActionSummary(
+      "protonmail.read_email",
+      { message_id: 10, folder: "INBOX" },
+      undefined,
+      { subject: "Weekly Update", from: ["alice@example.com"] },
+    );
+    expect(result).toContain("Read email");
+    expect(result).toContain("Weekly Update");
+    expect(result).toContain("alice@example.com");
+  });
+
+  it("falls back for protonmail.read_email without enrichment", () => {
+    const result = buildActionSummary("protonmail.read_email", {
+      message_id: 10,
+      folder: "INBOX",
+    });
+    expect(result).toContain("Read email");
+    expect(result).toContain("10");
+  });
+
+  it("formats protonmail.archive_email batch enrichment", () => {
+    const result = buildActionSummary(
+      "protonmail.archive_email",
+      { message_ids: [10, 11], folder: "INBOX" },
+      undefined,
+      {
+        messages: {
+          "10": { subject: "First", from: [], to: [], date: "2026-01-01T00:00:00Z" },
+          "11": { subject: "Second", from: [], to: [], date: "2026-01-02T00:00:00Z" },
+        },
+      },
+    );
+    expect(result).toContain("Archive 2 emails");
+    expect(result).toContain("First");
+    expect(result).toContain("Second");
+  });
+
   it("falls back to generic summary for unknown types", () => {
     const result = buildActionSummary("custom.do_thing", {
       target: "prod",

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -200,6 +200,42 @@ function truncate(s: string, maxLen: number): string {
   return s.slice(0, maxLen - 1) + "\u2026";
 }
 
+function protonmailEmailSummary(
+  prefix: string,
+  meta: Record<string, unknown>,
+): string | null {
+  const subject = strVal(meta.subject);
+  if (!subject) return null;
+  let result = `${prefix} \u201C${subject}\u201D`;
+  const from = formatRecipients(meta.from);
+  if (from) result += ` from ${from}`;
+  return result;
+}
+
+function protonmailBatchArchiveSummary(rd: Record<string, unknown>): string | null {
+  const rawMessages = rd.messages;
+  if (rawMessages == null || typeof rawMessages !== "object" || Array.isArray(rawMessages)) {
+    return null;
+  }
+  const entries = Object.entries(rawMessages as Record<string, unknown>);
+  if (entries.length <= 1) return null;
+
+  const subjects = entries
+    .map(([, meta]) =>
+      meta != null && typeof meta === "object"
+        ? strVal((meta as Record<string, unknown>).subject)
+        : null,
+    )
+    .filter((s): s is string => s != null);
+  if (subjects.length === 0) return null;
+
+  const preview =
+    subjects.length <= 2
+      ? subjects.join("; ")
+      : `${subjects.slice(0, 2).join("; ")} and ${subjects.length - 2} more`;
+  return `Archive ${String(entries.length)} emails: \u201C${truncate(preview, 80)}\u201D`;
+}
+
 /** Formats a recipient list (string or string[]) for display in email summaries. */
 function formatRecipients(v: unknown): string | null {
   if (typeof v === "string") return v;
@@ -264,6 +300,18 @@ const ACTION_FORMATTERS: Record<string, ActionFormatter> = {
     let result = `Send email to ${to}`;
     if (subject) result += ` \u2014 ${truncate(subject, 60)}`;
     return result;
+  },
+
+  "protonmail.read_email": (_params, rd) => {
+    if (!rd) return null;
+    return protonmailEmailSummary("Read email", rd);
+  },
+
+  "protonmail.archive_email": (_params, rd) => {
+    if (!rd) return null;
+    const batch = protonmailBatchArchiveSummary(rd);
+    if (batch) return batch;
+    return protonmailEmailSummary("Archive email", rd);
   },
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `ResolveResourceDetails` to the Proton Mail connector: metadata-only UID FETCH (envelope peek, no body/attachments/flags) resolves stable UID handles to `subject`, `from`, `to`, and `date` at approval creation time.
- Pass IMAP UIDVALIDITY store through resolver context so enrichment refuses stale handles and falls back silently when the proxy is down or UIDs are gone.
- Render enriched summaries on web (`ActionPreviewSummary`) and mobile (`approvalUtils`) for `protonmail.read_email` and `protonmail.archive_email`, including batch archive keyed by handle.

Closes #1304

## Test plan

### Claude Code
- [x] `gofmt` on changed Go files
- [x] `npx vitest run src/components/__tests__/ActionPreviewSummary.test.tsx` (43 passed)
- [x] `npm test -- --ci src/screens/approvals/__tests__/approvalUtils.test.ts` (53 passed)
- [x] `npm run build` in frontend (TypeScript clean)
- [ ] Backend `go test ./connectors/protonmail/...` — not run locally (sandbox Go toolchain constraint); CI will verify

### OpenClaw
- [ ] Approve a `protonmail.read_email` request against a live Bridge/hydroxide proxy and confirm subject/from appear instead of bare UID
- [ ] Approve a batch `protonmail.archive_email` (2+ messages) and confirm each subject is shown
- [ ] Confirm fallback to raw UID when proxy is stopped

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6824edf4-eed3-44e9-94b7-10b2cb4b3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6824edf4-eed3-44e9-94b7-10b2cb4b3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

