### PR TITLE
Mark Proton Mail connector as early preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Connectors are tested incrementally during the beta; maturity varies by integrat
 | Google | 🟡 Early Preview |
 | Microsoft | 🟡 Early Preview |
 | Slack | 🟡 Early Preview |
+| Proton Mail | 🟡 Early Preview |
 
 <details>
 <summary>Untested connectors (click to expand)</summary>

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -15,6 +15,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 		ID:          "protonmail",
 		Name:        "Proton Mail",
 		Description: "Send and read emails through Proton Mail via a local IMAP/SMTP proxy (Proton Mail Bridge on x86_64, or hydroxide on ARM/Raspberry Pi). The proxy must be running on the same host as Permission Slip.",
+		Status:      "early_preview",
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{


### PR DESCRIPTION
Promote the Proton Mail connector from its default 'untested' status to
'early_preview', matching the Google connector. Sets the Status field in
the manifest and adds Proton Mail to the Early Preview table in the README.