### PR TITLE
Cap dialog height at viewport and enable vertical scrolling

### DIFF
--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -56,7 +56,7 @@ function DialogContent({
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(
-            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid w-full min-w-0 gap-4 overflow-hidden overscroll-contain rounded-lg border p-6 shadow-lg duration-200 [&>*]:min-w-0 sm:max-w-lg",
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 relative grid max-h-[85dvh] w-full min-w-0 gap-4 overflow-x-hidden overflow-y-auto overscroll-contain rounded-lg border p-6 shadow-lg duration-200 [&>*]:min-w-0 sm:max-w-lg",
             className
           )}
           {...props}


### PR DESCRIPTION
## Summary

Long dialogs — like the Proton Mail Bridge credentials form — could grow past the viewport. The shared `DialogContent` had `overflow-hidden` with no height cap, so the bottom of long modals (submit buttons, Test Bridge connection) was unreachable.

This adds `max-h-[85dvh]` and `overflow-y-auto` (with `overflow-x-hidden`) to the shared `DialogContent` in `frontend/src/components/ui/dialog.tsx`, so **every** dialog scrolls vertically when its content exceeds the viewport — including the ~20 dialogs that never added their own override (EditCredentialDialog, AddCredentialDialog, SetupConnectorCredentialsDialog, AddConnectorDialog, etc.).

Existing behavior is preserved:
- Dialogs that already set their own constraint (e.g. `max-h-[90dvh]` on ReviewApprovalDialog) still win via `tailwind-merge`.
- `CommandDialog` passes `overflow-hidden`, which overrides the base overflow classes, so the command palette keeps its internal list scrolling.

## Test plan

- [x] `npm test` in `frontend/` — 104 files, 924 tests pass
- [x] `npm run build` in `frontend/` — TypeScript build passes
- [ ] Manual: open the Proton Mail "Update credentials" dialog in a short viewport and confirm the form scrolls to the Test Bridge connection button and footer

https://claude.ai/code/session_01YTRwWZdsqg9uMHGvgz1yS4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTRwWZdsqg9uMHGvgz1yS4)_