### PR TITLE
Group ProtonMail inbox/search results by email thread

### DIFF
--- a/connectors/protonmail/imap_helpers.go
+++ b/connectors/protonmail/imap_helpers.go
@@ -198,6 +198,11 @@ type emailSummary struct {
 	Date            string   `json:"date"`
 	Flags           []string `json:"flags"`
 	MessageIDHeader string   `json:"message_id_header,omitempty"`
+	InReplyTo       []string `json:"in_reply_to,omitempty"`
+	// ThreadSize and ThreadUIDs are only set when results are grouped by
+	// thread; ThreadUIDs is ascending and includes this summary's own UID.
+	ThreadSize int      `json:"thread_size,omitempty"`
+	ThreadUIDs []uint32 `json:"thread_uids,omitempty"`
 }
 
 // formatAddresses formats IMAP addresses as human-readable strings.
@@ -227,6 +232,7 @@ func envelopeToSummary(uid imap.UID, env *imap.Envelope, flags []imap.Flag) emai
 		From:            formatAddresses(env.From),
 		To:              formatAddresses(env.To),
 		MessageIDHeader: env.MessageID,
+		InReplyTo:       env.InReplyTo,
 	}
 	for _, f := range flags {
 		summary.Flags = append(summary.Flags, string(f))

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -147,6 +147,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 							"type": "boolean",
 							"default": false,
 							"description": "Only fetch unread emails"
+						},
+						"group_by_thread": {
+							"type": "boolean",
+							"default": true,
+							"description": "Collapse results to one entry per conversation: the latest message, with thread_size and thread_uids covering the fetched window (a long thread may be partially represented when it exceeds the limit). Set to false for a flat per-email listing. To act on a whole conversation (archive, delete, move), pass its thread_uids as the message_ids of the batch action."
 						}
 					}
 				}`)),
@@ -189,6 +194,11 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 							"maximum": 50,
 							"default": 10,
 							"description": "Maximum number of results to return"
+						},
+						"group_by_thread": {
+							"type": "boolean",
+							"default": true,
+							"description": "Collapse results to one entry per conversation: the latest message, with thread_size and thread_uids covering the fetched window (a long thread may be partially represented when it exceeds the limit). Set to false for a flat per-email listing. To act on a whole conversation (archive, delete, move), pass its thread_uids as the message_ids of the batch action."
 						}
 					}
 				}`)),

--- a/connectors/protonmail/read_inbox.go
+++ b/connectors/protonmail/read_inbox.go
@@ -17,6 +17,10 @@ type readInboxParams struct {
 	Folder     string `json:"folder"`
 	Limit      int    `json:"limit"`
 	UnreadOnly bool   `json:"unread_only"`
+	// GroupByThread collapses results to one entry per conversation (the
+	// latest message). Defaults to true when omitted; nil distinguishes
+	// "omitted" from an explicit false.
+	GroupByThread *bool `json:"group_by_thread"`
 }
 
 func (p *readInboxParams) validate() error {
@@ -95,5 +99,8 @@ func (a *readInboxAction) Execute(ctx context.Context, req connectors.ActionRequ
 		}
 	}
 
+	if groupByThreadEnabled(params.GroupByThread) {
+		emails = groupIntoThreads(emails)
+	}
 	return emailListResultWithFolder(params.Folder, emails)
 }

