### PR TITLE
Make redeploy.sh sudo usage adaptive

### DIFF
--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -10,6 +10,10 @@
 #
 #   PS_SERVICE=my-unit scripts/redeploy.sh
 #
+# Target a user-level unit (systemctl --user) instead of a system unit:
+#
+#   PS_SYSTEMCTL_ARGS=--user scripts/redeploy.sh
+#
 # Safety: the running server is only ever replaced by a SUCCESSFUL build. A
 # failed `git pull` (e.g. a transient network blip) or a failed dependency
 # install is non-fatal — the script falls back to rebuilding the current
@@ -47,7 +51,16 @@ make build
 
 echo "==> Restarting service: $SERVICE"
 if command -v systemctl >/dev/null 2>&1; then
-  sudo systemctl restart "$SERVICE"
+  # Use sudo only when not already root and sudo is available — restarting a
+  # system unit needs root, but a root deploy job (or a passwordless-sudo-less
+  # box) shouldn't trip over a hardcoded `sudo`.
+  SUDO=""
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  fi
+  # PS_SYSTEMCTL_ARGS lets you target a user unit, e.g.
+  #   PS_SYSTEMCTL_ARGS=--user scripts/redeploy.sh
+  $SUDO systemctl ${PS_SYSTEMCTL_ARGS:-} restart "$SERVICE"
 else
   echo "    systemctl not found — restart your server process manually." >&2
 fi


### PR DESCRIPTION
## Summary

`scripts/redeploy.sh` hardcoded `sudo systemctl restart` for the service restart. Restarting a *system* systemd unit does need root, but the hardcoded `sudo` broke two valid setups:

- A deploy already running as **root** — `sudo` is redundant, and on a minimal box `sudo` may not even be installed, so the restart would fail.
- **User-level units** (`systemctl --user`) — these don't need root at all, and the hardcoded system invocation targets the wrong systemd instance.

This change makes the privileged restart adaptive:

- Use `sudo` **only** when not already root *and* `sudo` is available.
- Add `PS_SYSTEMCTL_ARGS` so a user unit can be targeted: `PS_SYSTEMCTL_ARGS=--user scripts/redeploy.sh`.
- Document the new override in the script header.

The standard self-hosted (system service) path is unchanged — it still restarts via `sudo`.

## Test plan

- [x] `bash -n scripts/redeploy.sh` — syntax check passes
- [ ] Manual: run on a system-service host (uses sudo), as root (no sudo), and against a `--user` unit

Shell-only change; no Go/frontend tests apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_0112PCFFxctmJCauw4uaSxyi)_