### PR TITLE
Stabilize enrichment: prefer describers over templates, fix param labels

### DIFF
--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -148,7 +148,7 @@ export function buildSummary(
 
 /**
  * Core formatter: returns structured parts for an action.
- * Priority: template → ACTION_DESCRIBERS → generic fallback.
+ * Priority: ACTION_DESCRIBERS → template → generic fallback.
  */
 function buildParts(
   actionType: string,
@@ -158,7 +158,14 @@ function buildParts(
   displayTemplate?: string | null,
   resourceDetails?: Record<string, unknown> | null,
 ): SummaryPart[] {
-  // 1. Try display template from manifest.
+  // 1. Try action-specific describer (with resource details).
+  const formatter = ACTION_DESCRIBERS[actionType];
+  if (formatter) {
+    const result = formatter(parameters, resourceDetails ?? undefined);
+    if (result) return result;
+  }
+
+  // 2. Try display template from manifest.
   // Merge resourceDetails into the lookup so templates can resolve human-readable
   // names (e.g. {{channel_name}} → "#general") instead of raw IDs (#862).
   if (displayTemplate) {
@@ -167,13 +174,6 @@ function buildParts(
       : parameters;
     const templateParts = renderTemplate(displayTemplate, lookup);
     if (templateParts) return templateParts;
-  }
-
-  // 2. Try action-specific describer (with resource details).
-  const formatter = ACTION_DESCRIBERS[actionType];
-  if (formatter) {
-    const result = formatter(parameters, resourceDetails ?? undefined);
-    if (result) return result;
   }
 
   // 3. Fall back to generic.

--- a/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
+++ b/frontend/src/components/__tests__/ActionPreviewSummary.test.tsx
@@ -515,6 +515,32 @@ describe("buildSummary", () => {
   });
 
   describe("protonmail.archive_email", () => {
+    it("prefers describer over display template when resource_details present", () => {
+      const result = buildSummary(
+        "protonmail.archive_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        "Archive Email",
+        'Archive email in {{folder}}',
+        { subject: "Legacy Media litigation", from: ["daniel.rose@littensipe.com"] },
+      );
+      expect(result).toContain("Archive email");
+      expect(result).toContain("Legacy Media litigation");
+      expect(result).toContain("daniel.rose@littensipe.com");
+      expect(result).not.toContain('INBOX');
+    });
+
+    it("falls back to display template when resource_details absent", () => {
+      const result = buildSummary(
+        "protonmail.archive_email",
+        { message_id: 10, folder: "INBOX" },
+        null,
+        "Archive Email",
+        'Archive email in {{folder}}',
+      );
+      expect(result).toBe(`Archive email in ${q("INBOX")}`);
+    });
+
     it("shows enriched single archive", () => {
       const result = buildSummary(
         "protonmail.archive_email",

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -203,6 +203,28 @@ describe("buildActionSummary", () => {
     expect(result).toContain("asker@example.com");
   });
 
+  it("prefers describer over display template when resource_details present", () => {
+    const result = buildActionSummary(
+      "protonmail.archive_email",
+      { message_id: 10, folder: "INBOX" },
+      "Archive email in {{folder}}",
+      { subject: "Legacy Media litigation", from: ["daniel.rose@littensipe.com"] },
+    );
+    expect(result).toContain("Archive email");
+    expect(result).toContain("Legacy Media litigation");
+    expect(result).toContain("daniel.rose@littensipe.com");
+    expect(result).not.toContain("INBOX");
+  });
+
+  it("falls back to display template when resource_details absent", () => {
+    const result = buildActionSummary(
+      "protonmail.archive_email",
+      { message_id: 10, folder: "INBOX" },
+      "Archive email in {{folder}}",
+    );
+    expect(result).toBe('Archive email in \u201CINBOX\u201D');
+  });
+
   it("formats protonmail.archive_email batch enrichment", () => {
     const result = buildActionSummary(
       "protonmail.archive_email",

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -93,20 +93,20 @@ export function buildActionSummary(
   displayTemplate?: string | null,
   resourceDetails?: Record<string, unknown> | null,
 ): string {
-  // 1. Try display template from manifest.
+  // 1. Try action-specific formatter.
+  const formatter = ACTION_FORMATTERS[actionType];
+  if (formatter) {
+    const result = formatter(parameters, resourceDetails ?? undefined);
+    if (result) return result;
+  }
+
+  // 2. Try display template from manifest.
   // Merge resourceDetails so templates can resolve human-readable names (#862).
   if (displayTemplate) {
     const lookup = resourceDetails
       ? { ...parameters, ...resourceDetails }
       : parameters;
     const result = renderDisplayTemplate(displayTemplate, lookup);
-    if (result) return result;
-  }
-
-  // 2. Try action-specific formatter.
-  const formatter = ACTION_FORMATTERS[actionType];
-  if (formatter) {
-    const result = formatter(parameters, resourceDetails ?? undefined);
     if (result) return result;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Prefer `ACTION_DESCRIBERS` over manifest `display_template` when building approval summaries on web and mobile, so enriched email metadata (subject, sender) is shown instead of generic folder-only templates
- Label parameter rows with `x-ui.label` or `humanizeKey(key)` instead of verbose schema descriptions; show descriptions as muted helper text below values
- Add unit tests for describer/template priority and parameter labeling

Closes #1323

## Test plan

### Claude Code
- [x] `npx vitest run src/components/__tests__/ActionPreviewSummary.test.tsx src/components/__tests__/SchemaParameterDetails.test.tsx`
- [x] `npm test -- --ci src/screens/approvals/__tests__/approvalUtils.test.ts` (mobile)
- [x] `npm run build` (frontend TypeScript)

### OpenClaw
- [ ] Verify web approval dialog for `protonmail.archive_email` with `resource_details` shows enriched subject/sender summary
- [ ] Verify Parameters section shows short labels (e.g. "Message id") not uppercase schema doc strings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11acfb34-6f34-4ebe-959c-9628284e0dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11acfb34-6f34-4ebe-959c-9628284e0dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

