### PR TITLE
Proton Mail: approval previews, describers, and email-management actions

### DIFF
--- a/connectors/protonmail/archive_email.go
+++ b/connectors/protonmail/archive_email.go
@@ -18,14 +18,12 @@ type archiveEmailAction struct {
 	conn *ProtonMailConnector
 }
 
-type archiveEmailParams = uidMessageParams
-
-func parseArchiveParams(raw []byte) (*archiveEmailParams, error) {
+func parseArchiveParams(raw []byte) (*uidMessageParams, error) {
 	return parseUIDMessageParams(raw)
 }
 
-func (p *archiveEmailParams) validate() error {
-	if err := (*uidMessageParams)(p).validate(); err != nil {
+func validateArchiveParams(p *uidMessageParams) error {
+	if err := p.validate(); err != nil {
 		return err
 	}
 	if strings.EqualFold(p.Folder, archiveMailbox) {
@@ -39,7 +37,7 @@ func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionR
 	if err != nil {
 		return nil, err
 	}
-	if err := params.validate(); err != nil {
+	if err := validateArchiveParams(params); err != nil {
 		return nil, err
 	}
 

--- a/connectors/protonmail/archive_email.go
+++ b/connectors/protonmail/archive_email.go
@@ -2,11 +2,9 @@ package protonmail
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/emersion/go-imap/v2"
 	"github.com/supersuit-tech/permission-slip/connectors"
 )
 
@@ -20,80 +18,20 @@ type archiveEmailAction struct {
 	conn *ProtonMailConnector
 }
 
-// archiveEmailRaw handles flexible JSON input: accepts either a single integer
-// for message_id or an array for message_ids, so callers can archive one email
-// without wrapping it in an array.
-type archiveEmailRaw struct {
-	MessageID  *uint32         `json:"message_id,omitempty"`
-	MessageIDs json.RawMessage `json:"message_ids,omitempty"`
-	Folder     string          `json:"folder"`
-}
+type archiveEmailParams = uidMessageParams
 
-type archiveEmailParams struct {
-	MessageIDs []uint32 `json:"-"`
-	Folder     string   `json:"folder"`
-}
-
-// parseArchiveParams normalizes the flexible input into archiveEmailParams.
-// Accepts "message_id": 5 (single), "message_ids": [1,2,3] (batch), or both
-// (merged). Deduplication happens later in validate().
 func parseArchiveParams(raw []byte) (*archiveEmailParams, error) {
-	var r archiveEmailRaw
-	if err := json.Unmarshal(raw, &r); err != nil {
-		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
-	}
-
-	params := &archiveEmailParams{Folder: r.Folder}
-
-	if len(r.MessageIDs) > 0 && string(r.MessageIDs) != "null" {
-		if err := json.Unmarshal(r.MessageIDs, &params.MessageIDs); err != nil {
-			return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid message_ids: %v", err)}
-		}
-	}
-
-	if r.MessageID != nil {
-		params.MessageIDs = append(params.MessageIDs, *r.MessageID)
-	}
-
-	return params, nil
+	return parseUIDMessageParams(raw)
 }
 
 func (p *archiveEmailParams) validate() error {
-	if len(p.MessageIDs) == 0 {
-		return &connectors.ValidationError{Message: "missing required parameter: provide message_id (single) or message_ids (array)"}
-	}
-
-	p.MessageIDs = deduplicateUint32(p.MessageIDs)
-
-	if len(p.MessageIDs) > maxLimit {
-		return &connectors.ValidationError{Message: fmt.Sprintf("too many message_ids: maximum is %d", maxLimit)}
-	}
-	for _, id := range p.MessageIDs {
-		if id == 0 {
-			return &connectors.ValidationError{Message: "message_ids must not contain zero values"}
-		}
-	}
-	if p.Folder == "" {
-		p.Folder = "INBOX"
+	if err := (*uidMessageParams)(p).validate(); err != nil {
+		return err
 	}
 	if strings.EqualFold(p.Folder, archiveMailbox) {
 		return &connectors.ValidationError{Message: "cannot archive emails that are already in the Archive folder"}
 	}
 	return nil
-}
-
-// deduplicateUint32 returns a new slice with duplicate values removed,
-// preserving the original order.
-func deduplicateUint32(ids []uint32) []uint32 {
-	seen := make(map[uint32]struct{}, len(ids))
-	out := make([]uint32, 0, len(ids))
-	for _, id := range ids {
-		if _, ok := seen[id]; !ok {
-			seen[id] = struct{}{}
-			out = append(out, id)
-		}
-	}
-	return out
 }
 
 func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
@@ -119,12 +57,7 @@ func (a *archiveEmailAction) Execute(ctx context.Context, req connectors.ActionR
 		return nil, err
 	}
 
-	var uidSet imap.UIDSet
-	for _, id := range params.MessageIDs {
-		uidSet.AddNum(imap.UID(id))
-	}
-
-	moveCmd := session.client.Move(uidSet, archiveMailbox)
+	moveCmd := session.client.Move(uidSetFromMessageIDs(params.MessageIDs), archiveMailbox)
 	if _, err := moveCmd.Wait(); err != nil {
 		imapErr := mapIMAPError(err)
 		errMsg := err.Error()

--- a/connectors/protonmail/archive_email_test.go
+++ b/connectors/protonmail/archive_email_test.go
@@ -154,8 +154,8 @@ func TestArchiveEmail_ArchiveFolderRejected(t *testing.T) {
 func TestArchiveEmailParams_Defaults(t *testing.T) {
 	t.Parallel()
 
-	p := &archiveEmailParams{MessageIDs: []uint32{1}}
-	if err := p.validate(); err != nil {
+	p := &uidMessageParams{MessageIDs: []uint32{1}}
+	if err := validateArchiveParams(p); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if p.Folder != "INBOX" {
@@ -199,7 +199,7 @@ func TestArchiveEmail_SingleAndBatchCombined(t *testing.T) {
 func TestArchiveEmail_Deduplication(t *testing.T) {
 	t.Parallel()
 
-	p := &archiveEmailParams{MessageIDs: []uint32{3, 1, 3, 2, 1}}
+	p := &uidMessageParams{MessageIDs: []uint32{3, 1, 3, 2, 1}}
 	if err := p.validate(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/connectors/protonmail/delete_email.go
+++ b/connectors/protonmail/delete_email.go
@@ -1,0 +1,55 @@
+package protonmail
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// trashMailbox is the IMAP folder Proton Mail Bridge and hydroxide expose for
+// the Trash system label.
+const trashMailbox = "Trash"
+
+type deleteEmailAction struct {
+	conn *ProtonMailConnector
+}
+
+func (a *deleteEmailAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseUIDMessageParams(req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	if strings.EqualFold(params.Folder, trashMailbox) {
+		return nil, &connectors.ValidationError{Message: "cannot delete emails that are already in the Trash folder"}
+	}
+
+	err = executeUIDMessageAction(ctx, a.conn, req, params, func(session *imapSession, uidSet imap.UIDSet) error {
+		moveCmd := session.client.Move(uidSet, trashMailbox)
+		if _, err := moveCmd.Wait(); err != nil {
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "TRYCREATE") || strings.Contains(errMsg, "Mailbox doesn't exist") {
+				return &connectors.ExternalError{
+					Message: fmt.Sprintf("Trash folder not found on server — the mailbox %q may not exist. Ensure your local Proton IMAP/SMTP proxy exposes a Trash folder: %v", trashMailbox, err),
+				}
+			}
+			return mapUIDNotFoundError(err, params.Folder)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"status":      "deleted",
+		"folder":      params.Folder,
+		"deleted":     len(params.MessageIDs),
+		"message_ids": params.MessageIDs,
+	})
+}

--- a/connectors/protonmail/list_folders.go
+++ b/connectors/protonmail/list_folders.go
@@ -2,7 +2,6 @@ package protonmail
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
 )

--- a/connectors/protonmail/list_folders.go
+++ b/connectors/protonmail/list_folders.go
@@ -1,0 +1,52 @@
+package protonmail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type listFoldersAction struct {
+	conn *ProtonMailConnector
+}
+
+func (a *listFoldersAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	session, err := connectIMAP(req.Credentials, a.conn.timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	listCmd := session.client.List("", "*", nil)
+	mailboxes, err := listCmd.Collect()
+	if err != nil {
+		return nil, mapIMAPError(err)
+	}
+
+	folders := make([]map[string]any, 0, len(mailboxes))
+	for _, mbox := range mailboxes {
+		if mbox == nil {
+			continue
+		}
+		entry := map[string]any{
+			"name": mbox.Mailbox,
+		}
+		if len(mbox.Attrs) > 0 {
+			attrs := make([]string, 0, len(mbox.Attrs))
+			for _, attr := range mbox.Attrs {
+				attrs = append(attrs, string(attr))
+			}
+			entry["attributes"] = attrs
+		}
+		if mbox.Delim != 0 {
+			entry["delimiter"] = string(mbox.Delim)
+		}
+		folders = append(folders, entry)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"folders": folders,
+		"total":   len(folders),
+	})
+}

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -71,10 +71,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "protonmail.reply_email",
-				Name:        "Reply to Email",
-				Description: "Reply to an existing email with correct In-Reply-To threading via SMTP",
-				RiskLevel:   "medium",
+				ActionType:      "protonmail.reply_email",
+				Name:            "Reply to Email",
+				Description:     "Reply to an existing email with correct In-Reply-To threading via SMTP",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Reply to email in {{folder}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["in_reply_to_message_id", "body"],
@@ -193,10 +194,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "protonmail.read_email",
-				Name:        "Read Email",
-				Description: "Fetch a specific email by stable IMAP UID with full body",
-				RiskLevel:   "low",
+				ActionType:      "protonmail.read_email",
+				Name:            "Read Email",
+				Description:     "Fetch a specific email by stable IMAP UID with full body",
+				RiskLevel:       "low",
+				DisplayTemplate: "Read email in {{folder}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["message_id"],
@@ -215,10 +217,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "protonmail.archive_email",
-				Name:        "Archive Email",
-				Description: "Move one or more emails to the Archive folder via IMAP MOVE",
-				RiskLevel:   "medium",
+				ActionType:      "protonmail.archive_email",
+				Name:            "Archive Email",
+				Description:     "Move one or more emails to the Archive folder via IMAP MOVE",
+				RiskLevel:       "medium",
+				DisplayTemplate: "Archive email in {{folder}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"anyOf": [

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -19,10 +19,15 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 		LogoSVG:     logoSVG,
 		Actions: []connectors.ManifestAction{
 			{
-				ActionType:  "protonmail.send_email",
-				Name:        "Send Email",
-				Description: "Send an email via SMTP through the local Proton IMAP/SMTP proxy",
-				RiskLevel:   "high",
+				ActionType:      "protonmail.send_email",
+				Name:            "Send Email",
+				Description:     "Send an email via SMTP through the local Proton IMAP/SMTP proxy",
+				RiskLevel:       "high",
+				DisplayTemplate: "Send email to {{to}} — {{subject}}",
+				Preview: &connectors.ActionPreview{
+					Layout: "message",
+					Fields: map[string]string{"to": "to", "subject": "subject", "body": "body"},
+				},
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["to", "subject", "body"],
@@ -117,10 +122,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "protonmail.read_inbox",
-				Name:        "Read Inbox",
-				Description: "Fetch recent emails from a mailbox folder via IMAP",
-				RiskLevel:   "low",
+				ActionType:      "protonmail.read_inbox",
+				Name:            "Read Inbox",
+				Description:     "Fetch recent emails from a mailbox folder via IMAP",
+				RiskLevel:       "low",
+				DisplayTemplate: "Read {{limit:count}} most recent in {{folder}}",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -145,10 +151,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
-				ActionType:  "protonmail.search_emails",
-				Name:        "Search Emails",
-				Description: "Search emails by subject, sender, or date range via IMAP",
-				RiskLevel:   "low",
+				ActionType:      "protonmail.search_emails",
+				Name:            "Search Emails",
+				Description:     "Search emails by subject, sender, or date range via IMAP",
+				RiskLevel:       "low",
+				DisplayTemplate: "Search {{folder}} for emails",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"properties": {
@@ -238,6 +245,65 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 						}
 					}
 				}`)),
+			},
+			{
+				ActionType:      "protonmail.list_folders",
+				Name:            "List Folders",
+				Description:     "List mailbox folders available via IMAP",
+				RiskLevel:       "low",
+				DisplayTemplate: "List mailbox folders",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {}
+				}`)),
+			},
+			{
+				ActionType:       "protonmail.mark_read",
+				Name:             "Mark Read",
+				Description:      "Mark one or more emails as read via IMAP STORE \\Seen",
+				RiskLevel:        "low",
+				DisplayTemplate:  "Mark email as read",
+				ParametersSchema: uidMessageParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.mark_unread",
+				Name:             "Mark Unread",
+				Description:      "Mark one or more emails as unread via IMAP STORE \\Seen removal",
+				RiskLevel:        "low",
+				DisplayTemplate:  "Mark email as unread",
+				ParametersSchema: uidMessageParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.flag",
+				Name:             "Flag Email",
+				Description:      "Flag one or more emails via IMAP STORE \\Flagged",
+				RiskLevel:        "low",
+				DisplayTemplate:  "Flag email",
+				ParametersSchema: uidMessageParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.unflag",
+				Name:             "Unflag Email",
+				Description:      "Remove the flag from one or more emails via IMAP STORE \\Flagged removal",
+				RiskLevel:        "low",
+				DisplayTemplate:  "Unflag email",
+				ParametersSchema: uidMessageParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.move_to_folder",
+				Name:             "Move to Folder",
+				Description:      "Move one or more emails to another mailbox folder via IMAP MOVE",
+				RiskLevel:        "medium",
+				DisplayTemplate:  "Move email to {{target_folder}}",
+				ParametersSchema: moveToFolderParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.delete",
+				Name:             "Delete Email",
+				Description:      "Move one or more emails to the Trash folder via IMAP MOVE",
+				RiskLevel:        "high",
+				DisplayTemplate:  "Delete email",
+				ParametersSchema: uidMessageParametersSchema(),
 			},
 		},
 

--- a/connectors/protonmail/manifest_schema_helpers.go
+++ b/connectors/protonmail/manifest_schema_helpers.go
@@ -1,0 +1,70 @@
+package protonmail
+
+import (
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func uidMessageParametersSchema() json.RawMessage {
+	return json.RawMessage(connectors.TrimIndent(`{
+		"type": "object",
+		"anyOf": [
+			{"required": ["message_id"]},
+			{"required": ["message_ids"]}
+		],
+		"properties": {
+			"message_id": {
+				"type": "integer",
+				"minimum": 1,
+				"description": "Stable IMAP UID of a single email (shorthand for message_ids with one item)"
+			},
+			"message_ids": {
+				"type": "array",
+				"items": {"type": "integer", "minimum": 1},
+				"minItems": 1,
+				"maxItems": 50,
+				"description": "Stable IMAP UIDs of emails (batch). Combined unique count of message_id + message_ids must not exceed 50."
+			},
+			"folder": {
+				"type": "string",
+				"default": "INBOX",
+				"description": "Mailbox folder containing the emails"
+			}
+		}
+	}`))
+}
+
+func moveToFolderParametersSchema() json.RawMessage {
+	return json.RawMessage(connectors.TrimIndent(`{
+		"type": "object",
+		"required": ["target_folder"],
+		"anyOf": [
+			{"required": ["message_id"]},
+			{"required": ["message_ids"]}
+		],
+		"properties": {
+			"message_id": {
+				"type": "integer",
+				"minimum": 1,
+				"description": "Stable IMAP UID of a single email (shorthand for message_ids with one item)"
+			},
+			"message_ids": {
+				"type": "array",
+				"items": {"type": "integer", "minimum": 1},
+				"minItems": 1,
+				"maxItems": 50,
+				"description": "Stable IMAP UIDs of emails (batch). Combined unique count of message_id + message_ids must not exceed 50."
+			},
+			"folder": {
+				"type": "string",
+				"default": "INBOX",
+				"description": "Source mailbox folder containing the emails"
+			},
+			"target_folder": {
+				"type": "string",
+				"description": "Destination mailbox folder"
+			}
+		}
+	}`))
+}

--- a/connectors/protonmail/manifest_templates.go
+++ b/connectors/protonmail/manifest_templates.go
@@ -50,5 +50,26 @@ func protonmailTemplates() []connectors.ManifestTemplate {
 			Description: "Agent can move emails to the Archive folder.",
 			Parameters:  json.RawMessage(`{"folder":"INBOX","message_id":"*","message_ids":"*"}`),
 		},
+		{
+			ID:          "tpl_protonmail_list_folders",
+			ActionType:  "protonmail.list_folders",
+			Name:        "List mailbox folders",
+			Description: "Agent can list available mailbox folders.",
+			Parameters:  json.RawMessage(`{}`),
+		},
+		{
+			ID:          "tpl_protonmail_mark_read",
+			ActionType:  "protonmail.mark_read",
+			Name:        "Mark emails as read",
+			Description: "Agent can mark emails as read.",
+			Parameters:  json.RawMessage(`{"folder":"INBOX","message_id":"*"}`),
+		},
+		{
+			ID:          "tpl_protonmail_move",
+			ActionType:  "protonmail.move_to_folder",
+			Name:        "Move emails between folders",
+			Description: "Agent can move emails to another folder.",
+			Parameters:  json.RawMessage(`{"folder":"INBOX","target_folder":"*","message_id":"*"}`),
+		},
 	}
 }

--- a/connectors/protonmail/move_to_folder.go
+++ b/connectors/protonmail/move_to_folder.go
@@ -1,0 +1,87 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type moveToFolderAction struct {
+	conn *ProtonMailConnector
+}
+
+type moveToFolderParams struct {
+	uidMessageParams
+	TargetFolder string `json:"target_folder"`
+}
+
+func parseMoveToFolderParams(raw []byte) (*moveToFolderParams, error) {
+	base, err := parseUIDMessageParams(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var extra struct {
+		TargetFolder string `json:"target_folder"`
+	}
+	if err := json.Unmarshal(raw, &extra); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+
+	return &moveToFolderParams{
+		uidMessageParams: *base,
+		TargetFolder:     extra.TargetFolder,
+	}, nil
+}
+
+func (p *moveToFolderParams) validate() error {
+	if err := p.uidMessageParams.validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(p.TargetFolder) == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: target_folder"}
+	}
+	if strings.EqualFold(p.Folder, p.TargetFolder) {
+		return &connectors.ValidationError{Message: "target_folder must differ from source folder"}
+	}
+	return nil
+}
+
+func (a *moveToFolderAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseMoveToFolderParams(req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	err = executeUIDMessageAction(ctx, a.conn, req, &params.uidMessageParams, func(session *imapSession, uidSet imap.UIDSet) error {
+		moveCmd := session.client.Move(uidSet, params.TargetFolder)
+		if _, err := moveCmd.Wait(); err != nil {
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "TRYCREATE") || strings.Contains(errMsg, "Mailbox doesn't exist") {
+				return &connectors.ExternalError{
+					Message: fmt.Sprintf("target folder %q not found on server: %v", params.TargetFolder, err),
+				}
+			}
+			return mapUIDNotFoundError(err, params.Folder)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"status":        "moved",
+		"folder":        params.Folder,
+		"target_folder": params.TargetFolder,
+		"moved":         len(params.MessageIDs),
+		"message_ids":   params.MessageIDs,
+	})
+}

--- a/connectors/protonmail/protonmail.go
+++ b/connectors/protonmail/protonmail.go
@@ -3,7 +3,7 @@
 // Mail Bridge (official, x86_64) or hydroxide (open-source, ARM-friendly). Both
 // expose the same loopback IMAP/SMTP surface that this connector targets.
 //
-// Actions: send_email, reply_email (SMTP), read_inbox, search_emails, read_email, archive_email (IMAP).
+// Actions: send_email, reply_email (SMTP); read/search/inbox, archive/move/delete, flags (IMAP).
 package protonmail
 
 import (
@@ -53,12 +53,19 @@ func (c *ProtonMailConnector) ID() string { return "protonmail" }
 // Actions returns the registered action handlers keyed by action_type.
 func (c *ProtonMailConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"protonmail.send_email":    &sendEmailAction{conn: c},
-		"protonmail.reply_email":   &replyEmailAction{conn: c},
-		"protonmail.read_inbox":    &readInboxAction{conn: c},
-		"protonmail.search_emails": &searchEmailsAction{conn: c},
-		"protonmail.read_email":    &readEmailAction{conn: c},
-		"protonmail.archive_email": &archiveEmailAction{conn: c},
+		"protonmail.send_email":     &sendEmailAction{conn: c},
+		"protonmail.reply_email":    &replyEmailAction{conn: c},
+		"protonmail.read_inbox":     &readInboxAction{conn: c},
+		"protonmail.search_emails":  &searchEmailsAction{conn: c},
+		"protonmail.read_email":     &readEmailAction{conn: c},
+		"protonmail.archive_email":  &archiveEmailAction{conn: c},
+		"protonmail.list_folders":   &listFoldersAction{conn: c},
+		"protonmail.mark_read":      newMarkReadAction(c),
+		"protonmail.mark_unread":    newMarkUnreadAction(c),
+		"protonmail.flag":           newFlagAction(c),
+		"protonmail.unflag":         newUnflagAction(c),
+		"protonmail.move_to_folder": &moveToFolderAction{conn: c},
+		"protonmail.delete":         &deleteEmailAction{conn: c},
 	}
 }
 

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -30,6 +30,13 @@ func TestProtonMailConnector_Actions(t *testing.T) {
 		"protonmail.search_emails",
 		"protonmail.read_email",
 		"protonmail.archive_email",
+		"protonmail.list_folders",
+		"protonmail.mark_read",
+		"protonmail.mark_unread",
+		"protonmail.flag",
+		"protonmail.unflag",
+		"protonmail.move_to_folder",
+		"protonmail.delete",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -172,22 +172,30 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 	if m.Name != "Proton Mail" {
 		t.Errorf("Manifest().Name = %q, want %q", m.Name, "Proton Mail")
 	}
-	if len(m.Actions) != 6 {
-		t.Fatalf("Manifest().Actions has %d items, want 6", len(m.Actions))
-	}
-
-	actionTypes := make(map[string]bool)
-	for _, a := range m.Actions {
-		actionTypes[a.ActionType] = true
-	}
-	for _, want := range []string{
+	expectedActions := []string{
 		"protonmail.send_email",
 		"protonmail.reply_email",
 		"protonmail.read_inbox",
 		"protonmail.search_emails",
 		"protonmail.read_email",
 		"protonmail.archive_email",
-	} {
+		"protonmail.list_folders",
+		"protonmail.mark_read",
+		"protonmail.mark_unread",
+		"protonmail.flag",
+		"protonmail.unflag",
+		"protonmail.move_to_folder",
+		"protonmail.delete",
+	}
+	if len(m.Actions) != len(expectedActions) {
+		t.Fatalf("Manifest().Actions has %d items, want %d", len(m.Actions), len(expectedActions))
+	}
+
+	actionTypes := make(map[string]bool)
+	for _, a := range m.Actions {
+		actionTypes[a.ActionType] = true
+	}
+	for _, want := range expectedActions {
 		if !actionTypes[want] {
 			t.Errorf("Manifest().Actions missing %q", want)
 		}

--- a/connectors/protonmail/resolve_resource_details.go
+++ b/connectors/protonmail/resolve_resource_details.go
@@ -25,6 +25,13 @@ func (c *ProtonMailConnector) ResolveResourceDetails(ctx context.Context, action
 		return c.resolveArchiveEmailDetails(ctx, params, creds)
 	case "protonmail.reply_email":
 		return c.resolveReplyEmailDetails(ctx, params, creds)
+	case "protonmail.mark_read",
+		"protonmail.mark_unread",
+		"protonmail.flag",
+		"protonmail.unflag",
+		"protonmail.move_to_folder",
+		"protonmail.delete":
+		return c.resolveUIDMessageDetails(ctx, params, creds)
 	default:
 		return nil, nil
 	}
@@ -76,6 +83,17 @@ func (c *ProtonMailConnector) resolveReplyEmailDetails(ctx context.Context, para
 	return map[string]any{"in_reply_to": meta.asMap()}, nil
 }
 
+func (c *ProtonMailConnector) resolveUIDMessageDetails(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	uidParams, err := parseUIDMessageParams(params)
+	if err != nil {
+		return nil, nil
+	}
+	if err := uidParams.validate(); err != nil {
+		return nil, nil
+	}
+	return c.resolveMessageDetailsForUIDs(ctx, creds, uidParams.Folder, uidParams.MessageIDs)
+}
+
 func (c *ProtonMailConnector) resolveArchiveEmailDetails(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
 	archiveParams, err := parseArchiveParams(params)
 	if err != nil {
@@ -85,20 +103,24 @@ func (c *ProtonMailConnector) resolveArchiveEmailDetails(ctx context.Context, pa
 		return nil, nil
 	}
 
-	metaByUID, err := resolveMessageEnvelopes(ctx, c, creds, archiveParams.Folder, archiveParams.MessageIDs, connectors.MailboxUIDValidityFromContext(ctx))
+	return c.resolveMessageDetailsForUIDs(ctx, creds, archiveParams.Folder, archiveParams.MessageIDs)
+}
+
+func (c *ProtonMailConnector) resolveMessageDetailsForUIDs(ctx context.Context, creds connectors.Credentials, folder string, messageIDs []uint32) (map[string]any, error) {
+	metaByUID, err := resolveMessageEnvelopes(ctx, c, creds, folder, messageIDs, connectors.MailboxUIDValidityFromContext(ctx))
 	if err != nil || len(metaByUID) == 0 {
 		return nil, nil
 	}
 
-	if len(archiveParams.MessageIDs) == 1 {
-		if meta, ok := metaByUID[archiveParams.MessageIDs[0]]; ok {
+	if len(messageIDs) == 1 {
+		if meta, ok := metaByUID[messageIDs[0]]; ok {
 			return meta.asMap(), nil
 		}
 		return nil, nil
 	}
 
 	messages := make(map[string]any, len(metaByUID))
-	for _, id := range archiveParams.MessageIDs {
+	for _, id := range messageIDs {
 		if meta, ok := metaByUID[id]; ok {
 			messages[fmt.Sprintf("%d", id)] = meta.asMap()
 		}

--- a/connectors/protonmail/resolve_resource_details.go
+++ b/connectors/protonmail/resolve_resource_details.go
@@ -99,7 +99,7 @@ func (c *ProtonMailConnector) resolveArchiveEmailDetails(ctx context.Context, pa
 	if err != nil {
 		return nil, nil
 	}
-	if err := archiveParams.validate(); err != nil {
+	if err := validateArchiveParams(archiveParams); err != nil {
 		return nil, nil
 	}
 

--- a/connectors/protonmail/resolve_resource_details_test.go
+++ b/connectors/protonmail/resolve_resource_details_test.go
@@ -86,8 +86,6 @@ func TestResolveResourceDetails_ReadEmail_PopulatesMetadata(t *testing.T) {
 }
 
 func TestResolveResourceDetails_ReadEmail_FailureFallsBack(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 
@@ -171,8 +169,6 @@ func TestResolveResourceDetails_ArchiveEmail_BatchKeyedByHandle(t *testing.T) {
 }
 
 func TestResolveResourceDetails_PassesMailboxStoreFromContext(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 

--- a/connectors/protonmail/resolve_resource_details_test.go
+++ b/connectors/protonmail/resolve_resource_details_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestResolveResourceDetails_ReplyEmail_NestsInReplyTo(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 
@@ -46,8 +44,6 @@ func TestResolveResourceDetails_ReplyEmail_NestsInReplyTo(t *testing.T) {
 }
 
 func TestResolveResourceDetails_ReadEmail_PopulatesMetadata(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 
@@ -111,8 +107,6 @@ func TestResolveResourceDetails_ReadEmail_FailureFallsBack(t *testing.T) {
 }
 
 func TestResolveResourceDetails_ArchiveEmail_SingleUsesFlatFields(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 
@@ -138,8 +132,6 @@ func TestResolveResourceDetails_ArchiveEmail_SingleUsesFlatFields(t *testing.T) 
 }
 
 func TestResolveResourceDetails_ArchiveEmail_BatchKeyedByHandle(t *testing.T) {
-	t.Parallel()
-
 	orig := resolveMessageEnvelopes
 	t.Cleanup(func() { resolveMessageEnvelopes = orig })
 

--- a/connectors/protonmail/store_message_flags.go
+++ b/connectors/protonmail/store_message_flags.go
@@ -1,0 +1,83 @@
+package protonmail
+
+import (
+	"context"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type storeMessageFlagsAction struct {
+	conn       *ProtonMailConnector
+	actionType string
+	op         imap.StoreFlagsOp
+	flags      []imap.Flag
+	status     string
+}
+
+func (a *storeMessageFlagsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseUIDMessageParams(req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	err = executeUIDMessageAction(ctx, a.conn, req, params, func(session *imapSession, uidSet imap.UIDSet) error {
+		if err := storeMessageFlags(session, uidSet, a.op, a.flags); err != nil {
+			return mapUIDNotFoundError(err, params.Folder)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"status":      a.status,
+		"folder":      params.Folder,
+		"updated":     len(params.MessageIDs),
+		"message_ids": params.MessageIDs,
+	})
+}
+
+func newMarkReadAction(conn *ProtonMailConnector) connectors.Action {
+	return &storeMessageFlagsAction{
+		conn:       conn,
+		actionType: "protonmail.mark_read",
+		op:         imap.StoreFlagsAdd,
+		flags:      []imap.Flag{imap.FlagSeen},
+		status:     "marked_read",
+	}
+}
+
+func newMarkUnreadAction(conn *ProtonMailConnector) connectors.Action {
+	return &storeMessageFlagsAction{
+		conn:       conn,
+		actionType: "protonmail.mark_unread",
+		op:         imap.StoreFlagsDel,
+		flags:      []imap.Flag{imap.FlagSeen},
+		status:     "marked_unread",
+	}
+}
+
+func newFlagAction(conn *ProtonMailConnector) connectors.Action {
+	return &storeMessageFlagsAction{
+		conn:       conn,
+		actionType: "protonmail.flag",
+		op:         imap.StoreFlagsAdd,
+		flags:      []imap.Flag{imap.FlagFlagged},
+		status:     "flagged",
+	}
+}
+
+func newUnflagAction(conn *ProtonMailConnector) connectors.Action {
+	return &storeMessageFlagsAction{
+		conn:       conn,
+		actionType: "protonmail.unflag",
+		op:         imap.StoreFlagsDel,
+		flags:      []imap.Flag{imap.FlagFlagged},
+		status:     "unflagged",
+	}
+}

--- a/connectors/protonmail/uid_message_action.go
+++ b/connectors/protonmail/uid_message_action.go
@@ -1,0 +1,58 @@
+package protonmail
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// executeUIDMessageAction runs a read-write mailbox operation that requires
+// UIDVALIDITY verification and a UID set derived from message parameters.
+func executeUIDMessageAction(
+	ctx context.Context,
+	conn *ProtonMailConnector,
+	req connectors.ActionRequest,
+	params *uidMessageParams,
+	run func(session *imapSession, uidSet imap.UIDSet) error,
+) error {
+	session, err := connectIMAP(req.Credentials, conn.timeout)
+	if err != nil {
+		return err
+	}
+	defer session.close()
+
+	mboxData, err := session.selectMailboxReadWrite(params.Folder)
+	if err != nil {
+		return err
+	}
+	if err := syncUIDValidity(params.Folder, mboxData, req.MailboxUIDValidity, uidValidityVerify); err != nil {
+		return err
+	}
+
+	return run(session, uidSetFromMessageIDs(params.MessageIDs))
+}
+
+func mapUIDNotFoundError(err error, folder string) error {
+	if err == nil {
+		return nil
+	}
+	errMsg := err.Error()
+	if strings.Contains(strings.ToUpper(errMsg), "UID") || strings.Contains(strings.ToLower(errMsg), "not found") {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("one or more message UIDs not found in folder %q", folder),
+		}
+	}
+	return mapIMAPError(err)
+}
+
+func storeMessageFlags(session *imapSession, uidSet imap.UIDSet, op imap.StoreFlagsOp, flags []imap.Flag) error {
+	storeCmd := session.client.Store(uidSet, &imap.StoreFlags{
+		Op:     op,
+		Flags:  flags,
+		Silent: true,
+	}, nil)
+	return storeCmd.Close()
+}

--- a/connectors/protonmail/uid_message_params.go
+++ b/connectors/protonmail/uid_message_params.go
@@ -1,0 +1,87 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// uidMessageRaw handles flexible JSON input: accepts either a single integer
+// for message_id or an array for message_ids.
+type uidMessageRaw struct {
+	MessageID  *uint32         `json:"message_id,omitempty"`
+	MessageIDs json.RawMessage `json:"message_ids,omitempty"`
+	Folder     string          `json:"folder"`
+}
+
+// uidMessageParams normalizes UID-scoped message actions.
+type uidMessageParams struct {
+	MessageIDs []uint32 `json:"-"`
+	Folder     string   `json:"folder"`
+}
+
+func parseUIDMessageParams(raw []byte) (*uidMessageParams, error) {
+	var r uidMessageRaw
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+
+	params := &uidMessageParams{Folder: r.Folder}
+
+	if len(r.MessageIDs) > 0 && string(r.MessageIDs) != "null" {
+		if err := json.Unmarshal(r.MessageIDs, &params.MessageIDs); err != nil {
+			return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid message_ids: %v", err)}
+		}
+	}
+
+	if r.MessageID != nil {
+		params.MessageIDs = append(params.MessageIDs, *r.MessageID)
+	}
+
+	return params, nil
+}
+
+func (p *uidMessageParams) validate() error {
+	if len(p.MessageIDs) == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: provide message_id (single) or message_ids (array)"}
+	}
+
+	p.MessageIDs = deduplicateUint32(p.MessageIDs)
+
+	if len(p.MessageIDs) > maxLimit {
+		return &connectors.ValidationError{Message: fmt.Sprintf("too many message_ids: maximum is %d", maxLimit)}
+	}
+	for _, id := range p.MessageIDs {
+		if id == 0 {
+			return &connectors.ValidationError{Message: "message_ids must not contain zero values"}
+		}
+	}
+	if p.Folder == "" {
+		p.Folder = "INBOX"
+	}
+	return nil
+}
+
+func uidSetFromMessageIDs(ids []uint32) imap.UIDSet {
+	var uidSet imap.UIDSet
+	for _, id := range ids {
+		uidSet.AddNum(imap.UID(id))
+	}
+	return uidSet
+}
+
+// deduplicateUint32 returns a new slice with duplicate values removed,
+// preserving the original order.
+func deduplicateUint32(ids []uint32) []uint32 {
+	seen := make(map[uint32]struct{}, len(ids))
+	out := make([]uint32, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
+}

--- a/connectors/protonmail/uid_message_params_test.go
+++ b/connectors/protonmail/uid_message_params_test.go
@@ -22,8 +22,11 @@ func TestParseUIDMessageParams_SingleID(t *testing.T) {
 func TestParseUIDMessageParams_MissingIDs(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseUIDMessageParams([]byte(`{"folder": "INBOX"}`))
-	if err == nil {
+	params, err := parseUIDMessageParams([]byte(`{"folder": "INBOX"}`))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := params.validate(); err == nil {
 		t.Fatal("expected validation error")
 	}
 	if !connectors.IsValidationError(err) {

--- a/connectors/protonmail/uid_message_params_test.go
+++ b/connectors/protonmail/uid_message_params_test.go
@@ -26,11 +26,12 @@ func TestParseUIDMessageParams_MissingIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if err := params.validate(); err == nil {
+	valErr := params.validate()
+	if valErr == nil {
 		t.Fatal("expected validation error")
 	}
-	if !connectors.IsValidationError(err) {
-		t.Fatalf("expected ValidationError, got %T", err)
+	if !connectors.IsValidationError(valErr) {
+		t.Fatalf("expected ValidationError, got %T", valErr)
 	}
 }
 

--- a/connectors/protonmail/uid_message_params_test.go
+++ b/connectors/protonmail/uid_message_params_test.go
@@ -1,0 +1,91 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestParseUIDMessageParams_SingleID(t *testing.T) {
+	t.Parallel()
+
+	params, err := parseUIDMessageParams([]byte(`{"message_id": 5, "folder": "INBOX"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.MessageIDs) != 1 || params.MessageIDs[0] != 5 {
+		t.Fatalf("expected [5], got %v", params.MessageIDs)
+	}
+}
+
+func TestParseUIDMessageParams_MissingIDs(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseUIDMessageParams([]byte(`{"folder": "INBOX"}`))
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestMoveToFolderParams_MissingTarget(t *testing.T) {
+	t.Parallel()
+
+	params, err := parseMoveToFolderParams([]byte(`{"message_id": 5}`))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := params.validate(); err == nil {
+		t.Fatal("expected validation error for missing target_folder")
+	}
+}
+
+func TestMoveToFolderParams_SameFolder(t *testing.T) {
+	t.Parallel()
+
+	raw, _ := json.Marshal(map[string]any{
+		"message_id":    5,
+		"folder":        "INBOX",
+		"target_folder": "INBOX",
+	})
+	params, err := parseMoveToFolderParams(raw)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := params.validate(); err == nil {
+		t.Fatal("expected validation error for identical folders")
+	}
+}
+
+func TestDeleteEmailParams_RejectsTrashFolder(t *testing.T) {
+	t.Parallel()
+
+	params, err := parseUIDMessageParams([]byte(`{"message_id": 5, "folder": "Trash"}`))
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	action := &deleteEmailAction{conn: New()}
+	_, err = action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.delete",
+		Parameters:  mustJSON(t, map[string]any{"message_id": params.MessageIDs[0], "folder": params.Folder}),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected validation error for Trash folder")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/frontend/src/components/ActionPreviewSummary.stories.tsx
+++ b/frontend/src/components/ActionPreviewSummary.stories.tsx
@@ -94,6 +94,40 @@ export const GoogleReadEmail: Story = {
   },
 };
 
+export const ProtonmailSendEmail: Story = {
+  name: "protonmail.send_email",
+  args: {
+    actionType: "protonmail.send_email",
+    parameters: {
+      to: ["alice@example.com", "bob@example.com"],
+      subject: "Vendor follow-up",
+      body: "Hi,\n\nFollowing up on our conversation yesterday.",
+    },
+    schema: null,
+    actionName: "Send Email",
+  },
+};
+
+export const ProtonmailReadInbox: Story = {
+  name: "protonmail.read_inbox",
+  args: {
+    actionType: "protonmail.read_inbox",
+    parameters: { folder: "INBOX", limit: 10 },
+    schema: null,
+    actionName: "Read Inbox",
+  },
+};
+
+export const ProtonmailSearchEmails: Story = {
+  name: "protonmail.search_emails",
+  args: {
+    actionType: "protonmail.search_emails",
+    parameters: { folder: "INBOX", subject: "invoice", from: "acme.com" },
+    schema: null,
+    actionName: "Search Emails",
+  },
+};
+
 export const ProtonmailReadEmail: Story = {
   name: "protonmail.read_email",
   args: {

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -378,6 +378,51 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
 
   // ── Proton Mail ─────────────────────────────────────────────────
 
+  "protonmail.send_email": (params) => {
+    const to = formatRecipients(params.to);
+    const subject = strVal(params.subject);
+    if (!to) return null;
+    const parts: SummaryPart[] = [text("Send email to "), val(to)];
+    if (subject) parts.push(text(" — "), val(subject));
+    return parts;
+  },
+
+  "protonmail.read_inbox": (params) => {
+    const folder = strVal(params.folder) ?? "INBOX";
+    const limit =
+      typeof params.limit === "number" && Number.isFinite(params.limit)
+        ? params.limit
+        : 10;
+    const parts: SummaryPart[] = [
+      text("Read "),
+      val(String(limit)),
+      text(" most recent in "),
+      val(folder),
+    ];
+    if (params.unread_only === true) {
+      parts.push(text(" (unread only)"));
+    }
+    return parts;
+  },
+
+  "protonmail.search_emails": (params) => {
+    const folder = strVal(params.folder) ?? "INBOX";
+    const parts: SummaryPart[] = [text("Search "), val(folder)];
+    const filters: string[] = [];
+    const subject = strVal(params.subject);
+    if (subject) filters.push(`'${subject}'`);
+    const from = strVal(params.from);
+    if (from) filters.push(`from ${from}`);
+    const since = strVal(params.since);
+    if (since) filters.push(`since ${since}`);
+    const before = strVal(params.before);
+    if (before) filters.push(`before ${before}`);
+    if (filters.length > 0) {
+      parts.push(text(" for "), val(filters.join(", ")));
+    }
+    return parts;
+  },
+
   "protonmail.read_email": (_params, rd) => {
     if (!rd) return null;
     const summary = protonmailEmailSummaryParts(rd);
@@ -402,6 +447,21 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
     if (!summary) return null;
     return [text("Reply to "), ...summary];
   },
+
+  "protonmail.list_folders": () => [text("List mailbox folders")],
+
+  "protonmail.mark_read": (_params, rd) => protonmailUIDActionSummary("Mark as read", rd),
+  "protonmail.mark_unread": (_params, rd) => protonmailUIDActionSummary("Mark as unread", rd),
+  "protonmail.flag": (_params, rd) => protonmailUIDActionSummary("Flag email", rd),
+  "protonmail.unflag": (_params, rd) => protonmailUIDActionSummary("Unflag email", rd),
+
+  "protonmail.move_to_folder": (params, rd) => {
+    const target = strVal(params.target_folder);
+    const summary = protonmailUIDActionSummary("Move email", rd, target ? ` to ${target}` : null);
+    return summary;
+  },
+
+  "protonmail.delete": (_params, rd) => protonmailUIDActionSummary("Delete email", rd),
 };
 
 // ---------------------------------------------------------------------------
@@ -574,6 +634,63 @@ function protonmailInReplyToRecord(
   return null;
 }
 
+function protonmailUIDActionSummary(
+  prefix: string,
+  rd: Record<string, unknown> | null | undefined,
+  suffix?: string | null,
+): SummaryPart[] | null {
+  if (!rd) {
+    if (suffix) return [text(prefix), text(suffix)];
+    return [text(prefix)];
+  }
+  const batch = protonmailBatchEmailSummaryParts(rd);
+  if (batch) {
+    const parts: SummaryPart[] = [text(prefix), ...batch];
+    if (suffix) parts.push(text(suffix));
+    return parts;
+  }
+  const summary = protonmailEmailSummaryParts(rd);
+  if (!summary) {
+    if (suffix) return [text(prefix), text(suffix)];
+    return [text(prefix)];
+  }
+  const parts: SummaryPart[] = [text(`${prefix} `), ...summary];
+  if (suffix) parts.push(text(suffix));
+  return parts;
+}
+
+function protonmailBatchEmailSummaryParts(
+  rd: Record<string, unknown>,
+): SummaryPart[] | null {
+  const rawMessages = rd.messages;
+  if (rawMessages == null || typeof rawMessages !== "object" || Array.isArray(rawMessages)) {
+    return null;
+  }
+  const entries = Object.entries(rawMessages as Record<string, unknown>);
+  if (entries.length <= 1) return null;
+
+  const subjects = entries
+    .map(([, meta]) =>
+      meta != null && typeof meta === "object"
+        ? strVal((meta as Record<string, unknown>).subject)
+        : null,
+    )
+    .filter((s): s is string => s != null);
+  if (subjects.length === 0) return null;
+
+  const parts: SummaryPart[] = [
+    text(" "),
+    val(String(entries.length)),
+    text(" emails"),
+  ];
+  const preview =
+    subjects.length <= 2
+      ? subjects.join("; ")
+      : `${subjects.slice(0, 2).join("; ")} and ${subjects.length - 2} more`;
+  parts.push(text(": "), val(truncate(preview, 80)));
+  return parts;
+}
+
 function protonmailEmailSummaryParts(
   meta: Record<string, unknown>,
 ): SummaryPart[] | null {
@@ -588,34 +705,9 @@ function protonmailEmailSummaryParts(
 function protonmailBatchArchiveSummaryParts(
   rd: Record<string, unknown>,
 ): SummaryPart[] | null {
-  const rawMessages = rd.messages;
-  if (rawMessages == null || typeof rawMessages !== "object" || Array.isArray(rawMessages)) {
-    return null;
-  }
-  const entries = Object.entries(rawMessages as Record<string, unknown>);
-  if (entries.length <= 1) {
-    return null;
-  }
-  const subjects = entries
-    .map(([, meta]) =>
-      meta != null && typeof meta === "object"
-        ? strVal((meta as Record<string, unknown>).subject)
-        : null,
-    )
-    .filter((s): s is string => s != null);
-  if (subjects.length === 0) return null;
-
-  const parts: SummaryPart[] = [
-    text("Archive "),
-    val(String(entries.length)),
-    text(" emails"),
-  ];
-  const preview =
-    subjects.length <= 2
-      ? subjects.join("; ")
-      : `${subjects.slice(0, 2).join("; ")} and ${subjects.length - 2} more`;
-  parts.push(text(": "), val(truncate(preview, 80)));
-  return parts;
+  const batch = protonmailBatchEmailSummaryParts(rd);
+  if (!batch) return null;
+  return [text("Archive"), ...batch];
 }
 
 function formatCurrency(amount: unknown, currency: string): string {

--- a/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
+++ b/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
@@ -430,6 +430,63 @@ describe("buildSummary", () => {
 
   // ── Proton Mail ─────────────────────────────────────────────────
 
+  describe("protonmail.send_email", () => {
+    it("shows recipients and subject", () => {
+      const result = buildSummary(
+        "protonmail.send_email",
+        {
+          to: ["alice@example.com", "bob@example.com"],
+          subject: "Project update",
+          body: "Hello",
+        },
+        null,
+        "Send Email",
+      );
+      expect(result).toContain("Send email to");
+      expect(result).toContain("alice@example.com");
+      expect(result).toContain("Project update");
+    });
+  });
+
+  describe("protonmail.read_inbox", () => {
+    it("shows folder and limit", () => {
+      const result = buildSummary(
+        "protonmail.read_inbox",
+        { folder: "INBOX", limit: 10 },
+        null,
+        "Read Inbox",
+      );
+      expect(result).toContain("Read");
+      expect(result).toContain("10");
+      expect(result).toContain("INBOX");
+    });
+
+    it("notes unread-only filter", () => {
+      const result = buildSummary(
+        "protonmail.read_inbox",
+        { folder: "INBOX", limit: 5, unread_only: true },
+        null,
+        "Read Inbox",
+      );
+      expect(result).toContain("unread only");
+    });
+  });
+
+  describe("protonmail.search_emails", () => {
+    it("shows folder and search filters", () => {
+      const result = buildSummary(
+        "protonmail.search_emails",
+        { folder: "INBOX", subject: "invoice", from: "acme.com" },
+        null,
+        "Search Emails",
+      );
+      expect(result).toContain("Search");
+      expect(result).toContain("INBOX");
+      expect(result).toContain("invoice");
+      expect(result).toContain("acme.com");
+    });
+  });
+
   describe("protonmail.read_email", () => {
     it("shows subject and sender from resourceDetails", () => {
       const result = buildSummary(
@@ -525,6 +582,49 @@ describe("buildSummary", () => {
       expect(result).toContain("Reply to");
       expect(result).toContain("Question");
       expect(result).toContain("asker@example.com");
+    });
+  });
+
+  describe("protonmail.mark_read", () => {
+    it("shows enriched subject", () => {
+      const result = buildSummary(
+        "protonmail.mark_read",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        null,
+        undefined,
+        { subject: "Unread notice", from: ["alerts@example.com"] },
+      );
+      expect(result).toContain("Mark as read");
+      expect(result).toContain("Unread notice");
+    });
+  });
+
+  describe("protonmail.move_to_folder", () => {
+    it("shows target folder", () => {
+      const result = buildSummary(
+        "protonmail.move_to_folder",
+        { message_id: 10, folder: "INBOX", target_folder: "Archive" },
+        null,
+        null,
+        undefined,
+        { subject: "Move me" },
+      );
+      expect(result).toContain("Move email");
+      expect(result).toContain("Move me");
+      expect(result).toContain("Archive");
+    });
+  });
+
+  describe("protonmail.list_folders", () => {
+    it("shows list folders label", () => {
+      const result = buildSummary(
+        "protonmail.list_folders",
+        {},
+        null,
+        "List Folders",
+      );
+      expect(result).toBe("List mailbox folders");
     });
   });
 

--- a/frontend/src/components/previews/ActionPreviewCard.stories.tsx
+++ b/frontend/src/components/previews/ActionPreviewCard.stories.tsx
@@ -42,6 +42,23 @@ export const EventLayout: Story = {
 // Message layout
 // ---------------------------------------------------------------------------
 
+export const ProtonSendEmailLayout: Story = {
+  args: {
+    preview: {
+      layout: "message",
+      fields: { to: "to", subject: "subject", body: "body" },
+    },
+    parameters: {
+      to: ["alice@example.com", "bob@example.com"],
+      subject: "Contract review",
+      body: "Please review the attached contract before Friday.",
+    },
+    actionType: "protonmail.send_email",
+    schema: null,
+    actionName: "Send Email",
+  },
+};
+
 export const MessageLayout: Story = {
   args: {
     preview: {

--- a/frontend/src/components/previews/MessagePreviewLayout.stories.tsx
+++ b/frontend/src/components/previews/MessagePreviewLayout.stories.tsx
@@ -10,6 +10,17 @@ const meta: Meta<typeof MessagePreviewLayout> = {
 export default meta;
 type Story = StoryObj<typeof MessagePreviewLayout>;
 
+export const ProtonEmailRecipients: Story = {
+  args: {
+    parameters: {
+      to: ["alice@example.com", "bob@example.com", "team@example.com"],
+      subject: "Proton send approval preview",
+      body: "This preview renders array recipients from protonmail.send_email.",
+    },
+    fields: { to: "to", subject: "subject", body: "body" },
+  },
+};
+
 export const EmailMessage: Story = {
   args: {
     parameters: {

--- a/frontend/src/components/previews/MessagePreviewLayout.tsx
+++ b/frontend/src/components/previews/MessagePreviewLayout.tsx
@@ -1,6 +1,17 @@
 import { Mail } from "lucide-react";
 import { truncate } from "@/lib/formatValues";
 
+function formatMessageRecipient(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (Array.isArray(value)) {
+    const recipients = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+    if (recipients.length === 0) return null;
+    if (recipients.length <= 3) return recipients.join(", ");
+    return `${recipients[0]}, ${recipients[1]}, and ${recipients.length - 2} more`;
+  }
+  return null;
+}
+
 interface MessagePreviewLayoutProps {
   parameters: Record<string, unknown>;
   fields: Record<string, string>;
@@ -10,10 +21,7 @@ export function MessagePreviewLayout({
   parameters,
   fields,
 }: MessagePreviewLayoutProps) {
-  const to =
-    typeof parameters[fields.to ?? ""] === "string"
-      ? (parameters[fields.to ?? ""] as string)
-      : null;
+  const to = formatMessageRecipient(parameters[fields.to ?? ""]);
   const subject =
     typeof parameters[fields.subject ?? ""] === "string"
       ? (parameters[fields.subject ?? ""] as string)

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -133,6 +133,36 @@ describe("buildActionSummary", () => {
     expect(result).toContain("U12345678");
   });
 
+  it("formats protonmail.send_email", () => {
+    const result = buildActionSummary("protonmail.send_email", {
+      to: ["alice@example.com"],
+      subject: "Hello",
+      body: "Body",
+    });
+    expect(result).toContain("Send email to");
+    expect(result).toContain("alice@example.com");
+    expect(result).toContain("Hello");
+  });
+
+  it("formats protonmail.read_inbox", () => {
+    const result = buildActionSummary("protonmail.read_inbox", {
+      folder: "INBOX",
+      limit: 10,
+    });
+    expect(result).toContain("Read 10 most recent in INBOX");
+  });
+
+  it("formats protonmail.search_emails", () => {
+    const result = buildActionSummary("protonmail.search_emails", {
+      folder: "INBOX",
+      subject: "invoice",
+      from: "acme.com",
+    });
+    expect(result).toContain("Search INBOX");
+    expect(result).toContain("invoice");
+    expect(result).toContain("acme.com");
+  });
+
   it("formats protonmail.read_email with enriched metadata", () => {
     const result = buildActionSummary(
       "protonmail.read_email",

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -212,7 +212,7 @@ function protonmailEmailSummary(
   return result;
 }
 
-function protonmailBatchArchiveSummary(rd: Record<string, unknown>): string | null {
+function protonmailBatchEmailSummary(rd: Record<string, unknown>): string | null {
   const rawMessages = rd.messages;
   if (rawMessages == null || typeof rawMessages !== "object" || Array.isArray(rawMessages)) {
     return null;
@@ -233,7 +233,26 @@ function protonmailBatchArchiveSummary(rd: Record<string, unknown>): string | nu
     subjects.length <= 2
       ? subjects.join("; ")
       : `${subjects.slice(0, 2).join("; ")} and ${subjects.length - 2} more`;
-  return `Archive ${String(entries.length)} emails: \u201C${truncate(preview, 80)}\u201D`;
+  return ` ${String(entries.length)} emails: \u201C${truncate(preview, 80)}\u201D`;
+}
+
+function protonmailBatchArchiveSummary(rd: Record<string, unknown>): string | null {
+  const batch = protonmailBatchEmailSummary(rd);
+  if (!batch) return null;
+  return `Archive${batch}`;
+}
+
+function protonmailUIDActionSummary(
+  prefix: string,
+  rd: Record<string, unknown> | null | undefined,
+  suffix?: string | null,
+): string | null {
+  if (!rd) return suffix ? `${prefix}${suffix}` : prefix;
+  const batch = protonmailBatchEmailSummary(rd);
+  if (batch) return `${prefix}${batch}${suffix ?? ""}`;
+  const summary = protonmailEmailSummary(prefix, rd);
+  if (!summary) return suffix ? `${prefix}${suffix}` : prefix;
+  return suffix ? `${summary}${suffix}` : summary;
 }
 
 /** Formats a recipient list (string or string[]) for display in email summaries. */
@@ -302,6 +321,42 @@ const ACTION_FORMATTERS: Record<string, ActionFormatter> = {
     return result;
   },
 
+  "protonmail.send_email": (params) => {
+    const to = formatRecipients(params.to);
+    const subject = strVal(params.subject);
+    if (!to) return null;
+    let result = `Send email to ${to}`;
+    if (subject) result += ` \u2014 ${truncate(subject, 60)}`;
+    return result;
+  },
+
+  "protonmail.read_inbox": (params) => {
+    const folder = strVal(params.folder) ?? "INBOX";
+    const limit =
+      typeof params.limit === "number" && Number.isFinite(params.limit)
+        ? params.limit
+        : 10;
+    let result = `Read ${String(limit)} most recent in ${folder}`;
+    if (params.unread_only === true) result += " (unread only)";
+    return result;
+  },
+
+  "protonmail.search_emails": (params) => {
+    const folder = strVal(params.folder) ?? "INBOX";
+    const filters: string[] = [];
+    const subject = strVal(params.subject);
+    if (subject) filters.push(`'${subject}'`);
+    const from = strVal(params.from);
+    if (from) filters.push(`from ${from}`);
+    const since = strVal(params.since);
+    if (since) filters.push(`since ${since}`);
+    const before = strVal(params.before);
+    if (before) filters.push(`before ${before}`);
+    let result = `Search ${folder}`;
+    if (filters.length > 0) result += ` for ${filters.join(", ")}`;
+    return result;
+  },
+
   "protonmail.read_email": (_params, rd) => {
     if (!rd) return null;
     return protonmailEmailSummary("Read email", rd);
@@ -322,6 +377,21 @@ const ACTION_FORMATTERS: Record<string, ActionFormatter> = {
     }
     return protonmailEmailSummary("Reply to", raw as Record<string, unknown>);
   },
+
+  "protonmail.list_folders": () => "List mailbox folders",
+
+  "protonmail.mark_read": (_params, rd) => protonmailUIDActionSummary("Mark as read", rd),
+  "protonmail.mark_unread": (_params, rd) => protonmailUIDActionSummary("Mark as unread", rd),
+  "protonmail.flag": (_params, rd) => protonmailUIDActionSummary("Flag email", rd),
+  "protonmail.unflag": (_params, rd) => protonmailUIDActionSummary("Unflag email", rd),
+
+  "protonmail.move_to_folder": (params, rd) => {
+    const target = strVal(params.target_folder);
+    const suffix = target ? ` to ${target}` : null;
+    return protonmailUIDActionSummary("Move email", rd, suffix);
+  },
+
+  "protonmail.delete": (_params, rd) => protonmailUIDActionSummary("Delete email", rd),
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Phase 1:** `protonmail.send_email` now uses a message preview card (To / Subject / Body) matching Google, plus web/mobile approval summaries. `send_email` remains **high** risk.
- **Phase 2:** Human-readable approval summaries for `read_inbox` and `search_emails` on web and mobile.
- **Phase 3:** New IMAP actions — `list_folders`, `mark_read`/`mark_unread`, `flag`/`unflag`, `move_to_folder`, `delete` (Trash) — each with manifest schema, display templates, UIDVALIDITY guards, resource-detail enrichment for UID-based actions, and web/mobile describers.

`MessagePreviewLayout` now formats array `to` recipients so Proton send previews render correctly.

Closes #1310

## Test plan

### Claude Code
- [x] `cd frontend && npx vitest run src/components/__tests__/ActionPreviewSummary.test.tsx` (50 tests)
- [x] `cd mobile && npm test -- --ci src/screens/approvals/__tests__/approvalUtils.test.ts`
- [x] `gofmt` + parse check on new/changed Go connector files
- [ ] CI `make test-backend` (not run locally — sandbox Go module resolution constraint)

### OpenClaw
- [ ] Approve a `protonmail.send_email` action and confirm the message preview card shows recipients, subject, and body
- [ ] Exercise new email-management actions against a live Proton Bridge instance (mark read/unread, flag, move, delete, list folders)

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d02fdcb3-9b5a-493d-b72d-5340b1d20c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d02fdcb3-9b5a-493d-b72d-5340b1d20c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