--- a/connectors/protonmail/search_emails.go
+++ b/connectors/protonmail/search_emails.go
@@ -21,6 +21,10 @@ type searchEmailsParams struct {
 	Since   string `json:"since"`
 	Before  string `json:"before"`
 	Limit   int    `json:"limit"`
+	// GroupByThread collapses results to one entry per conversation (the
+	// latest message). Defaults to true when omitted; nil distinguishes
+	// "omitted" from an explicit false.
+	GroupByThread *bool `json:"group_by_thread"`
 }
 
 func (p *searchEmailsParams) validate() error {
@@ -116,6 +120,9 @@ func (a *searchEmailsAction) Execute(ctx context.Context, req connectors.ActionR
 	emails, err := fetchEnvelopesByUID(session, uidSet)
 	if err != nil {
 		return nil, err
+	}
+	if groupByThreadEnabled(params.GroupByThread) {
+		emails = groupIntoThreads(emails)
 	}
 	return emailListResultWithFolder(params.Folder, emails)
 }

--- a/connectors/protonmail/thread_grouping.go
+++ b/connectors/protonmail/thread_grouping.go
@@ -1,0 +1,163 @@
+package protonmail
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// groupByThreadEnabled interprets the optional group_by_thread parameter.
+// A nil value means the parameter was omitted, which defaults to enabled.
+func groupByThreadEnabled(v *bool) bool {
+	return v == nil || *v
+}
+
+// groupIntoThreads collapses a flat list of email summaries into one entry per
+// conversation: the latest message of each thread, annotated with ThreadSize
+// and ThreadUIDs so agents can still reach earlier messages.
+//
+// Grouping happens in two passes over the fetched window:
+//  1. Header pass: an email is joined to the email whose Message-ID appears in
+//     its In-Reply-To header. The IMAP ENVELOPE carries both fields, so this
+//     needs no extra fetches. ENVELOPE does not include References, so a chain
+//     whose intermediate parents fall outside the window can break here.
+//  2. Subject fallback pass: groups sharing a normalized subject (Re:/Fwd:
+//     prefixes stripped) are joined to bridge those gaps. This can merge two
+//     genuinely distinct conversations that share a subject line — an accepted
+//     tradeoff for a listing view. Emails with empty normalized subjects are
+//     never merged by this pass.
+//
+// Thread counts only cover the fetched window: a long thread whose older
+// messages were not fetched is partially represented.
+func groupIntoThreads(emails []emailSummary) []emailSummary {
+	if len(emails) <= 1 {
+		if len(emails) == 1 {
+			annotated := emails[0]
+			annotated.ThreadSize = 1
+			annotated.ThreadUIDs = []uint32{annotated.UID}
+			return []emailSummary{annotated}
+		}
+		return emails
+	}
+
+	parent := make([]int, len(emails))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(i int) int {
+		if parent[i] != i {
+			parent[i] = find(parent[i])
+		}
+		return parent[i]
+	}
+	union := func(a, b int) {
+		ra, rb := find(a), find(b)
+		if ra != rb {
+			parent[ra] = rb
+		}
+	}
+
+	// Header pass: link replies to the message they answer.
+	byMessageID := make(map[string]int, len(emails))
+	for i, e := range emails {
+		if e.MessageIDHeader != "" {
+			byMessageID[e.MessageIDHeader] = i
+		}
+	}
+	for i, e := range emails {
+		for _, ref := range e.InReplyTo {
+			if j, ok := byMessageID[ref]; ok {
+				union(i, j)
+			}
+		}
+	}
+
+	// Subject fallback pass: bridge chains broken by missing parents.
+	bySubject := make(map[string]int, len(emails))
+	for i, e := range emails {
+		subject := normalizeSubject(e.Subject)
+		if subject == "" {
+			continue
+		}
+		if j, ok := bySubject[subject]; ok {
+			union(i, j)
+		} else {
+			bySubject[subject] = i
+		}
+	}
+
+	groups := make(map[int][]int)
+	for i := range emails {
+		root := find(i)
+		groups[root] = append(groups[root], i)
+	}
+
+	threads := make([]emailSummary, 0, len(groups))
+	for _, members := range groups {
+		canonical := members[0]
+		for _, m := range members[1:] {
+			if summaryNewer(emails[m], emails[canonical]) {
+				canonical = m
+			}
+		}
+		thread := emails[canonical]
+		thread.ThreadSize = len(members)
+		thread.ThreadUIDs = make([]uint32, 0, len(members))
+		for _, m := range members {
+			thread.ThreadUIDs = append(thread.ThreadUIDs, emails[m].UID)
+		}
+		sort.Slice(thread.ThreadUIDs, func(a, b int) bool {
+			return thread.ThreadUIDs[a] < thread.ThreadUIDs[b]
+		})
+		threads = append(threads, thread)
+	}
+
+	// Most recent last, matching the flat listing order.
+	sort.Slice(threads, func(a, b int) bool {
+		return summaryNewer(threads[b], threads[a])
+	})
+	return threads
+}
+
+// summaryNewer reports whether a is more recent than b, comparing envelope
+// dates with UID as tie-break (higher UID = later delivery).
+func summaryNewer(a, b emailSummary) bool {
+	ta := parseSummaryDate(a.Date)
+	tb := parseSummaryDate(b.Date)
+	if !ta.Equal(tb) {
+		return ta.After(tb)
+	}
+	return a.UID > b.UID
+}
+
+// parseSummaryDate parses the RFC 3339 date stored on summaries. Unparseable
+// dates compare as the zero time, i.e. older than everything.
+func parseSummaryDate(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// subjectPrefixes are reply/forward markers stripped during normalization.
+var subjectPrefixes = []string{"re:", "fwd:", "fw:"}
+
+// normalizeSubject strips reply/forward prefixes and lowercases the subject so
+// "RE: RE: Project update" and "Project update" group together.
+func normalizeSubject(subject string) string {
+	s := strings.ToLower(strings.TrimSpace(subject))
+	for {
+		stripped := false
+		for _, prefix := range subjectPrefixes {
+			if strings.HasPrefix(s, prefix) {
+				s = strings.TrimSpace(s[len(prefix):])
+				stripped = true
+			}
+		}
+		if !stripped {
+			return s
+		}
+	}
+}

--- a/connectors/protonmail/thread_grouping_test.go
+++ b/connectors/protonmail/thread_grouping_test.go
@@ -1,0 +1,237 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// summaryFixture builds an emailSummary for grouping tests. inReplyTo may be
+// empty for thread roots or messages with stripped headers.
+func summaryFixture(uid uint32, subject, date, messageID string, inReplyTo ...string) emailSummary {
+	return emailSummary{
+		UID:             uid,
+		Subject:         subject,
+		Date:            date,
+		MessageIDHeader: messageID,
+		InReplyTo:       inReplyTo,
+	}
+}
+
+func threadByUID(t *testing.T, threads []emailSummary, uid uint32) emailSummary {
+	t.Helper()
+	for _, thread := range threads {
+		if thread.UID == uid {
+			return thread
+		}
+	}
+	t.Fatalf("no thread with canonical UID %d in %+v", uid, threads)
+	return emailSummary{}
+}
+
+func TestGroupIntoThreads_LinearReplyChain(t *testing.T) {
+	t.Parallel()
+
+	emails := []emailSummary{
+		summaryFixture(33, "Project update", "2026-06-01T10:00:00Z", "a@example.com"),
+		summaryFixture(40, "RE: Project update", "2026-06-02T10:00:00Z", "b@example.com", "a@example.com"),
+		summaryFixture(146, "RE: RE: Project update", "2026-06-03T10:00:00Z", "c@example.com", "b@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 1 {
+		t.Fatalf("expected 1 thread, got %d: %+v", len(threads), threads)
+	}
+	thread := threads[0]
+	if thread.UID != 146 {
+		t.Errorf("expected latest message UID 146 as canonical, got %d", thread.UID)
+	}
+	if thread.ThreadSize != 3 {
+		t.Errorf("expected thread_size 3, got %d", thread.ThreadSize)
+	}
+	if want := []uint32{33, 40, 146}; !reflect.DeepEqual(thread.ThreadUIDs, want) {
+		t.Errorf("expected thread_uids %v, got %v", want, thread.ThreadUIDs)
+	}
+}
+
+func TestGroupIntoThreads_SubjectFallbackBridgesGaps(t *testing.T) {
+	t.Parallel()
+
+	// The middle of the chain was not fetched: neither email references the
+	// other directly, so only the normalized subject links them.
+	emails := []emailSummary{
+		summaryFixture(10, "Project update", "2026-06-01T10:00:00Z", "a@example.com"),
+		summaryFixture(50, "RE: RE: Project update", "2026-06-03T10:00:00Z", "c@example.com", "missing@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 1 {
+		t.Fatalf("expected 1 thread, got %d: %+v", len(threads), threads)
+	}
+	if threads[0].UID != 50 {
+		t.Errorf("expected canonical UID 50, got %d", threads[0].UID)
+	}
+	if want := []uint32{10, 50}; !reflect.DeepEqual(threads[0].ThreadUIDs, want) {
+		t.Errorf("expected thread_uids %v, got %v", want, threads[0].ThreadUIDs)
+	}
+}
+
+func TestGroupIntoThreads_DistinctSubjectsStaySeparate(t *testing.T) {
+	t.Parallel()
+
+	emails := []emailSummary{
+		summaryFixture(1, "Invoice", "2026-06-01T10:00:00Z", "a@example.com"),
+		summaryFixture(2, "Lunch plans", "2026-06-02T10:00:00Z", "b@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 2 {
+		t.Fatalf("expected 2 threads, got %d: %+v", len(threads), threads)
+	}
+	for _, thread := range threads {
+		if thread.ThreadSize != 1 {
+			t.Errorf("UID %d: expected thread_size 1, got %d", thread.UID, thread.ThreadSize)
+		}
+		if want := []uint32{thread.UID}; !reflect.DeepEqual(thread.ThreadUIDs, want) {
+			t.Errorf("UID %d: expected thread_uids %v, got %v", thread.UID, want, thread.ThreadUIDs)
+		}
+	}
+}
+
+func TestGroupIntoThreads_EmptySubjectsNeverMergedByFallback(t *testing.T) {
+	t.Parallel()
+
+	emails := []emailSummary{
+		summaryFixture(1, "", "2026-06-01T10:00:00Z", "a@example.com"),
+		summaryFixture(2, "", "2026-06-02T10:00:00Z", "b@example.com"),
+		summaryFixture(3, "Re:", "2026-06-03T10:00:00Z", "c@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 3 {
+		t.Fatalf("expected 3 threads (empty subjects never merge), got %d: %+v", len(threads), threads)
+	}
+}
+
+func TestGroupIntoThreads_LatestByDateWithUIDTieBreak(t *testing.T) {
+	t.Parallel()
+
+	emails := []emailSummary{
+		summaryFixture(5, "Topic", "2026-06-02T10:00:00Z", "a@example.com"),
+		summaryFixture(9, "Re: Topic", "2026-06-02T10:00:00Z", "b@example.com", "a@example.com"),
+		summaryFixture(7, "Re: Topic", "2026-06-01T10:00:00Z", "c@example.com", "a@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 1 {
+		t.Fatalf("expected 1 thread, got %d: %+v", len(threads), threads)
+	}
+	// UIDs 5 and 9 share a date; the higher UID wins the tie.
+	if threads[0].UID != 9 {
+		t.Errorf("expected canonical UID 9 (date tie broken by UID), got %d", threads[0].UID)
+	}
+}
+
+func TestGroupIntoThreads_MostRecentThreadLast(t *testing.T) {
+	t.Parallel()
+
+	emails := []emailSummary{
+		summaryFixture(4, "Newest topic", "2026-06-05T10:00:00Z", "d@example.com"),
+		summaryFixture(1, "Old topic", "2026-06-01T10:00:00Z", "a@example.com"),
+		summaryFixture(2, "Re: Old topic", "2026-06-02T10:00:00Z", "b@example.com", "a@example.com"),
+		summaryFixture(3, "Middle topic", "2026-06-03T10:00:00Z", "c@example.com"),
+	}
+
+	threads := groupIntoThreads(emails)
+	if len(threads) != 3 {
+		t.Fatalf("expected 3 threads, got %d: %+v", len(threads), threads)
+	}
+	var order []uint32
+	for _, thread := range threads {
+		order = append(order, thread.UID)
+	}
+	if want := []uint32{2, 3, 4}; !reflect.DeepEqual(order, want) {
+		t.Errorf("expected most-recent-last order %v, got %v", want, order)
+	}
+}
+
+func TestGroupIntoThreads_SingleAndEmptyInput(t *testing.T) {
+	t.Parallel()
+
+	if got := groupIntoThreads(nil); len(got) != 0 {
+		t.Errorf("expected empty result for nil input, got %+v", got)
+	}
+
+	threads := groupIntoThreads([]emailSummary{
+		summaryFixture(42, "Solo", "2026-06-01T10:00:00Z", "a@example.com"),
+	})
+	if len(threads) != 1 {
+		t.Fatalf("expected 1 thread, got %d", len(threads))
+	}
+	if threads[0].ThreadSize != 1 {
+		t.Errorf("expected thread_size 1, got %d", threads[0].ThreadSize)
+	}
+	if want := []uint32{42}; !reflect.DeepEqual(threads[0].ThreadUIDs, want) {
+		t.Errorf("expected thread_uids %v, got %v", want, threads[0].ThreadUIDs)
+	}
+}
+
+func TestNormalizeSubject(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Project update", "project update"},
+		{"RE: Project update", "project update"},
+		{"Re: re: RE: Project update", "project update"},
+		{"Fwd: Project update", "project update"},
+		{"FW: Re: Project update", "project update"},
+		{"  Re:   Project update  ", "project update"},
+		{"", ""},
+		{"Re:", ""},
+		{"Regarding the project", "regarding the project"},
+	}
+	for _, tc := range cases {
+		if got := normalizeSubject(tc.in); got != tc.want {
+			t.Errorf("normalizeSubject(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestGroupByThreadEnabled(t *testing.T) {
+	t.Parallel()
+
+	if !groupByThreadEnabled(nil) {
+		t.Error("expected nil (omitted) to default to enabled")
+	}
+	enabled := true
+	if !groupByThreadEnabled(&enabled) {
+		t.Error("expected explicit true to be enabled")
+	}
+	disabled := false
+	if groupByThreadEnabled(&disabled) {
+		t.Error("expected explicit false to be disabled")
+	}
+}
+
+func TestGroupByThreadParam_DefaultsAndExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	var inbox readInboxParams
+	if err := json.Unmarshal([]byte(`{}`), &inbox); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !groupByThreadEnabled(inbox.GroupByThread) {
+		t.Error("read_inbox: expected omitted group_by_thread to default to enabled")
+	}
+
+	var search searchEmailsParams
+	if err := json.Unmarshal([]byte(`{"subject":"x","group_by_thread":false}`), &search); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if groupByThreadEnabled(search.GroupByThread) {
+		t.Error("search_emails: expected explicit group_by_thread=false to disable grouping")
+	}
+}


### PR DESCRIPTION
## Summary

`protonmail.read_inbox` and `protonmail.search_emails` now collapse results to **one entry per conversation by default**: the latest message of each thread, annotated with `thread_size` and `thread_uids` (ascending, includes the canonical UID) so agents can still read or batch-archive earlier messages. Pass `group_by_thread: false` for the previous flat per-email listing.

- **No extra IMAP round trips:** go-imap v2's `Envelope` already carries `In-Reply-To` alongside `Message-ID`; we were discarding it. `envelopeToSummary` now copies it and exposes it as `in_reply_to`.
- **Grouping** (new `thread_grouping.go`): union-find over the fetched window — header pass links replies via In-Reply-To → Message-ID; a normalized-subject fallback (`Re:`/`Fwd:`/`FW:` stripped, case-insensitive) bridges chains whose intermediate parents fall outside the window (ENVELOPE has no References header). Empty subjects never merge by fallback.
- **Canonical message:** latest by envelope date, UID tie-break. Threads ordered most-recent-last, matching the flat listing.
- **Schemas** (`manifest.go`): `group_by_thread` (`default: true`) added to both actions, with guidance that whole-conversation operations should pass `thread_uids` as the `message_ids` of the batch archive/delete/move actions.
- Known tradeoff (documented): subject fallback can merge two distinct conversations sharing a subject line — acceptable for a listing view; `read_email` by UID is unaffected. Thread counts cover only the fetched window (`limit` applies pre-grouping).

Closes #1318

## Test plan

- [x] New `thread_grouping_test.go`: linear In-Reply-To chain; subject-fallback gap bridging; distinct subjects stay separate; empty subjects never merged; latest-by-date with UID tie-break; singletons get `thread_size: 1`; most-recent-last ordering; `normalizeSubject` table; `group_by_thread` defaults true when omitted / explicit `false` disables (both param structs)
- [x] `gofmt -l` / `gofmt -e` clean on all changed files
- [ ] CI `go test` — **backend tests were not run locally** (sandbox cannot resolve the module graph: Go 1.25 transitive dep block); relying on CI for the full pass

https://claude.ai/code/session_018hmpYSt4AhLeUuZ2xNkaqU

---
_Generated by [Claude Code](https://claude.ai/code/session_018hmpYSt4AhLeUuZ2xNkaqU)_