### PR TITLE
Add Proton Mail Bridge connection health check

### DIFF
--- a/api/credential_test_connection.go
+++ b/api/credential_test_connection.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/connectors/protonmail"
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+const protonmailService = "protonmail"
+
+// testProtonBridgeConnection is the Bridge handshake used by the API. Tests may replace it.
+var testProtonBridgeConnection = func(ctx context.Context, creds connectors.Credentials, timeout time.Duration) error {
+	return protonmail.TestBridgeConnectionContext(ctx, creds, timeout)
+}
+
+type testCredentialConnectionRequest struct {
+	Service      string         `json:"service" validate:"required"`
+	Credentials  map[string]any `json:"credentials"`
+	CredentialID *string        `json:"credential_id,omitempty"`
+}
+
+type testCredentialConnectionResponse struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+func init() {
+	RegisterRouteGroup(RegisterCredentialTestConnectionRoutes)
+}
+
+// RegisterCredentialTestConnectionRoutes adds the Bridge connectivity test endpoint.
+func RegisterCredentialTestConnectionRoutes(mux *http.ServeMux, deps *Deps) {
+	requireProfile := RequireProfile(deps)
+	mux.Handle("POST /credentials/test-connection", requireProfile(handleTestCredentialConnection(deps)))
+}
+
+func handleTestCredentialConnection(deps *Deps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		profile := Profile(r.Context())
+
+		var req testCredentialConnectionRequest
+		if !DecodeJSONOrReject(w, r, &req) {
+			return
+		}
+		if !ValidateRequest(w, r, &req) {
+			return
+		}
+
+		if req.Service != protonmailService {
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, "test-connection is only supported for protonmail credentials"))
+			return
+		}
+
+		credStrings, credID, err := resolveTestConnectionCredentials(r.Context(), deps, profile.ID, req)
+		if err != nil {
+			var credErr *db.CredentialError
+			if errors.As(err, &credErr) && credErr.Code == db.CredentialErrNotFound {
+				RespondError(w, r, http.StatusNotFound, NotFound(ErrCredentialNotFound, "Credential not found"))
+				return
+			}
+			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, err.Error()))
+			return
+		}
+
+		connErrCtx := ConnectorContext{
+			ConnectorID: protonmailService,
+			ActionType:  "protonmail.read_inbox",
+		}
+
+		creds := connectors.NewCredentials(credStrings)
+		if err := testProtonBridgeConnection(r.Context(), creds, 30*time.Second); err != nil {
+			if credID != "" {
+				_ = db.SetProtonmailHealth(r.Context(), deps.DB, credID, db.ProtonmailHealthState{
+					Status:    db.ProtonmailHealthError,
+					CheckedAt: time.Now().UTC(),
+					Message:   connectorErrorMessage(err),
+				})
+			}
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] TestCredentialConnection: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Bridge connection test failed"))
+			return
+		}
+
+		if credID != "" {
+			if err := db.SetProtonmailHealth(r.Context(), deps.DB, credID, db.ProtonmailHealthState{
+				Status:    db.ProtonmailHealthOK,
+				CheckedAt: time.Now().UTC(),
+			}); err != nil {
+				log.Printf("[%s] TestCredentialConnection: persist health: %v", TraceID(r.Context()), err)
+				CaptureError(r.Context(), err)
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, testCredentialConnectionResponse{
+			OK:      true,
+			Message: "Bridge connection successful (IMAP and SMTP)",
+		})
+	}
+}
+
+func resolveTestConnectionCredentials(
+	ctx context.Context,
+	deps *Deps,
+	userID string,
+	req testCredentialConnectionRequest,
+) (map[string]string, string, error) {
+	var base map[string]string
+	var credID string
+
+	if req.CredentialID != nil && *req.CredentialID != "" {
+		credID = *req.CredentialID
+		if deps.Vault == nil {
+			return nil, "", errors.New("credential vault not available")
+		}
+		owned, err := db.GetOwnedCredential(ctx, deps.DB, credID, userID)
+		if err != nil {
+			return nil, "", err
+		}
+		if owned.Service != protonmailService {
+			return nil, "", errors.New("credential service does not match protonmail")
+		}
+		raw, err := deps.Vault.ReadSecret(ctx, deps.DB, owned.VaultSecretID)
+		if err != nil {
+			return nil, "", err
+		}
+		if err := json.Unmarshal(raw, &base); err != nil {
+			return nil, "", err
+		}
+	}
+
+	merged := make(map[string]any)
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range req.Credentials {
+		if s, ok := v.(string); ok && s != "" {
+			merged[k] = s
+		}
+	}
+
+	if len(merged) == 0 {
+		return nil, "", errors.New("credentials are required when credential_id is not provided")
+	}
+
+	candidates, err := db.GetRequiredCredentialsByService(ctx, deps.DB, protonmailService)
+	if err != nil {
+		return nil, "", err
+	}
+	credStrings, pickErr := resolveAndValidateCredentialPayload(protonmailService, candidates, merged)
+	if pickErr != nil {
+		return nil, "", pickErr
+	}
+	return credStrings, credID, nil
+}
+
+func connectorErrorMessage(err error) string {
+	switch {
+	case connectors.IsAuthError(err):
+		var ae *connectors.AuthError
+		if errors.As(err, &ae) && ae.Message != "" {
+			return ae.Message
+		}
+	case connectors.IsTimeoutError(err):
+		var te *connectors.TimeoutError
+		if errors.As(err, &te) && te.Message != "" {
+			return te.Message
+		}
+	case connectors.IsExternalError(err):
+		var ee *connectors.ExternalError
+		if errors.As(err, &ee) && ee.Message != "" {
+			return ee.Message
+		}
+	case connectors.IsValidationError(err):
+		var ve *connectors.ValidationError
+		if errors.As(err, &ve) && ve.Message != "" {
+			return ve.Message
+		}
+	}
+	return err.Error()
+}
+
+func maybeValidateLiveCredentials(ctx context.Context, deps *Deps, service string, credStrings map[string]string) error {
+	if deps.Connectors == nil || service != protonmailService {
+		return nil
+	}
+	conn, ok := deps.Connectors.Get(protonmailService)
+	if !ok {
+		return nil
+	}
+	return conn.ValidateCredentials(ctx, connectors.NewCredentials(credStrings))
+}

--- a/api/credential_test_connection_test.go
+++ b/api/credential_test_connection_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 

