### PR TITLE
Proton Mail: fix SMTP STARTTLS against Bridge's self-signed cert

### DIFF
--- a/connectors/protonmail/health_check.go
+++ b/connectors/protonmail/health_check.go
@@ -2,7 +2,6 @@ package protonmail
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -48,8 +47,7 @@ var testSMTPConn = func(creds connectors.Credentials, timeout time.Duration) err
 	defer client.Close()
 
 	if ok, _ := client.Extension("STARTTLS"); ok {
-		tlsConfig := &tls.Config{ServerName: host}
-		if err := client.StartTLS(tlsConfig); err != nil {
+		if err := client.StartTLS(smtpTLSConfig(host)); err != nil {
 			return &connectors.ExternalError{Message: fmt.Sprintf("SMTP STARTTLS failed: %v", err)}
 		}
 	}
@@ -100,9 +98,12 @@ func mapDialError(proto string, err error) error {
 	return &connectors.ExternalError{Message: fmt.Sprintf("%s connection failed: %v", proto, err)}
 }
 
+// mapBridgeAuthMessage reports which protocol the proxy rejected and the
+// server's actual response, with the most common cause as a hint — auth can
+// fail for reasons other than a wrong password (e.g. the Bridge instance
+// serving the port has no account logged in), so don't assert one cause.
 func mapBridgeAuthMessage(proto string, err error) string {
-	_ = proto
-	return fmt.Sprintf("Wrong Bridge password (not your Proton account password). Run protonmail-bridge info to get the correct password. (%v)", err)
+	return fmt.Sprintf("%s authentication rejected by Bridge: %v — check that the password is the bridge password from protonmail-bridge info (not your Proton account password) and that this Bridge instance has your account logged in", proto, err)
 }
 
 func mapBridgeError(proto string, err error) error {

--- a/connectors/protonmail/send_email.go
+++ b/connectors/protonmail/send_email.go
@@ -2,7 +2,6 @@ package protonmail
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -176,8 +175,7 @@ func sendMailTLS(ctx context.Context, addr, host string, auth smtp.Auth, from st
 	// Try STARTTLS — Bridge advertises it; hydroxide does not (and this block
 	// is a no-op when the proxy doesn't advertise the extension).
 	if ok, _ := client.Extension("STARTTLS"); ok {
-		tlsConfig := &tls.Config{ServerName: host}
-		if err := client.StartTLS(tlsConfig); err != nil {
+		if err := client.StartTLS(smtpTLSConfig(host)); err != nil {
 			return &connectors.ExternalError{Message: fmt.Sprintf("STARTTLS failed: %v", err)}
 		}
 	}

--- a/connectors/protonmail/smtp_tls.go
+++ b/connectors/protonmail/smtp_tls.go
@@ -1,0 +1,18 @@
+package protonmail
+
+import "crypto/tls"
+
+// smtpTLSConfig returns the TLS configuration used for SMTP STARTTLS upgrades.
+//
+// For loopback hosts (Proton Mail Bridge or hydroxide), certificate
+// verification is skipped: Bridge serves a self-signed certificate by design,
+// so strict verification can never succeed on a headless host. The session is
+// still TLS-encrypted and the traffic never leaves the machine — this mirrors
+// imapDial, which dials loopback without TLS for the same reason. For remote
+// hosts, full verification is enforced to protect credentials in transit.
+func smtpTLSConfig(host string) *tls.Config {
+	return &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: isLocalhost(host), //nolint:gosec // loopback only; Bridge's cert is self-signed by design
+	}
+}

--- a/connectors/protonmail/smtp_tls_test.go
+++ b/connectors/protonmail/smtp_tls_test.go
@@ -1,0 +1,26 @@
+package protonmail
+
+import "testing"
+
+func TestSMTPTLSConfig_loopbackSkipsVerification(t *testing.T) {
+	t.Parallel()
+	for _, host := range []string{"127.0.0.1", "localhost", "::1"} {
+		cfg := smtpTLSConfig(host)
+		if !cfg.InsecureSkipVerify {
+			t.Errorf("smtpTLSConfig(%q).InsecureSkipVerify = false, want true (Bridge serves a self-signed cert)", host)
+		}
+		if cfg.ServerName != host {
+			t.Errorf("smtpTLSConfig(%q).ServerName = %q, want %q", host, cfg.ServerName, host)
+		}
+	}
+}
+
+func TestSMTPTLSConfig_remoteVerifies(t *testing.T) {
+	t.Parallel()
+	for _, host := range []string{"mail.example.com", "192.168.1.50"} {
+		cfg := smtpTLSConfig(host)
+		if cfg.InsecureSkipVerify {
+			t.Errorf("smtpTLSConfig(%q).InsecureSkipVerify = true, want false (remote hosts must verify)", host)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

After #1312, validating/saving Proton Mail credentials performs an SMTP leg (EHLO → STARTTLS → AUTH) in addition to the IMAP login. The STARTTLS upgrade used strict certificate verification, but Proton Mail Bridge serves a **self-signed certificate by design** — so the SMTP leg could never pass against a real Bridge on a headless host. Worse, `mapBridgeAuthMessage` rewrote every auth-classified failure into "Wrong Bridge password…", sending users hunting for a password problem that didn't exist (hit in production today: correct bridge password, persistent "wrong bridge password" error).

## Changes

- **`smtp_tls.go` (new):** `smtpTLSConfig(host)` — skips cert verification for loopback hosts only, mirroring `imapDial`'s existing loopback special-case (which dials plain TCP for the same reason). Remote hosts still get full verification to protect credentials in transit.
- **`health_check.go`:** `testSMTPConn` uses the shared config; `mapBridgeAuthMessage` now reports which protocol (IMAP/SMTP) was rejected and the server's actual response instead of unconditionally asserting a wrong password (it previously discarded the `proto` argument entirely).
- **`send_email.go`:** `sendMailTLS` (used by both `send_email` and `reply_email`) uses the shared config — same latent failure for sends through real Bridge.

## Test plan

- [ ] New unit tests: `TestSMTPTLSConfig_loopbackSkipsVerification` (127.0.0.1, localhost, ::1) and `TestSMTPTLSConfig_remoteVerifies`
- [ ] Existing health-check tests assert error types/non-empty messages, not exact strings — unaffected
- [ ] CI `make test-backend` (backend tests cannot run in the web sandbox — Go 1.25 module-graph constraint; changed files verified with `gofmt -l`/`-e`, so please rely on CI for the full pass)

https://claude.ai/code/session_01A7oriM9VtCpdU4L4NDSMXD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7oriM9VtCpdU4L4NDSMXD)_