--- a/api/credential_test_connection_test.go
+++ b/api/credential_test_connection_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+	"github.com/supersuit-tech/permission-slip/vault"
+)
+
+func decodeTestConnection(t *testing.T, body []byte) testCredentialConnectionResponse {
+	t.Helper()
+	var resp testCredentialConnectionResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("failed to unmarshal test connection response: %v", err)
+	}
+	return resp
+}
+
+func TestTestCredentialConnection_Success(t *testing.T) {
+	t.Parallel()
+
+	old := testProtonBridgeConnection
+	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
+		return nil
+	}
+	t.Cleanup(func() { testProtonBridgeConnection = old })
+
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service":"protonmail","credentials":{"username":"user@proton.me","password":"bridge-pass"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials/test-connection", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	resp := decodeTestConnection(t, w.Body.Bytes())
+	if !resp.OK {
+		t.Errorf("expected ok=true, got %+v", resp)
+	}
+}
+
+func TestTestCredentialConnection_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	old := testProtonBridgeConnection
+	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
+		return &connectors.AuthError{Message: "Wrong Bridge password"}
+	}
+	t.Cleanup(func() { testProtonBridgeConnection = old })
+
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service":"protonmail","credentials":{"username":"user@proton.me","password":"bad"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials/test-connection", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTestCredentialConnection_UnsupportedService(t *testing.T) {
+	t.Parallel()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	deps := &Deps{DB: tx, Vault: vault.NewMockVaultStore(), JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service":"github","credentials":{"api_key":"x"}}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials/test-connection", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTestCredentialConnection_StoredCredentialPersistsHealth(t *testing.T) {
+	t.Parallel()
+
+	old := testProtonBridgeConnection
+	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
+		return nil
+	}
+	t.Cleanup(func() { testProtonBridgeConnection = old })
+
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	credID := testhelper.GenerateID(t, "cred_")
+
+	mockVault := vault.NewMockVaultStore()
+	secretID, err := mockVault.CreateSecret(t.Context(), tx, credID, []byte(`{"username":"user@proton.me","password":"bridge-pass"}`))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	testhelper.InsertCredentialWithVaultSecretID(t, tx, credID, uid, "protonmail", secretID)
+
+	deps := &Deps{DB: tx, Vault: mockVault, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	body := `{"service":"protonmail","credential_id":"` + credID + `"}`
+	r := authenticatedJSONRequest(t, http.MethodPost, "/credentials/test-connection", uid, body)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	health, err := db.GetProtonmailHealth(t.Context(), tx, credID)
+	if err != nil {
+		t.Fatalf("GetProtonmailHealth: %v", err)
+	}
+	if health == nil || health.Status != db.ProtonmailHealthOK {
+		t.Fatalf("expected health ok, got %+v", health)
+	}
+}

--- a/api/credential_test_connection_test.go
+++ b/api/credential_test_connection_test.go
@@ -24,8 +24,6 @@ func decodeTestConnection(t *testing.T, body []byte) testCredentialConnectionRes
 }
 
 func TestTestCredentialConnection_Success(t *testing.T) {
-	t.Parallel()
-
 	old := testProtonBridgeConnection
 	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
 		return nil
@@ -54,8 +52,6 @@ func TestTestCredentialConnection_Success(t *testing.T) {
 }
 
 func TestTestCredentialConnection_AuthFailure(t *testing.T) {
-	t.Parallel()
-
 	old := testProtonBridgeConnection
 	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
 		return &connectors.AuthError{Message: "Wrong Bridge password"}
@@ -80,7 +76,6 @@ func TestTestCredentialConnection_AuthFailure(t *testing.T) {
 }
 
 func TestTestCredentialConnection_UnsupportedService(t *testing.T) {
-	t.Parallel()
 	tx := testhelper.SetupTestDB(t)
 	uid := testhelper.GenerateUID(t)
 	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
@@ -99,8 +94,6 @@ func TestTestCredentialConnection_UnsupportedService(t *testing.T) {
 }
 
 func TestTestCredentialConnection_StoredCredentialPersistsHealth(t *testing.T) {
-	t.Parallel()
-
 	old := testProtonBridgeConnection
 	testProtonBridgeConnection = func(_ context.Context, _ connectors.Credentials, _ time.Duration) error {
 		return nil

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/api/credentials.go
+++ b/api/credentials.go
@@ -21,11 +21,18 @@ type storeCredentialRequest struct {
 	Label       *string        `json:"label,omitempty"`
 }
 
+type bridgeHealthSummary struct {
+	Status    string    `json:"status"`
+	CheckedAt time.Time `json:"checked_at"`
+	Message   string    `json:"message,omitempty"`
+}
+
 type credentialSummary struct {
-	ID        string    `json:"id"`
-	Service   string    `json:"service"`
-	Label     *string   `json:"label,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	ID           string               `json:"id"`
+	Service      string               `json:"service"`
+	Label        *string              `json:"label,omitempty"`
+	CreatedAt    time.Time            `json:"created_at"`
+	BridgeHealth *bridgeHealthSummary `json:"bridge_health,omitempty"`
 }
 
 type credentialListResponse struct {
@@ -78,7 +85,7 @@ func handleListCredentials(deps *Deps) http.HandlerFunc {
 
 		data := make([]credentialSummary, len(creds))
 		for i, c := range creds {
-			data[i] = toCredentialSummary(c)
+			data[i] = toCredentialSummaryWithHealth(r.Context(), deps.DB, c)
 		}
 
 		RespondJSON(w, http.StatusOK, credentialListResponse{Credentials: data})
@@ -147,6 +154,16 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 			RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pickErr.Error()))
 			return
 		}
+		if err := maybeValidateLiveCredentials(r.Context(), deps, req.Service, credStrings); err != nil {
+			connErrCtx := ConnectorContext{ConnectorID: req.Service, ActionType: req.Service + ".read_inbox"}
+			if handleConnectorError(w, r, err, connErrCtx) {
+				return
+			}
+			log.Printf("[%s] StoreCredential: validate: %v", TraceID(r.Context()), err)
+			CaptureConnectorError(r.Context(), err, connErrCtx)
+			RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+			return
+		}
 		credJSON, err := json.Marshal(credStrings)
 		if err != nil {
 			log.Printf("[%s] StoreCredential: marshal credentials: %v", TraceID(r.Context()), err)
@@ -199,7 +216,14 @@ func handleStoreCredential(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		RespondJSON(w, http.StatusCreated, toCredentialSummary(*cred))
+		if req.Service == protonmailService {
+			_ = db.SetProtonmailHealth(r.Context(), deps.DB, cred.ID, db.ProtonmailHealthState{
+				Status:    db.ProtonmailHealthOK,
+				CheckedAt: time.Now().UTC(),
+			})
+		}
+
+		RespondJSON(w, http.StatusCreated, toCredentialSummaryWithHealth(r.Context(), deps.DB, *cred))
 	}
 }
 
@@ -331,6 +355,16 @@ func handleUpdateCredential(deps *Deps) http.HandlerFunc {
 				RespondError(w, r, http.StatusBadRequest, BadRequest(ErrInvalidRequest, pickErr.Error()))
 				return
 			}
+			if err := maybeValidateLiveCredentials(r.Context(), deps, ownedCred.Service, credStrings); err != nil {
+				connErrCtx := ConnectorContext{ConnectorID: ownedCred.Service, ActionType: ownedCred.Service + ".read_inbox"}
+				if handleConnectorError(w, r, err, connErrCtx) {
+					return
+				}
+				log.Printf("[%s] UpdateCredential: validate: %v", TraceID(r.Context()), err)
+				CaptureConnectorError(r.Context(), err, connErrCtx)
+				RespondError(w, r, http.StatusInternalServerError, InternalError("Credential validation failed"))
+				return
+			}
 			credJSON, err := json.Marshal(credStrings)
 			if err != nil {
 				log.Printf("[%s] UpdateCredential: marshal credentials: %v", TraceID(r.Context()), err)
@@ -385,7 +419,14 @@ func handleUpdateCredential(deps *Deps) http.HandlerFunc {
 			}
 		}
 
-		RespondJSON(w, http.StatusOK, toCredentialSummary(result))
+		if hasCredentialFieldUpdates && ownedCred.Service == protonmailService {
+			_ = db.SetProtonmailHealth(r.Context(), deps.DB, credID, db.ProtonmailHealthState{
+				Status:    db.ProtonmailHealthOK,
+				CheckedAt: time.Now().UTC(),
+			})
+		}
+
+		RespondJSON(w, http.StatusOK, toCredentialSummaryWithHealth(r.Context(), deps.DB, result))
 	}
 }
 
@@ -464,6 +505,23 @@ func toCredentialSummary(c db.Credential) credentialSummary {
 		Label:     c.Label,
 		CreatedAt: c.CreatedAt,
 	}
+}
+
+func toCredentialSummaryWithHealth(ctx context.Context, d db.DBTX, c db.Credential) credentialSummary {
+	summary := toCredentialSummary(c)
+	if c.Service != protonmailService {
+		return summary
+	}
+	health, err := db.GetProtonmailHealth(ctx, d, c.ID)
+	if err != nil || health == nil {
+		return summary
+	}
+	summary.BridgeHealth = &bridgeHealthSummary{
+		Status:    string(health.Status),
+		CheckedAt: health.CheckedAt,
+		Message:   health.Message,
+	}
+	return summary
 }
 
 // resolveAndValidateCredentialPayload picks the matching connector credential row

--- a/connectors/protonmail/health_check.go
+++ b/connectors/protonmail/health_check.go
@@ -1,0 +1,148 @@
+package protonmail
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// testIMAPConn performs IMAP login and a read-only INBOX SELECT without reading
+// message content. Tests may replace it to avoid a running Bridge instance.
+var testIMAPConn = func(creds connectors.Credentials, timeout time.Duration) error {
+	session, err := connectIMAP(creds, timeout)
+	if err != nil {
+		return err
+	}
+	defer session.close()
+	if _, err := session.selectMailbox("INBOX"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// testSMTPConn verifies SMTP reachability with EHLO + AUTH only — no mail is sent.
+// Tests may replace it to avoid a running Bridge instance.
+var testSMTPConn = func(creds connectors.Credentials, timeout time.Duration) error {
+	host, port, username, password := smtpConfig(creds)
+	addr := net.JoinHostPort(host, port)
+
+	dialer := &net.Dialer{Timeout: timeout}
+	conn, err := dialer.Dial("tcp", addr)
+	if err != nil {
+		return mapDialError("SMTP", err)
+	}
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		conn.Close()
+		return &connectors.ExternalError{Message: fmt.Sprintf("SMTP handshake failed: %v", err)}
+	}
+	defer client.Close()
+
+	if ok, _ := client.Extension("STARTTLS"); ok {
+		tlsConfig := &tls.Config{ServerName: host}
+		if err := client.StartTLS(tlsConfig); err != nil {
+			return &connectors.ExternalError{Message: fmt.Sprintf("SMTP STARTTLS failed: %v", err)}
+		}
+	}
+
+	auth := smtp.PlainAuth("", username, password, host)
+	if err := client.Auth(auth); err != nil {
+		return &connectors.AuthError{Message: mapBridgeAuthMessage("SMTP", err)}
+	}
+	return client.Quit()
+}
+
+// TestBridgeConnection verifies IMAP and SMTP connectivity to the local Proton
+// proxy. It performs login/handshake only — no mailbox reads or mail delivery.
+func TestBridgeConnection(creds connectors.Credentials, timeout time.Duration) error {
+	if err := validateCredentialShape(creds); err != nil {
+		return err
+	}
+	if err := testIMAPConn(creds, timeout); err != nil {
+		return mapBridgeError("IMAP", err)
+	}
+	if err := testSMTPConn(creds, timeout); err != nil {
+		return mapBridgeError("SMTP", err)
+	}
+	return nil
+}
+
+// TestBridgeConnectionContext is like TestBridgeConnection but respects ctx deadlines.
+func TestBridgeConnectionContext(ctx context.Context, creds connectors.Credentials, timeout time.Duration) error {
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+	return TestBridgeConnection(creds, timeout)
+}
+
+func mapDialError(proto string, err error) error {
+	if connectors.IsTimeout(err) {
+		return &connectors.TimeoutError{
+			Message: fmt.Sprintf("%s host unreachable — check the %s host and that Bridge is running on this machine", proto, strings.ToLower(proto)),
+		}
+	}
+	if isConnectionRefused(err) {
+		return &connectors.ExternalError{
+			Message: fmt.Sprintf("%s connection refused — Bridge not running or wrong port. Start Bridge (systemctl --user status protonmail-bridge) and confirm ports with protonmail-bridge info", proto),
+		}
+	}
+	return &connectors.ExternalError{Message: fmt.Sprintf("%s connection failed: %v", proto, err)}
+}
+
+func mapBridgeAuthMessage(proto string, err error) string {
+	_ = proto
+	return fmt.Sprintf("Wrong Bridge password (not your Proton account password). Run protonmail-bridge info to get the correct password. (%v)", err)
+}
+
+func mapBridgeError(proto string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if connectors.IsValidationError(err) || connectors.IsAuthError(err) ||
+		connectors.IsExternalError(err) || connectors.IsTimeoutError(err) {
+		// Re-wrap with clearer messages where the low-level text is opaque.
+		switch {
+		case connectors.IsAuthError(err):
+			var ae *connectors.AuthError
+			if errors.As(err, &ae) {
+				return &connectors.AuthError{Message: mapBridgeAuthMessage(proto, errors.New(ae.Message))}
+			}
+		case connectors.IsTimeoutError(err):
+			return &connectors.TimeoutError{
+				Message: fmt.Sprintf("%s host unreachable — check the %s host and that Bridge is running on this machine", proto, strings.ToLower(proto)),
+			}
+		case connectors.IsExternalError(err):
+			var ee *connectors.ExternalError
+			if errors.As(err, &ee) && isConnectionRefused(errors.New(ee.Message)) {
+				return &connectors.ExternalError{
+					Message: fmt.Sprintf("%s connection refused — Bridge not running or wrong port. Start Bridge and confirm ports with protonmail-bridge info", proto),
+				}
+			}
+		}
+		return err
+	}
+	return mapDialError(proto, err)
+}
+
+func isConnectionRefused(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && errors.Is(opErr.Err, syscall.ECONNREFUSED) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "connection refused") || strings.Contains(msg, "connect: connection refused")
+}

--- a/connectors/protonmail/health_check_test.go
+++ b/connectors/protonmail/health_check_test.go
@@ -1,0 +1,138 @@
+package protonmail
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestTestBridgeConnection_success(t *testing.T) {
+	t.Parallel()
+
+	oldIMAP := testIMAPConn
+	oldSMTP := testSMTPConn
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	testSMTPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	t.Cleanup(func() {
+		testIMAPConn = oldIMAP
+		testSMTPConn = oldSMTP
+	})
+
+	if err := TestBridgeConnection(validCreds(), time.Second); err != nil {
+		t.Fatalf("TestBridgeConnection() error = %v, want nil", err)
+	}
+}
+
+func TestTestBridgeConnection_imapFailure(t *testing.T) {
+	t.Parallel()
+
+	oldIMAP := testIMAPConn
+	oldSMTP := testSMTPConn
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
+		return &connectors.ExternalError{Message: "dial tcp 127.0.0.1:1143: connect: connection refused"}
+	}
+	testSMTPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	t.Cleanup(func() {
+		testIMAPConn = oldIMAP
+		testSMTPConn = oldSMTP
+	})
+
+	err := TestBridgeConnection(validCreds(), time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsExternalError(err) {
+		t.Fatalf("expected ExternalError, got %T: %v", err, err)
+	}
+	var ee *connectors.ExternalError
+	if !errors.As(err, &ee) {
+		t.Fatal("expected ExternalError")
+	}
+	if ee.Message == "" || ee.Message == "dial tcp 127.0.0.1:1143: connect: connection refused" {
+		t.Errorf("expected actionable message, got %q", ee.Message)
+	}
+}
+
+func TestTestBridgeConnection_authFailure(t *testing.T) {
+	t.Parallel()
+
+	oldIMAP := testIMAPConn
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
+		return &connectors.AuthError{Message: "IMAP login failed: invalid credentials"}
+	}
+	t.Cleanup(func() { testIMAPConn = oldIMAP })
+
+	err := TestBridgeConnection(validCreds(), time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+	var ae *connectors.AuthError
+	if !errors.As(err, &ae) {
+		t.Fatal("expected AuthError")
+	}
+	if ae.Message == "" {
+		t.Error("expected non-empty auth message")
+	}
+}
+
+func TestTestBridgeConnection_timeout(t *testing.T) {
+	t.Parallel()
+
+	oldIMAP := testIMAPConn
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
+		return &connectors.TimeoutError{Message: "IMAP connection timed out"}
+	}
+	t.Cleanup(func() { testIMAPConn = oldIMAP })
+
+	err := TestBridgeConnection(validCreds(), time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsTimeoutError(err) {
+		t.Fatalf("expected TimeoutError, got %T: %v", err, err)
+	}
+}
+
+func TestIsConnectionRefused(t *testing.T) {
+	t.Parallel()
+	if !isConnectionRefused(syscall.ECONNREFUSED) {
+		t.Error("expected ECONNREFUSED to match")
+	}
+	if !isConnectionRefused(errors.New("dial tcp 127.0.0.1:1143: connect: connection refused")) {
+		t.Error("expected connection refused message to match")
+	}
+	if isConnectionRefused(errors.New("no such host")) {
+		t.Error("expected unrelated error not to match")
+	}
+}
+
+func TestProtonMailConnector_ValidateCredentials_usesBridgeTest(t *testing.T) {
+	t.Parallel()
+
+	oldIMAP := testIMAPConn
+	oldSMTP := testSMTPConn
+	called := false
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
+		called = true
+		return nil
+	}
+	testSMTPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	t.Cleanup(func() {
+		testIMAPConn = oldIMAP
+		testSMTPConn = oldSMTP
+	})
+
+	c := New()
+	if err := c.ValidateCredentials(t.Context(), validCreds()); err != nil {
+		t.Fatalf("ValidateCredentials() error = %v", err)
+	}
+	if !called {
+		t.Error("expected IMAP health check to run")
+	}
+}

--- a/connectors/protonmail/health_check_test.go
+++ b/connectors/protonmail/health_check_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestTestBridgeConnection_success(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	oldSMTP := testSMTPConn
 	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
@@ -27,8 +25,6 @@ func TestTestBridgeConnection_success(t *testing.T) {
 }
 
 func TestTestBridgeConnection_imapFailure(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	oldSMTP := testSMTPConn
 	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
@@ -57,8 +53,6 @@ func TestTestBridgeConnection_imapFailure(t *testing.T) {
 }
 
 func TestTestBridgeConnection_authFailure(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
 		return &connectors.AuthError{Message: "IMAP login failed: invalid credentials"}
@@ -82,8 +76,6 @@ func TestTestBridgeConnection_authFailure(t *testing.T) {
 }
 
 func TestTestBridgeConnection_timeout(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error {
 		return &connectors.TimeoutError{Message: "IMAP connection timed out"}
@@ -113,8 +105,6 @@ func TestIsConnectionRefused(t *testing.T) {
 }
 
 func TestProtonMailConnector_ValidateCredentials_usesBridgeTest(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	oldSMTP := testSMTPConn
 	called := false

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -202,6 +202,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						Placeholder: "Your Proton address as shown by Bridge info",
 						Secret:      ptrBool(false),
 						Required:    ptrBool(true),
+						HelpText:    "Run protonmail-bridge --cli, then type info. Use the username Bridge prints — it must match the running Bridge instance.",
 					},
 					{
 						Key:         "password",
@@ -209,7 +210,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						Placeholder: "From Bridge info (not your Proton account password)",
 						Secret:      ptrBool(true),
 						Required:    ptrBool(true),
-						HelpText:    "Run protonmail-bridge info to get the Bridge-generated password. This is not your Proton account login password.",
+						HelpText:    "From protonmail-bridge info — the Bridge-generated password, not your Proton account login password.",
 					},
 					{
 						Key:         "imap_host",
@@ -217,6 +218,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						Placeholder: "127.0.0.1",
 						Secret:      ptrBool(false),
 						Required:    ptrBool(false),
+						HelpText:    "Leave blank when Bridge runs on the same host (default 127.0.0.1:1143).",
 					},
 					{
 						Key:         "imap_port",
@@ -231,6 +233,7 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						Placeholder: "127.0.0.1",
 						Secret:      ptrBool(false),
 						Required:    ptrBool(false),
+						HelpText:    "Leave blank when Bridge runs on the same host (default 127.0.0.1:1025).",
 					},
 					{
 						Key:         "smtp_port",

--- a/connectors/protonmail/protonmail.go
+++ b/connectors/protonmail/protonmail.go
@@ -31,10 +31,6 @@ const (
 	defaultIMAPPort = "1143"
 )
 
-// validateIMAPConn is the IMAP dial+login used by ValidateCredentials. Tests may
-// replace it to avoid requiring a running local Proton proxy.
-var validateIMAPConn = connectIMAP
-
 // ProtonMailConnector owns the shared configuration for all Proton Mail actions.
 type ProtonMailConnector struct {
 	timeout time.Duration
@@ -76,12 +72,7 @@ func (c *ProtonMailConnector) ValidateCredentials(ctx context.Context, creds con
 		}
 	}
 
-	session, err := validateIMAPConn(creds, timeout)
-	if err != nil {
-		return err
-	}
-	session.close()
-	return nil
+	return TestBridgeConnection(creds, timeout)
 }
 
 func validateCredentialShape(creds connectors.Credentials) error {

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -120,8 +120,6 @@ func TestValidateCredentialShape(t *testing.T) {
 }
 
 func TestProtonMailConnector_ValidateCredentials(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	oldSMTP := testSMTPConn
 	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -122,11 +122,14 @@ func TestValidateCredentialShape(t *testing.T) {
 func TestProtonMailConnector_ValidateCredentials(t *testing.T) {
 	t.Parallel()
 
-	old := validateIMAPConn
-	validateIMAPConn = func(_ connectors.Credentials, _ time.Duration) (*imapSession, error) {
-		return &imapSession{}, nil
-	}
-	t.Cleanup(func() { validateIMAPConn = old })
+	oldIMAP := testIMAPConn
+	oldSMTP := testSMTPConn
+	testIMAPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	testSMTPConn = func(_ connectors.Credentials, _ time.Duration) error { return nil }
+	t.Cleanup(func() {
+		testIMAPConn = oldIMAP
+		testSMTPConn = oldSMTP
+	})
 
 	c := New()
 	for _, creds := range []connectors.Credentials{validCreds(), validCredsAllFields()} {
@@ -139,9 +142,16 @@ func TestProtonMailConnector_ValidateCredentials(t *testing.T) {
 func TestProtonMailConnector_ValidateCredentials_proxyUnreachable(t *testing.T) {
 	t.Parallel()
 
-	old := validateIMAPConn
-	validateIMAPConn = connectIMAP
-	t.Cleanup(func() { validateIMAPConn = old })
+	oldIMAP := testIMAPConn
+	testIMAPConn = func(creds connectors.Credentials, timeout time.Duration) error {
+		session, err := connectIMAP(creds, timeout)
+		if err != nil {
+			return err
+		}
+		session.close()
+		return nil
+	}
+	t.Cleanup(func() { testIMAPConn = oldIMAP })
 
 	c := New()
 	err := c.ValidateCredentials(t.Context(), validCreds())
@@ -236,9 +246,17 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 			t.Errorf("credential fields[%d].required = %s, want %v", i, gotRequired, want.required)
 		}
 	}
-	passwordField := cred.Fields[1]
-	if passwordField.HelpText == "" {
-		t.Error("password field help_text is empty, want guidance about the Bridge password")
+	for _, key := range []string{"username", "password"} {
+		var field connectors.ManifestCredentialField
+		for _, f := range cred.Fields {
+			if f.Key == key {
+				field = f
+				break
+			}
+		}
+		if field.HelpText == "" {
+			t.Errorf("%s field help_text is empty, want Bridge setup guidance", key)
+		}
 	}
 
 	for _, a := range m.Actions {

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -138,8 +138,6 @@ func TestProtonMailConnector_ValidateCredentials(t *testing.T) {
 }
 
 func TestProtonMailConnector_ValidateCredentials_proxyUnreachable(t *testing.T) {
-	t.Parallel()
-
 	oldIMAP := testIMAPConn
 	testIMAPConn = func(creds connectors.Credentials, timeout time.Duration) error {
 		session, err := connectIMAP(creds, timeout)

--- a/db/credential_connector_state.go
+++ b/db/credential_connector_state.go
@@ -4,11 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
+
+// ProtonmailHealthStatus is the last-known Bridge connectivity check result.
+type ProtonmailHealthStatus string
+
+const (
+	ProtonmailHealthOK    ProtonmailHealthStatus = "ok"
+	ProtonmailHealthError ProtonmailHealthStatus = "error"
+)
+
+// ProtonmailHealthState records the outcome of a Bridge connectivity check.
+type ProtonmailHealthState struct {
+	Status    ProtonmailHealthStatus `json:"status"`
+	CheckedAt time.Time              `json:"checked_at"`
+	Message   string                 `json:"message,omitempty"`
+}
 
 // ProtonmailConnectorState holds non-secret Proton Mail sync metadata for a credential.
 type ProtonmailConnectorState struct {
 	Folders map[string]ProtonmailFolderState `json:"folders,omitempty"`
+	Health  *ProtonmailHealthState           `json:"health,omitempty"`
 }
 
 // ProtonmailFolderState records IMAP state for a single mailbox folder.
@@ -35,6 +52,42 @@ func GetProtonmailUIDValidity(ctx context.Context, db DBTX, credentialID, folder
 		return 0, false, nil
 	}
 	return folderState.UIDValidity, true, nil
+}
+
+// GetProtonmailHealth returns the stored Bridge health check, or nil if none recorded.
+func GetProtonmailHealth(ctx context.Context, db DBTX, credentialID string) (*ProtonmailHealthState, error) {
+	state, err := loadCredentialConnectorState(ctx, db, credentialID)
+	if err != nil {
+		return nil, err
+	}
+	if state.Protonmail == nil || state.Protonmail.Health == nil {
+		return nil, nil
+	}
+	health := *state.Protonmail.Health
+	return &health, nil
+}
+
+// SetProtonmailHealth records Bridge connectivity health on the credential.
+func SetProtonmailHealth(ctx context.Context, db DBTX, credentialID string, health ProtonmailHealthState) error {
+	state, err := loadCredentialConnectorState(ctx, db, credentialID)
+	if err != nil {
+		return err
+	}
+	if state.Protonmail == nil {
+		state.Protonmail = &ProtonmailConnectorState{}
+	}
+	state.Protonmail.Health = &health
+
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal connector_state: %w", err)
+	}
+
+	_, err = db.Exec(ctx, `
+		UPDATE credentials
+		SET connector_state = $2
+		WHERE id = $1`, credentialID, raw)
+	return err
 }
 
 // SetProtonmailUIDValidity records UIDVALIDITY for a folder on the credential.

--- a/db/credential_connector_state_test.go
+++ b/db/credential_connector_state_test.go
@@ -3,6 +3,7 @@ package db_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/supersuit-tech/permission-slip/db"
 	"github.com/supersuit-tech/permission-slip/db/testhelper"
@@ -44,5 +45,51 @@ func TestProtonmailUIDValidityRoundTrip(t *testing.T) {
 	got, known, err = db.GetProtonmailUIDValidity(ctx, tx, credID, "INBOX")
 	if err != nil || !known || got != 12345 {
 		t.Fatalf("INBOX validity should be unchanged, got %d (known=%v) err=%v", got, known, err)
+	}
+}
+
+func TestProtonmailHealthRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tx := testhelper.SetupTestDB(t)
+
+	uid := testhelper.GenerateUID(t)
+	credID := testhelper.GenerateID(t, "cred_")
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	testhelper.InsertCredential(t, tx, credID, uid, "protonmail")
+
+	health, err := db.GetProtonmailHealth(ctx, tx, credID)
+	if err != nil {
+		t.Fatalf("GetProtonmailHealth: %v", err)
+	}
+	if health != nil {
+		t.Fatalf("expected no health initially, got %+v", health)
+	}
+
+	checkedAt, err := time.Parse(time.RFC3339, "2026-06-09T12:00:00Z")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
+	}
+	if err := db.SetProtonmailHealth(ctx, tx, credID, db.ProtonmailHealthState{
+		Status:    db.ProtonmailHealthOK,
+		CheckedAt: checkedAt,
+	}); err != nil {
+		t.Fatalf("SetProtonmailHealth: %v", err)
+	}
+
+	health, err = db.GetProtonmailHealth(ctx, tx, credID)
+	if err != nil {
+		t.Fatalf("GetProtonmailHealth after set: %v", err)
+	}
+	if health == nil || health.Status != db.ProtonmailHealthOK {
+		t.Fatalf("got %+v, want status ok", health)
+	}
+
+	if err := db.SetProtonmailUIDValidity(ctx, tx, credID, "INBOX", 42); err != nil {
+		t.Fatalf("SetProtonmailUIDValidity: %v", err)
+	}
+	health, err = db.GetProtonmailHealth(ctx, tx, credID)
+	if err != nil || health == nil || health.Status != db.ProtonmailHealthOK {
+		t.Fatalf("health should survive UIDVALIDITY update, got %+v err=%v", health, err)
 	}
 }

--- a/frontend/src/hooks/useTestCredentialConnection.ts
+++ b/frontend/src/hooks/useTestCredentialConnection.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/auth/AuthContext";
+import client from "@/api/client";
+import { getApiErrorMessage } from "@/api/errors";
+import type { components } from "@/api/schema";
+
+type TestRequest = components["schemas"]["TestCredentialConnectionRequest"];
+
+export function useTestCredentialConnection() {
+  const { session } = useAuth();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: async (body: TestRequest) => {
+      if (!session?.access_token) {
+        throw new Error("Not authenticated");
+      }
+
+      const { data, error } = await client.POST("/v1/credentials/test-connection", {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        body,
+      });
+      if (error) {
+        throw new Error(
+          getApiErrorMessage(error, "Bridge connection test failed"),
+        );
+      }
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["credentials"] });
+    },
+  });
+
+  return {
+    testConnection: (body: TestRequest) => mutation.mutateAsync(body),
+    isTesting: mutation.isPending,
+  };
+}

--- a/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/AddCredentialDialog.tsx
@@ -15,6 +15,7 @@ import { Label } from "@/components/ui/label";
 import { useStoreCredential } from "@/hooks/useStoreCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import validation from "@/lib/validation";
+import { BridgeTestConnectionButton } from "./BridgeTestConnectionButton";
 import { resolveStaticCredentialFields } from "./credentialFields";
 
 interface AddCredentialDialogProps {
@@ -222,6 +223,11 @@ export function AddCredentialDialog({
                 </div>
               ))
             )}
+            <BridgeTestConnectionButton
+              service={credential.service}
+              buildCredentials={buildCredentials}
+              disabled={isLoading}
+            />
           </div>
           <DialogFooter>
             <Button

--- a/frontend/src/pages/agents/connectors/BridgeTestConnectionButton.tsx
+++ b/frontend/src/pages/agents/connectors/BridgeTestConnectionButton.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { Loader2, PlugZap } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useTestCredentialConnection } from "@/hooks/useTestCredentialConnection";
+
+interface BridgeTestConnectionButtonProps {
+  service: string;
+  credentialId?: string;
+  buildCredentials: () => Record<string, string> | null;
+  disabled?: boolean;
+}
+
+export function BridgeTestConnectionButton({
+  service,
+  credentialId,
+  buildCredentials,
+  disabled,
+}: BridgeTestConnectionButtonProps) {
+  const { testConnection, isTesting } = useTestCredentialConnection();
+  const [lastResult, setLastResult] = useState<"ok" | "error" | null>(null);
+
+  if (service !== "protonmail") {
+    return null;
+  }
+
+  async function handleTest() {
+    const credentials = buildCredentials();
+    if (!credentials && !credentialId) {
+      toast.error("Enter Bridge username and password to test");
+      return;
+    }
+
+    try {
+      const result = await testConnection({
+        service: "protonmail",
+        credential_id: credentialId,
+        credentials: credentials ?? undefined,
+      });
+      setLastResult("ok");
+      toast.success(result?.message ?? "Bridge connection successful");
+    } catch (err) {
+      setLastResult("error");
+      toast.error(
+        err instanceof Error ? err.message : "Bridge connection test failed",
+      );
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleTest}
+        disabled={disabled || isTesting}
+        className="w-full"
+      >
+        {isTesting ? (
+          <Loader2 className="animate-spin" />
+        ) : (
+          <PlugZap className="size-4" />
+        )}
+        Test Bridge connection
+      </Button>
+      {lastResult === "ok" ? (
+        <p className="text-xs text-green-600 dark:text-green-400">
+          Bridge is reachable over IMAP and SMTP.
+        </p>
+      ) : null}
+      {lastResult === "error" ? (
+        <p className="text-muted-foreground text-xs">
+          Fix the values above and try again. Run{" "}
+          <code className="text-xs">protonmail-bridge info</code> for the correct
+          host, port, username, and Bridge password.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/agents/connectors/EditCredentialDialog.tsx
+++ b/frontend/src/pages/agents/connectors/EditCredentialDialog.tsx
@@ -16,6 +16,7 @@ import type { CredentialSummary } from "@/hooks/useCredentials";
 import { useUpdateCredential } from "@/hooks/useUpdateCredential";
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import validation from "@/lib/validation";
+import { BridgeTestConnectionButton } from "./BridgeTestConnectionButton";
 import { resolveStaticCredentialFields } from "./credentialFields";
 
 interface EditCredentialDialogProps {
@@ -224,6 +225,12 @@ export function EditCredentialDialog({
                 </div>
               ))
             )}
+            <BridgeTestConnectionButton
+              service={credential.service}
+              credentialId={storedCredential.id}
+              buildCredentials={buildCredentialUpdates}
+              disabled={isLoading}
+            />
           </div>
           <DialogFooter>
             <Button

--- a/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
+++ b/frontend/src/pages/agents/connectors/ManageCredentialsDialog.tsx
@@ -34,6 +34,7 @@ import {
 import type { RequiredCredential } from "@/hooks/useConnectorDetail";
 import { serviceLabel, authTypeLabel } from "@/lib/labels";
 import { useTryAutoAssign } from "@/hooks/useTryAutoAssign";
+import { useTestCredentialConnection } from "@/hooks/useTestCredentialConnection";
 import { AddCredentialDialog } from "./AddCredentialDialog";
 import { EditCredentialDialog } from "./EditCredentialDialog";
 import { RemoveCredentialDialog } from "./RemoveCredentialDialog";
@@ -545,16 +546,38 @@ function StaticCredentialRow({
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<CredentialSummary | null>(null);
   const [removeTarget, setRemoveTarget] = useState<CredentialSummary | null>(null);
+  const [checkingId, setCheckingId] = useState<string | null>(null);
   const { tryAssign } = useTryAutoAssign(agentId, connectorId);
+  const { testConnection } = useTestCredentialConnection();
 
   const isConnected = storedCredentials.length > 0;
+  const isProtonmail = requiredCredential.service === "protonmail";
+  const bridgeHealth = protonBridgeHealthSummary(storedCredentials);
+  const showBridgeWarning =
+    isProtonmail && isConnected && bridgeHealth === "error";
+  const showBridgeHealthy =
+    isProtonmail && isConnected && bridgeHealth === "ok";
+
+  async function handleCheckBridge(cred: CredentialSummary) {
+    setCheckingId(cred.id);
+    try {
+      await testConnection({
+        service: "protonmail",
+        credential_id: cred.id,
+      });
+    } finally {
+      setCheckingId(null);
+    }
+  }
 
   return (
     <>
       <div className="rounded-lg border p-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-1 items-center gap-3">
-            {isConnected ? (
+            {showBridgeWarning ? (
+              <AlertTriangle className="size-5 shrink-0 text-amber-600 dark:text-amber-400" />
+            ) : isConnected ? (
               <CheckCircle2 className="size-5 shrink-0 text-green-600 dark:text-green-400" />
             ) : (
               <Circle className="text-muted-foreground size-5 shrink-0" />
@@ -589,12 +612,20 @@ function StaticCredentialRow({
           <div className="flex shrink-0 items-center gap-2 pl-8 sm:pl-0">
             <span
               className={`text-xs font-medium ${
-                isConnected
-                  ? "text-green-600 dark:text-green-400"
-                  : "text-muted-foreground"
+                showBridgeWarning
+                  ? "text-amber-600 dark:text-amber-400"
+                  : isConnected
+                    ? "text-green-600 dark:text-green-400"
+                    : "text-muted-foreground"
               }`}
             >
-              {isConnected ? "Connected" : "Not configured"}
+              {showBridgeWarning
+                ? "Bridge unreachable"
+                : showBridgeHealthy
+                  ? "Bridge reachable"
+                  : isConnected
+                    ? "Connected"
+                    : "Not configured"}
             </span>
             <Button
               variant="outline"
@@ -623,6 +654,21 @@ function StaticCredentialRow({
                   </p>
                 </div>
                 <div className="flex items-center gap-1">
+                  {isProtonmail ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleCheckBridge(cred)}
+                      disabled={checkingId === cred.id}
+                      aria-label={`Check Bridge connection for ${cred.label ?? cred.service}`}
+                    >
+                      {checkingId === cred.id ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <CheckCircle2 className="size-4" />
+                      )}
+                    </Button>
+                  ) : null}
                   <Button
                     variant="ghost"
                     size="sm"
@@ -678,4 +724,19 @@ function StaticCredentialRow({
       )}
     </>
   );
+}
+
+function protonBridgeHealthSummary(
+  storedCredentials: CredentialSummary[],
+): "ok" | "error" | "unknown" {
+  const withHealth = storedCredentials
+    .map((c) => c.bridge_health?.status)
+    .filter((s): s is "ok" | "error" => s === "ok" || s === "error");
+  if (withHealth.length === 0) {
+    return "unknown";
+  }
+  if (withHealth.some((s) => s === "error")) {
+    return "error";
+  }
+  return "ok";
 }

--- a/spec/openapi/components/paths/credentials.yaml
+++ b/spec/openapi/components/paths/credentials.yaml
@@ -161,6 +161,89 @@ credentials:
       '503':
         $ref: '../responses/errors.yaml#/ServiceUnavailable'
 
+testCredentialConnection:
+  post:
+    operationId: testCredentialConnection
+    summary: Test Proton Mail Bridge connectivity
+    description: |
+      Attempt an IMAP login + INBOX select and an SMTP EHLO + AUTH handshake using
+      the supplied credentials. No mailbox content is read and no mail is sent.
+
+      Use this before saving credentials to catch misconfigured Bridge host/port or
+      wrong Bridge passwords at setup time. When `credential_id` is provided, the
+      stored vault secret is used as a base and any submitted `credentials` fields
+      override it (blank values keep the stored secret).
+
+      On success or failure with a `credential_id`, the result is recorded in
+      `bridge_health` on the credential summary.
+
+    tags:
+      - Credentials
+
+    security:
+      - SupabaseSession: []
+
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/credentials.yaml#/TestCredentialConnectionRequest'
+          examples:
+            pre_save:
+              summary: Test before saving
+              value:
+                service: "protonmail"
+                credentials:
+                  username: "user@proton.me"
+                  password: "bridge-generated-password"
+            stored:
+              summary: Re-test stored credential
+              value:
+                service: "protonmail"
+                credential_id: "cred_abc123"
+
+    responses:
+      '200':
+        description: Bridge is reachable and credentials authenticated
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/credentials.yaml#/TestCredentialConnectionResponse'
+            example:
+              ok: true
+              message: "Bridge connection successful (IMAP and SMTP)"
+
+      '400':
+        $ref: '../responses/errors.yaml#/BadRequest'
+
+      '401':
+        $ref: '../responses/errors.yaml#/Unauthorized'
+
+      '404':
+        description: Credential not found
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '502':
+        description: Bridge unreachable or rejected the connection
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '504':
+        description: Bridge connection timed out
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/errors.yaml#/ErrorResponse'
+
+      '500':
+        $ref: '../responses/errors.yaml#/InternalServerError'
+
 credentialById:
   patch:
     operationId: updateCredential

--- a/spec/openapi/components/schemas/credentials.yaml
+++ b/spec/openapi/components/schemas/credentials.yaml
@@ -154,11 +154,77 @@ CredentialSummary:
         ISO 8601 timestamp (RFC 3339 format, UTC) when the credential was stored.
       example: "2026-02-11T10:00:00Z"
 
+    bridge_health:
+      $ref: '../schemas/credentials.yaml#/BridgeHealthSummary'
+      description: |
+        Last-known Proton Mail Bridge connectivity check. Present only for protonmail
+        credentials after a test-connection call or successful save-time validation.
+
   example:
     id: "cred_abc123"
     service: "github"
     label: "Personal Access Token"
     created_at: "2026-02-11T10:00:00Z"
+
+BridgeHealthSummary:
+  type: object
+  required:
+    - status
+    - checked_at
+  properties:
+    status:
+      type: string
+      enum: [ok, error]
+      description: Result of the most recent Bridge connectivity check.
+      example: "ok"
+    checked_at:
+      type: string
+      format: date-time
+      description: When the connectivity check last ran.
+      example: "2026-06-09T12:00:00Z"
+    message:
+      type: string
+      description: Actionable error detail when status is error.
+      example: "IMAP connection refused — Bridge not running or wrong port"
+
+TestCredentialConnectionRequest:
+  type: object
+  required:
+    - service
+  properties:
+    service:
+      type: string
+      description: Credential service to test. Currently only protonmail is supported.
+      example: "protonmail"
+    credentials:
+      type: object
+      additionalProperties: true
+      description: |
+        Credential field values to test. Required when credential_id is omitted.
+        When credential_id is provided, blank fields keep the stored vault values.
+      example:
+        username: "user@proton.me"
+        password: "bridge-generated-password"
+    credential_id:
+      type: string
+      pattern: '^cred_[a-zA-Z0-9]{6,64}$'
+      description: Optional stored credential to load as a base before applying credentials overrides.
+      example: "cred_abc123"
+
+TestCredentialConnectionResponse:
+  type: object
+  required:
+    - ok
+    - message
+  properties:
+    ok:
+      type: boolean
+      description: True when IMAP and SMTP handshakes succeeded.
+      example: true
+    message:
+      type: string
+      description: Human-readable result summary.
+      example: "Bridge connection successful (IMAP and SMTP)"
 
 UpdateCredentialRequest:
   type: object

--- a/spec/openapi/openapi.bundle.yaml
+++ b/spec/openapi/openapi.bundle.yaml
@@ -4444,6 +4444,78 @@ paths:
           $ref: '#/components/responses/InternalServerError'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /v1/credentials/test-connection:
+    post:
+      operationId: testCredentialConnection
+      summary: Test Proton Mail Bridge connectivity
+      description: |
+        Attempt an IMAP login + INBOX select and an SMTP EHLO + AUTH handshake using
+        the supplied credentials. No mailbox content is read and no mail is sent.
+
+        Use this before saving credentials to catch misconfigured Bridge host/port or
+        wrong Bridge passwords at setup time. When `credential_id` is provided, the
+        stored vault secret is used as a base and any submitted `credentials` fields
+        override it (blank values keep the stored secret).
+
+        On success or failure with a `credential_id`, the result is recorded in
+        `bridge_health` on the credential summary.
+      tags:
+        - Credentials
+      security:
+        - SupabaseSession: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TestCredentialConnectionRequest'
+            examples:
+              pre_save:
+                summary: Test before saving
+                value:
+                  service: protonmail
+                  credentials:
+                    username: user@proton.me
+                    password: bridge-generated-password
+              stored:
+                summary: Re-test stored credential
+                value:
+                  service: protonmail
+                  credential_id: cred_abc123
+      responses:
+        '200':
+          description: Bridge is reachable and credentials authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestCredentialConnectionResponse'
+              example:
+                ok: true
+                message: Bridge connection successful (IMAP and SMTP)
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          description: Credential not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '502':
+          description: Bridge unreachable or rejected the connection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '504':
+          description: Bridge connection timed out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /v1/credentials/{credential_id}:
     patch:
       operationId: updateCredential
@@ -7859,6 +7931,11 @@ components:
           description: |
             ISO 8601 timestamp (RFC 3339 format, UTC) when the credential was stored.
           example: '2026-02-11T10:00:00Z'
+        bridge_health:
+          $ref: '#/components/schemas/BridgeHealthSummary'
+          description: |
+            Last-known Proton Mail Bridge connectivity check. Present only for protonmail
+            credentials after a test-connection call or successful save-time validation.
       example:
         id: cred_abc123
         service: github
@@ -7913,6 +7990,65 @@ components:
       example:
         id: cred_abc123
         deleted_at: '2026-02-11T15:00:00Z'
+    TestCredentialConnectionRequest:
+      type: object
+      required:
+        - service
+      properties:
+        service:
+          type: string
+          description: Credential service to test. Currently only protonmail is supported.
+          example: protonmail
+        credentials:
+          type: object
+          additionalProperties: true
+          description: |
+            Credential field values to test. Required when credential_id is omitted.
+            When credential_id is provided, blank fields keep the stored vault values.
+          example:
+            username: user@proton.me
+            password: bridge-generated-password
+        credential_id:
+          type: string
+          pattern: ^cred_[a-zA-Z0-9]{6,64}$
+          description: Optional stored credential to load as a base before applying credentials overrides.
+          example: cred_abc123
+    TestCredentialConnectionResponse:
+      type: object
+      required:
+        - ok
+        - message
+      properties:
+        ok:
+          type: boolean
+          description: True when IMAP and SMTP handshakes succeeded.
+          example: true
+        message:
+          type: string
+          description: Human-readable result summary.
+          example: Bridge connection successful (IMAP and SMTP)
+    BridgeHealthSummary:
+      type: object
+      required:
+        - status
+        - checked_at
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+            - error
+          description: Result of the most recent Bridge connectivity check.
+          example: ok
+        checked_at:
+          type: string
+          format: date-time
+          description: When the connectivity check last ran.
+          example: '2026-06-09T12:00:00Z'
+        message:
+          type: string
+          description: Actionable error detail when status is error.
+          example: IMAP connection refused — Bridge not running or wrong port
     ConnectorListResponse:
       type: object
       required:

--- a/spec/openapi/openapi.yaml
+++ b/spec/openapi/openapi.yaml
@@ -241,6 +241,9 @@ paths:
 
   /v1/credentials:
     $ref: './components/paths/credentials.yaml#/credentials'
+
+  /v1/credentials/test-connection:
+    $ref: './components/paths/credentials.yaml#/testCredentialConnection'
   
   /v1/credentials/{credential_id}:
     $ref: './components/paths/credentials.yaml#/credentialById'
@@ -415,6 +418,12 @@ components:
       $ref: './components/schemas/credentials.yaml#/UpdateCredentialRequest'
     DeleteCredentialResponse:
       $ref: './components/schemas/credentials.yaml#/DeleteCredentialResponse'
+    TestCredentialConnectionRequest:
+      $ref: './components/schemas/credentials.yaml#/TestCredentialConnectionRequest'
+    TestCredentialConnectionResponse:
+      $ref: './components/schemas/credentials.yaml#/TestCredentialConnectionResponse'
+    BridgeHealthSummary:
+      $ref: './components/schemas/credentials.yaml#/BridgeHealthSummary'
     
     # Connectors
     ConnectorListResponse:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds IMAP (login + INBOX select) and SMTP (EHLO + AUTH) Bridge health checks in the protonmail connector with actionable error messages for connection refused, auth failure, and timeout cases.
- Introduces `POST /v1/credentials/test-connection` for on-demand testing (pre-save or stored credentials), persists results in `connector_state`, and exposes `bridge_health` on credential summaries.
- Validates protonmail credentials at save/update time (matching existing docs), and adds a Test Bridge connection button on add/edit dialogs plus a health indicator and re-check affordance on the connector credentials card.

Closes #1311

## Test plan

### Claude Code
- [x] `gofmt` on all changed Go files
- [x] `cd frontend && npx vitest run src/pages/agents/connectors/` (214 tests passed)
- [x] `cd frontend && npm run build` (TypeScript + Vite build succeeded)
- [ ] Backend `go test` not run locally (sandbox Go 1.24 / bigquery constraint) — CI will verify

### OpenClaw
- [ ] Add Proton Mail credentials with Bridge running; confirm Test connection succeeds before saving
- [ ] Stop Bridge and confirm Test connection / health indicator shows unreachable with a useful message
- [ ] Enter wrong Bridge password and confirm auth error message distinguishes it from Proton account password

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4384921c-e142-484a-990a-09585eaa52a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4384921c-e142-484a-990a-09585eaa52a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

