### PR TITLE
Web approval dialog: match mobile layout and parameter rendering

### DIFF
--- a/frontend/src/components/KeyValueList.tsx
+++ b/frontend/src/components/KeyValueList.tsx
@@ -1,0 +1,51 @@
+/**
+ * Renders a list of key-value pairs for approval parameters and context.
+ * Short values display inline; long or multiline values stack below the label.
+ */
+export interface KeyValueEntry {
+  label: string;
+  value: string;
+}
+
+interface KeyValueListProps {
+  entries: KeyValueEntry[];
+}
+
+function isLongValue(value: string): boolean {
+  return value.length > 40 || value.includes("\n");
+}
+
+export function KeyValueList({ entries }: KeyValueListProps) {
+  return (
+    <div>
+      {entries.map(({ label, value }, index) => {
+        const isLong = isLongValue(value);
+        const isLast = index === entries.length - 1;
+
+        return (
+          <div
+            key={`${label}-${index}`}
+            className={
+              isLong
+                ? `space-y-1 py-2 ${isLast ? "" : "border-border border-b"}`
+                : `flex items-start justify-between gap-3 py-2 ${isLast ? "" : "border-border border-b"}`
+            }
+          >
+            <span className="text-muted-foreground shrink-0 text-sm font-medium">
+              {label}
+            </span>
+            <span
+              className={
+                isLong
+                  ? "text-foreground block text-sm leading-relaxed break-words whitespace-pre-wrap"
+                  : "text-foreground min-w-0 text-right text-sm break-all"
+              }
+            >
+              {value}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/SchemaParameterDetails.tsx
+++ b/frontend/src/components/SchemaParameterDetails.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import type { ParametersSchema } from "@/lib/parameterSchema";
+import type { ParametersSchema, SchemaProperty } from "@/lib/parameterSchema";
 import { friendlyTypeLabel } from "@/lib/parameterSchema";
 import { formatParameterValue, humanizeKey } from "@/lib/formatValues";
 import { slackResolvedDisplayValue } from "@/lib/slackParameterDisplay";
+import { KeyValueList, type KeyValueEntry } from "@/components/KeyValueList";
 
 export type { ParametersSchema } from "@/lib/parameterSchema";
 export { parseParametersSchema } from "@/lib/parameterSchema";
@@ -18,17 +21,84 @@ interface SchemaParameterDetailsProps {
   resourceDetails?: Record<string, unknown> | null;
 }
 
+function parameterDisplayLabel(key: string, prop?: SchemaProperty): string {
+  const uiLabel = prop?.["x-ui"]?.label;
+  return uiLabel ?? humanizeKey(key);
+}
+
+function resolveDisplayValue(
+  key: string,
+  value: unknown,
+  actionType?: string,
+  resourceDetails?: Record<string, unknown> | null,
+): string {
+  const resolved =
+    actionType != null
+      ? slackResolvedDisplayValue(actionType, key, value, resourceDetails)
+      : null;
+  return resolved ?? formatParameterValue(value);
+}
+
+interface ParameterRowData {
+  key: string;
+  label: string;
+  value: unknown;
+  prop?: SchemaProperty;
+  isRequired?: boolean;
+  isProvided: boolean;
+}
+
+function collectParameterRows(
+  parameters: Record<string, unknown>,
+  schema: ParametersSchema | null,
+): ParameterRowData[] {
+  if (!schema?.properties) {
+    return Object.entries(parameters).map(([key, value]) => ({
+      key,
+      label: humanizeKey(key),
+      value,
+      isProvided: true,
+    }));
+  }
+
+  const properties = schema.properties;
+  const requiredSet = new Set(schema.required ?? []);
+
+  const schemaKeys = Object.keys(properties).filter((key) => {
+    const isProvided = key in parameters;
+    const isRequired = requiredSet.has(key);
+    return isProvided || isRequired;
+  });
+  const extraKeys = Object.keys(parameters).filter((k) => !properties[k]);
+
+  const rows: ParameterRowData[] = schemaKeys.map((key) => {
+    const prop = properties[key]!;
+    return {
+      key,
+      label: parameterDisplayLabel(key, prop),
+      value: parameters[key],
+      prop,
+      isRequired: requiredSet.has(key),
+      isProvided: key in parameters,
+    };
+  });
+
+  for (const key of extraKeys) {
+    rows.push({
+      key,
+      label: humanizeKey(key),
+      value: parameters[key],
+      isProvided: true,
+    });
+  }
+
+  return rows;
+}
+
 /**
- * Renders action parameters using the connector's JSON Schema for rich
- * display. When a schema is available, parameters are shown with their
- * human-readable descriptions as labels, type annotations, and enum context.
- * Falls back to raw key-value display when no schema is available.
- *
- * Improvements over raw display:
- * - humanizeKey for clean labels when no description provided
- * - tryFormatDateTime for timestamp values
- * - Dividers between parameter rows
- * - Hides unprovided optional parameters
+ * Renders action parameters as a clean key/value list for approvers.
+ * Full schema metadata (descriptions, types, enums) is available behind
+ * a collapsed "Developer details" toggle.
  */
 export function SchemaParameterDetails({
   parameters,
@@ -36,73 +106,70 @@ export function SchemaParameterDetails({
   actionType,
   resourceDetails,
 }: SchemaParameterDetailsProps) {
-  if (!schema?.properties) {
-    return (
-      <FallbackDetails
-        parameters={parameters}
-        actionType={actionType}
-        resourceDetails={resourceDetails}
-      />
-    );
-  }
+  const [developerOpen, setDeveloperOpen] = useState(false);
+  const rows = collectParameterRows(parameters, schema);
 
-  const properties = schema.properties;
-  const requiredSet = new Set(schema.required ?? []);
+  const entries: KeyValueEntry[] = rows
+    .filter((row) => row.isProvided)
+    .map((row) => ({
+      label: row.label,
+      value: resolveDisplayValue(row.key, row.value, actionType, resourceDetails),
+    }));
 
-  // Render schema-known parameters first (in schema property order),
-  // then any extra parameters not in the schema.
-  // Hide unprovided optional params to reduce noise.
-  const schemaKeys = Object.keys(properties).filter((key) => {
-    const isProvided = key in parameters;
-    const isRequired = requiredSet.has(key);
-    return isProvided || isRequired;
-  });
-  const extraKeys = Object.keys(parameters).filter(
-    (k) => !properties[k],
-  );
+  const hasDeveloperDetails = schema?.properties != null;
 
   return (
-    <div className="divide-border divide-y">
-      {schemaKeys.map((key) => {
-        // Safe to assert: schemaKeys come from Object.keys(properties).
-        const prop = properties[key]!;
-        const value = parameters[key];
-        const isRequired = requiredSet.has(key);
+    <div className="space-y-3">
+      {entries.length > 0 ? (
+        <KeyValueList entries={entries} />
+      ) : (
+        <p className="text-muted-foreground text-sm">No parameters provided.</p>
+      )}
 
-        return (
-          <ParameterRow
-            key={key}
-            name={key}
-            label={prop.description ?? humanizeKey(key)}
-            value={value}
-            type={prop.type}
-            enumValues={prop.enum}
-            defaultValue={prop.default}
-            isRequired={isRequired}
-            isProvided={key in parameters}
-            actionType={actionType}
-            resourceDetails={resourceDetails}
-          />
-        );
-      })}
-      {extraKeys.map((key) => (
-        <ParameterRow
-          key={key}
-          name={key}
-          label={humanizeKey(key)}
-          value={parameters[key]}
-          isProvided
-          actionType={actionType}
-          resourceDetails={resourceDetails}
-        />
-      ))}
+      {hasDeveloperDetails && (
+        <div className="border-border border-t pt-2">
+          <button
+            type="button"
+            onClick={() => setDeveloperOpen((open) => !open)}
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+            aria-expanded={developerOpen}
+          >
+            <ChevronRight
+              className={`size-3 shrink-0 transition-transform duration-150 ${developerOpen ? "rotate-90" : ""}`}
+              aria-hidden="true"
+            />
+            Developer details
+          </button>
+          {developerOpen && (
+            <div className="divide-border mt-2 divide-y">
+              {rows.map((row) => (
+                <DeveloperParameterRow
+                  key={row.key}
+                  name={row.key}
+                  label={row.label}
+                  description={row.prop?.description}
+                  value={row.value}
+                  type={row.prop?.type}
+                  enumValues={row.prop?.enum}
+                  defaultValue={row.prop?.default}
+                  isRequired={row.isRequired}
+                  isProvided={row.isProvided}
+                  actionType={actionType}
+                  resourceDetails={resourceDetails}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
-function ParameterRow({
+function DeveloperParameterRow({
   name,
   label,
+  description,
   value,
   type,
   enumValues,
@@ -114,6 +181,7 @@ function ParameterRow({
 }: {
   name: string;
   label: string;
+  description?: string;
   value: unknown;
   type?: string;
   enumValues?: string[];
@@ -123,11 +191,7 @@ function ParameterRow({
   actionType?: string;
   resourceDetails?: Record<string, unknown> | null;
 }) {
-  const resolved =
-    actionType != null
-      ? slackResolvedDisplayValue(actionType, name, value, resourceDetails)
-      : null;
-  const displayValue = resolved ?? formatParameterValue(value);
+  const displayValue = resolveDisplayValue(name, value, actionType, resourceDetails);
   const isDefault =
     defaultValue !== undefined && String(value) === String(defaultValue);
   const isMultiline = typeof value === "string" && value.includes("\n");
@@ -135,40 +199,37 @@ function ParameterRow({
 
   return (
     <div className="space-y-1.5 py-3 first:pt-0 last:pb-0">
-      {/* Label row */}
-      <div className="flex items-center gap-1.5">
-        <span className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">
-          {label !== name ? label : humanizeKey(name)}
-        </span>
-        {label !== name && (
-          <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 text-[10px] font-mono">{name}</code>
-        )}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-foreground text-xs font-semibold">{label}</span>
+        <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 font-mono text-[10px]">
+          {name}
+        </code>
         {typeLabel && (
-          <span className="text-muted-foreground text-[10px] font-mono">{typeLabel}</span>
+          <span className="text-muted-foreground font-mono text-[10px]">{typeLabel}</span>
         )}
         {isRequired && !isProvided && (
-          <Badge
-            variant="destructive"
-            className="rounded-full text-[9px] leading-tight"
-          >
+          <Badge variant="destructive" className="rounded-full text-[9px] leading-tight">
             missing
           </Badge>
         )}
         {isDefault && (
-          <Badge variant="secondary" className="text-[9px] leading-tight ml-auto">
+          <Badge variant="secondary" className="ml-auto text-[9px] leading-tight">
             default
           </Badge>
         )}
       </div>
 
-      {/* Value */}
+      {description && (
+        <p className="text-muted-foreground text-xs leading-relaxed">{description}</p>
+      )}
+
       {isProvided ? (
         isMultiline ? (
-          <pre className="bg-muted/60 border-border rounded-md border px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words font-sans text-foreground">
+          <pre className="bg-muted/60 border-border text-foreground rounded-md border px-3 py-2 font-sans text-xs leading-relaxed break-words whitespace-pre-wrap">
             {displayValue}
           </pre>
         ) : (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="bg-muted/60 border-border text-foreground inline-block rounded-md border px-2.5 py-1 text-sm font-medium break-all">
               {displayValue}
             </span>
@@ -183,46 +244,5 @@ function ParameterRow({
         <span className="text-muted-foreground text-sm italic">not provided</span>
       )}
     </div>
-  );
-}
-
-function FallbackDetails({
-  parameters,
-  actionType,
-  resourceDetails,
-}: {
-  parameters: Record<string, unknown>;
-  actionType?: string;
-  resourceDetails?: Record<string, unknown> | null;
-}) {
-  return (
-    <dl className="divide-border divide-y">
-      {Object.entries(parameters).map(([key, value]) => {
-        const resolved =
-          actionType != null
-            ? slackResolvedDisplayValue(actionType, key, value, resourceDetails)
-            : null;
-        const displayValue = resolved ?? formatParameterValue(value);
-        const isMultiline = typeof value === "string" && value.includes("\n");
-        return (
-          <div key={key} className="space-y-1.5 py-3 first:pt-0 last:pb-0">
-            <dt className="text-foreground/70 text-xs font-semibold tracking-wide uppercase">
-              {humanizeKey(key)}
-            </dt>
-            <dd>
-              {isMultiline ? (
-                <pre className="bg-muted/60 border-border rounded-md border px-3 py-2 text-xs leading-relaxed whitespace-pre-wrap break-words font-sans text-foreground">
-                  {displayValue}
-                </pre>
-              ) : (
-                <span className="bg-muted/60 border-border text-foreground inline-block rounded-md border px-2.5 py-1 text-sm font-medium break-all">
-                  {displayValue}
-                </span>
-              )}
-            </dd>
-          </div>
-        );
-      })}
-    </dl>
   );
 }

--- a/frontend/src/components/TimelineView.tsx
+++ b/frontend/src/components/TimelineView.tsx
@@ -1,0 +1,57 @@
+/**
+ * Vertical timeline for approval lifecycle timestamps.
+ * Terminal events (approved/denied) use semantic dot colors.
+ */
+export interface TimelineEntry {
+  label: string;
+  value: string;
+  dotColor?: "success" | "error";
+}
+
+interface TimelineViewProps {
+  entries: TimelineEntry[];
+}
+
+const DOT_COLORS = {
+  success: "bg-emerald-500",
+  error: "bg-destructive",
+  default: "bg-muted-foreground/40",
+} as const;
+
+export function TimelineView({ entries }: TimelineViewProps) {
+  return (
+    <div className="pl-1">
+      {entries.map((entry, index) => {
+        const isLast = index === entries.length - 1;
+        const dotClass =
+          entry.dotColor === "success"
+            ? DOT_COLORS.success
+            : entry.dotColor === "error"
+              ? DOT_COLORS.error
+              : DOT_COLORS.default;
+
+        return (
+          <div key={`${index}-${entry.label}`} className="flex min-h-8">
+            <div className="flex w-5 shrink-0 flex-col items-center">
+              <span
+                className={`mt-1.5 size-2 shrink-0 rounded-full ${dotClass}`}
+                aria-hidden="true"
+              />
+              {!isLast && (
+                <span className="bg-border my-0.5 w-0.5 flex-1" aria-hidden="true" />
+              )}
+            </div>
+            <div className="mb-3 ml-2 flex flex-1 items-start justify-between gap-3">
+              <span className="text-muted-foreground text-sm font-medium">
+                {entry.label}
+              </span>
+              <span className="text-foreground shrink-0 text-right text-sm">
+                {entry.value}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SchemaParameterDetails.test.tsx
+++ b/frontend/src/components/__tests__/SchemaParameterDetails.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 import { SchemaParameterDetails } from "../SchemaParameterDetails";
 import type { ParametersSchema } from "@/lib/parameterSchema";
@@ -20,7 +21,7 @@ const schema: ParametersSchema = {
 };
 
 describe("SchemaParameterDetails", () => {
-  it("renders parameter descriptions as labels", () => {
+  it("renders humanized keys as labels, not schema descriptions", () => {
     render(
       <SchemaParameterDetails
         parameters={{ owner: "acme", repo: "widgets" }}
@@ -28,11 +29,37 @@ describe("SchemaParameterDetails", () => {
       />,
     );
 
-    expect(screen.getByText("Repository owner")).toBeInTheDocument();
-    expect(screen.getByText("Repository name")).toBeInTheDocument();
+    expect(screen.getByText("Owner")).toBeInTheDocument();
+    expect(screen.getByText("Repo")).toBeInTheDocument();
+    expect(screen.queryByText("Repository owner")).not.toBeInTheDocument();
   });
 
-  it("renders parameter values", () => {
+  it("uses x-ui label when available", () => {
+    const labeledSchema: ParametersSchema = {
+      type: "object",
+      properties: {
+        message_id: {
+          type: "string",
+          description: "Stable IMAP UID of a single email to archive",
+          "x-ui": { label: "Message" },
+        },
+      },
+    };
+
+    render(
+      <SchemaParameterDetails
+        parameters={{ message_id: "12345" }}
+        schema={labeledSchema}
+      />,
+    );
+
+    expect(screen.getByText("Message")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Stable IMAP UID of a single email to archive"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders parameter values in the clean view", () => {
     render(
       <SchemaParameterDetails
         parameters={{ owner: "acme", repo: "widgets" }}
@@ -44,44 +71,7 @@ describe("SchemaParameterDetails", () => {
     expect(screen.getByText("widgets")).toBeInTheDocument();
   });
 
-  it("shows parameter key as secondary label when description exists", () => {
-    render(
-      <SchemaParameterDetails
-        parameters={{ owner: "acme" }}
-        schema={schema}
-      />,
-    );
-
-    // The key is shown as a small code element alongside the description label
-    expect(screen.getByText("owner")).toBeInTheDocument();
-  });
-
-  it("shows 'missing' badge for required parameters not provided", () => {
-    render(
-      <SchemaParameterDetails
-        parameters={{ owner: "acme" }}
-        schema={schema}
-      />,
-    );
-
-    // "repo" is required but not provided
-    expect(screen.getByText("missing")).toBeInTheDocument();
-  });
-
-  it("hides unprovided optional parameters", () => {
-    render(
-      <SchemaParameterDetails
-        parameters={{ owner: "acme", repo: "widgets" }}
-        schema={schema}
-      />,
-    );
-
-    // "title" and "merge_method" are optional and not provided — should be hidden
-    expect(screen.queryByText("not provided")).not.toBeInTheDocument();
-    expect(screen.queryByText("Issue title")).not.toBeInTheDocument();
-  });
-
-  it("shows enum options for enum parameters", () => {
+  it("hides developer chrome from the default view", () => {
     render(
       <SchemaParameterDetails
         parameters={{ owner: "acme", repo: "widgets", merge_method: "squash" }}
@@ -89,10 +79,46 @@ describe("SchemaParameterDetails", () => {
       />,
     );
 
+    expect(screen.queryByText("owner")).not.toBeInTheDocument();
+    expect(screen.queryByText("one of: merge, squash, rebase")).not.toBeInTheDocument();
+    expect(screen.queryByText("default")).not.toBeInTheDocument();
+  });
+
+  it("shows full schema details behind the developer toggle", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SchemaParameterDetails
+        parameters={{ owner: "acme" }}
+        schema={schema}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /developer details/i }));
+
+    expect(screen.getByText("Repository owner")).toBeInTheDocument();
+    expect(screen.getByText("owner")).toBeInTheDocument();
+    expect(screen.getByText("missing")).toBeInTheDocument();
+  });
+
+  it("shows enum options in developer details", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SchemaParameterDetails
+        parameters={{ owner: "acme", repo: "widgets", merge_method: "squash" }}
+        schema={schema}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /developer details/i }));
+
     expect(screen.getByText("one of: merge, squash, rebase")).toBeInTheDocument();
   });
 
-  it("shows 'default' badge when value matches default", () => {
+  it("shows default badge in developer details", async () => {
+    const user = userEvent.setup();
+
     render(
       <SchemaParameterDetails
         parameters={{ owner: "acme", repo: "widgets", merge_method: "merge" }}
@@ -100,7 +126,21 @@ describe("SchemaParameterDetails", () => {
       />,
     );
 
+    await user.click(screen.getByRole("button", { name: /developer details/i }));
+
     expect(screen.getByText("default")).toBeInTheDocument();
+  });
+
+  it("hides unprovided optional parameters from the clean view", () => {
+    render(
+      <SchemaParameterDetails
+        parameters={{ owner: "acme", repo: "widgets" }}
+        schema={schema}
+      />,
+    );
+
+    expect(screen.queryByText("Title")).not.toBeInTheDocument();
+    expect(screen.queryByText("not provided")).not.toBeInTheDocument();
   });
 
   it("renders extra parameters not in schema with humanized keys", () => {
@@ -111,7 +151,6 @@ describe("SchemaParameterDetails", () => {
       />,
     );
 
-    // humanizeKey turns "custom_field" into "Custom field"
     expect(screen.getByText("Custom field")).toBeInTheDocument();
     expect(screen.getByText("hello")).toBeInTheDocument();
   });
@@ -124,7 +163,6 @@ describe("SchemaParameterDetails", () => {
       />,
     );
 
-    // humanizeKey capitalizes the first letter
     expect(screen.getByText("Foo")).toBeInTheDocument();
     expect(screen.getByText("bar")).toBeInTheDocument();
     expect(screen.getByText("Count")).toBeInTheDocument();

--- a/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
+++ b/frontend/src/pages/dashboard/ApprovalDialog.stories.tsx
@@ -32,7 +32,10 @@ import {
   parseProtonBatchEmails,
 } from "@/components/previews/ProtonBatchEmailsPreview";
 import { SchemaParameterDetails } from "@/components/SchemaParameterDetails";
-import { RiskBadge } from "./approval-components";
+import { TimelineView } from "@/components/TimelineView";
+import { CountdownBadge, RiskBadge } from "./approval-components";
+import { ApprovalSection } from "./ApprovalSection";
+import { formatAbsoluteTime } from "@/lib/utils";
 import { getInitials } from "@/components/ui/avatar";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 import type { ActionPreviewConfig } from "@/hooks/useActionSchema";
@@ -63,14 +66,14 @@ interface MockApprovalProps {
   preview: ActionPreviewConfig | null;
   displayTemplate?: string | null;
   resourceDetails?: Record<string, unknown>;
-  /** Countdown display text (static for stories). */
-  countdown?: string;
   /** Context description shown above the preview. */
   description?: string;
   /** Whether to show the dialog in an expired state. */
   expired?: boolean;
   /** Override dialog state: "pending" | "approved-success" | "approved-error" | "approved-pending". */
   dialogState?: "pending" | "approved-success" | "approved-error" | "approved-pending";
+  createdAt?: string;
+  expiresAt?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,19 +92,19 @@ function ApprovalDialogStory({
   preview,
   displayTemplate,
   resourceDetails,
-  countdown = "9:30",
   description,
   expired = false,
   dialogState = "pending",
+  createdAt = "2026-03-16T10:00:00Z",
+  expiresAt = "2026-03-16T10:15:00Z",
 }: MockApprovalProps) {
-  const [rawOpen, setRawOpen] = useState(false);
   const hasParams = Object.keys(parameters).length > 0;
   const protonBatchEmails = parseProtonBatchEmails(resourceDetails);
 
   if (dialogState === "approved-success") {
     return (
       <Dialog open>
-        <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogContent className="max-h-[90dvh] w-[calc(100vw-1.5rem)] overflow-y-auto sm:max-w-2xl">
           <DialogHeader>
             <div className="flex items-center gap-3">
               <ConnectorLogo name={connectorName} logoSvg={connectorLogo} size="lg" />
@@ -131,7 +134,7 @@ function ApprovalDialogStory({
   if (dialogState === "approved-error") {
     return (
       <Dialog open>
-        <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogContent className="max-h-[90dvh] w-[calc(100vw-1.5rem)] overflow-y-auto sm:max-w-2xl">
           <DialogHeader>
             <div className="flex items-center gap-3">
               <ConnectorLogo name={connectorName} logoSvg={connectorLogo} size="lg" />
@@ -161,7 +164,7 @@ function ApprovalDialogStory({
   if (dialogState === "approved-pending") {
     return (
       <Dialog open>
-        <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+        <DialogContent className="max-h-[90dvh] w-[calc(100vw-1.5rem)] overflow-y-auto sm:max-w-2xl">
           <DialogHeader>
             <div className="flex items-center gap-3">
               <ConnectorLogo name={connectorName} logoSvg={connectorLogo} size="lg" />
@@ -189,7 +192,7 @@ function ApprovalDialogStory({
 
   return (
     <Dialog open>
-      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="max-h-[90dvh] w-[calc(100vw-1.5rem)] overflow-y-auto sm:max-w-2xl">
         {/* Connector header */}
         <DialogHeader>
           <div className="flex items-center gap-3">
@@ -226,15 +229,7 @@ function ApprovalDialogStory({
               <div className="flex min-w-0 items-center gap-2">
                 <span className="truncate text-sm font-semibold">{actionName}</span>
               </div>
-              <div className="flex items-center gap-2">
-                <RiskBadge level={riskLevel} />
-                <span
-                  className={`inline-flex shrink-0 items-center gap-1 text-xs font-medium ${expired ? "text-muted-foreground" : "text-muted-foreground"}`}
-                >
-                  <Clock className="size-3" />
-                  {expired ? "Expired" : countdown}
-                </span>
-              </div>
+              <RiskBadge level={riskLevel} />
             </div>
 
             {description && (
@@ -257,42 +252,37 @@ function ApprovalDialogStory({
             )}
           </div>
 
-          {/* Raw parameters (collapsible pill toggle) */}
-          {hasParams && (
-            <div className="space-y-2">
-              <button
-                type="button"
-                onClick={() => setRawOpen((o) => !o)}
-                className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                aria-expanded={rawOpen}
-              >
-                <span
-                  className="transition-transform duration-150"
-                  style={{ display: "inline-block", transform: rawOpen ? "rotate(90deg)" : "rotate(0deg)" }}
-                  aria-hidden="true"
-                >
-                  &#9656;
-                </span>
-                Parameters
-              </button>
-              {rawOpen && (
-                <div className="bg-muted/30 overflow-x-auto rounded-xl border p-3 sm:p-4">
-                  <SchemaParameterDetails parameters={parameters} schema={schema} />
-                </div>
-              )}
+          {/* Expiry */}
+          <ApprovalSection label="Expiry">
+            <div className="flex items-center gap-2">
+              <CountdownBadge expiresAt={expiresAt} />
+              <span className="text-muted-foreground text-sm">
+                {expired ? "This request has expired" : "remaining"}
+              </span>
             </div>
+            {expired && (
+              <p className="text-muted-foreground mt-2 text-sm" role="alert">
+                The agent will need to submit a new request if the action is still needed.
+              </p>
+            )}
+          </ApprovalSection>
+
+          {/* Parameters */}
+          {hasParams && (
+            <ApprovalSection label="Parameters">
+              <SchemaParameterDetails parameters={parameters} schema={schema} />
+            </ApprovalSection>
           )}
 
-          {/* Expired notice */}
-          {expired && (
-            <div role="alert" className="bg-muted/50 flex items-start gap-2 rounded-lg border p-3">
-              <Clock className="text-muted-foreground mt-0.5 size-4 shrink-0" />
-              <p className="text-muted-foreground text-sm">
-                This request has expired. The agent will need to submit a new
-                request if the action is still needed.
-              </p>
-            </div>
-          )}
+          {/* Timeline */}
+          <ApprovalSection label="Timeline">
+            <TimelineView
+              entries={[
+                { label: "Created", value: formatAbsoluteTime(createdAt) },
+                { label: "Expires", value: formatAbsoluteTime(expiresAt) },
+              ]}
+            />
+          </ApprovalSection>
 
           {/* High risk warning */}
           {riskLevel === "high" && (
@@ -306,28 +296,23 @@ function ApprovalDialogStory({
           )}
 
           {/* Action buttons */}
-          <div className="space-y-2 pt-2">
+          <div className="flex flex-col gap-2 pt-2 sm:flex-row">
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full border-destructive/40 text-destructive hover:bg-destructive/5 hover:text-destructive sm:flex-1"
+              disabled={expired}
+            >
+              Deny
+            </Button>
             <Button
               size="lg"
-              className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700"
+              className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700 sm:flex-1"
               disabled={expired}
             >
               <Check className="mr-1 size-4" />
               Approve
             </Button>
-            <Button variant="outline" size="lg" className="w-full" disabled={expired}>
-              Deny
-            </Button>
-            {hasParams && (
-              <button
-                className="text-muted-foreground hover:text-foreground flex w-full items-center justify-center gap-1 py-1 text-sm transition-colors"
-                type="button"
-                disabled={expired}
-              >
-                <ShieldCheck className="size-3" />
-                Always allow this action
-              </button>
-            )}
           </div>
         </div>
       </DialogContent>
@@ -404,6 +389,7 @@ export const Expired: Story = {
     preview: null,
     resourceDetails: { title: "Q1 Planning Review", start_time: "2026-03-16T14:00:00-05:00" },
     expired: true,
+    expiresAt: "2020-01-01T00:00:00Z",
   },
 };
 

--- a/frontend/src/pages/dashboard/ApprovalSection.tsx
+++ b/frontend/src/pages/dashboard/ApprovalSection.tsx
@@ -1,0 +1,21 @@
+interface ApprovalSectionProps {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/** Labeled section with card container — mirrors mobile approval detail layout. */
+export function ApprovalSection({
+  label,
+  children,
+  className,
+}: ApprovalSectionProps) {
+  return (
+    <section className={className}>
+      <h3 className="text-muted-foreground mb-2 text-xs font-semibold uppercase tracking-wide">
+        {label}
+      </h3>
+      <div className="rounded-xl border bg-card p-3 shadow-sm sm:p-4">{children}</div>
+    </section>
+  );
+}

--- a/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
+++ b/frontend/src/pages/dashboard/ReviewApprovalDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { Loader2, Clock, AlertTriangle, CheckCircle, XCircle, Check } from "lucide-react";
+import { Loader2, AlertTriangle, CheckCircle, XCircle, Check } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
@@ -40,12 +40,10 @@ import {
   parseProtonBatchEmails,
 } from "@/components/previews/ProtonBatchEmailsPreview";
 import type { components } from "@/api/schema";
-import {
-  useCountdown,
-  formatCountdown,
-  urgencyColor,
-  RiskBadge,
-} from "./approval-components";
+import { TimelineView, type TimelineEntry } from "@/components/TimelineView";
+import { formatAbsoluteTime } from "@/lib/utils";
+import { useCountdown, RiskBadge, CountdownBadge } from "./approval-components";
+import { ApprovalSection } from "./ApprovalSection";
 import { formatConnectorDisplayName } from "./approvalConnectorLabel";
 import { buildCreateStandingApprovalFromApproval } from "./standingApprovalFromApproval";
 
@@ -113,6 +111,36 @@ function ExecutionStatusBanner({ result }: { result: ApproveResult }) {
   );
 }
 
+function buildTimelineEntries(approval: ApprovalSummary): TimelineEntry[] {
+  const entries: TimelineEntry[] = [
+    { label: "Created", value: formatAbsoluteTime(approval.created_at) },
+    { label: "Expires", value: formatAbsoluteTime(approval.expires_at) },
+  ];
+
+  if (approval.approved_at) {
+    entries.push({
+      label: "Approved",
+      value: formatAbsoluteTime(approval.approved_at),
+      dotColor: "success",
+    });
+  }
+  if (approval.denied_at) {
+    entries.push({
+      label: "Denied",
+      value: formatAbsoluteTime(approval.denied_at),
+      dotColor: "error",
+    });
+  }
+  if (approval.cancelled_at) {
+    entries.push({
+      label: "Cancelled",
+      value: formatAbsoluteTime(approval.cancelled_at),
+    });
+  }
+
+  return entries;
+}
+
 export function ReviewApprovalDialog({
   approval,
   agentDisplayName,
@@ -124,7 +152,7 @@ export function ReviewApprovalDialog({
   const [autoApproveFuture, setAutoApproveFuture] = useState(false);
   const [pendingAction, setPendingAction] = useState<"approve" | null>(null);
   const [denialReason, setDenialReason] = useState("");
-  const [paramsOpen, setParamsOpen] = useState(false);
+  const [denyInitiated, setDenyInitiated] = useState(false);
   const isApproved = approveResult !== null;
   const { approveApproval } = useApproveApproval();
   const { denyApproval, isPending: isDenying } = useDenyApproval();
@@ -153,6 +181,10 @@ export function ReviewApprovalDialog({
   const { configs } = useActionConfigs(approval.agent_id);
   const params = approval.action.parameters as Record<string, unknown>;
   const hasParams = Object.keys(params).length > 0;
+  const timelineEntries = useMemo(
+    () => buildTimelineEntries(approval),
+    [approval],
+  );
   const hasExistingStandingApproval = useMemo(
     () =>
       standingApprovals.some(
@@ -246,6 +278,11 @@ export function ReviewApprovalDialog({
   ]);
 
   const handleDeny = useCallback(async () => {
+    if (!denyInitiated) {
+      setDenyInitiated(true);
+      return;
+    }
+
     try {
       const reason = denialReason.trim();
       await denyApproval(approval.approval_id, reason || undefined);
@@ -254,7 +291,7 @@ export function ReviewApprovalDialog({
     } catch {
       toast.error("Failed to deny request. Please try again.");
     }
-  }, [denyApproval, approval.approval_id, denialReason, onOpenChange]);
+  }, [denyApproval, approval.approval_id, denialReason, denyInitiated, onOpenChange]);
 
   function handleClose(nextOpen: boolean) {
     if (!nextOpen) {
@@ -263,19 +300,25 @@ export function ReviewApprovalDialog({
       setAutoApproveFuture(false);
       setPendingAction(null);
       setDenialReason("");
+      setDenyInitiated(false);
     }
     onOpenChange(nextOpen);
   }
 
+  function cancelDeny() {
+    setDenyInitiated(false);
+    setDenialReason("");
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-2xl">
+      <DialogContent className="max-h-[90dvh] w-[calc(100vw-1.5rem)] overflow-y-auto sm:max-w-2xl">
         {/* Connector header with logo, action name, and connector name */}
         <DialogHeader>
           <div className="flex items-center gap-3">
             {schemaLoading ? (
               <>
-                <Skeleton className="size-10 rounded-lg shrink-0" />
+                <Skeleton className="size-10 shrink-0 rounded-lg" />
                 <div className="min-w-0 flex-1 space-y-2">
                   <DialogTitle className="sr-only">Loading action details…</DialogTitle>
                   <Skeleton className="h-4 w-40" />
@@ -350,37 +393,25 @@ export function ReviewApprovalDialog({
 
             {/* Rich action preview card */}
             <div className="space-y-2">
-              {/* Action header above the card */}
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2">
                   <span className="truncate text-sm font-semibold">
                     {actionName ?? approval.action.type}
                   </span>
                 </div>
-                <div className="flex items-center gap-2">
-                  <RiskBadge level={approval.context.risk_level} />
-                  <span
-                    aria-label={isExpired ? "Request expired" : `Time remaining: ${formatCountdown(remaining)}`}
-                    className={`inline-flex shrink-0 items-center gap-1 text-xs font-medium ${urgencyColor(remaining)}`}
-                  >
-                    <Clock className="size-3" aria-hidden="true" />
-                    {isExpired ? "Expired" : formatCountdown(remaining)}
-                  </span>
-                </div>
+                <RiskBadge level={approval.context.risk_level} />
               </div>
 
-              {/* Context description */}
               {approval.context.description && (
                 <p className="text-muted-foreground text-sm">
                   {approval.context.description}
                 </p>
               )}
 
-              {/* Preview card — show skeleton while connector metadata loads */}
               {schemaLoading ? (
                 <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm space-y-3">
                   <div className="flex items-center gap-3">
-                    <Skeleton className="size-10 rounded-lg shrink-0" />
+                    <Skeleton className="size-10 shrink-0 rounded-lg" />
                     <div className="flex-1 space-y-2">
                       <Skeleton className="h-4 w-3/4" />
                       <Skeleton className="h-3 w-1/2" />
@@ -419,49 +450,39 @@ export function ReviewApprovalDialog({
               )}
             </div>
 
-            {/* Raw parameters (collapsible pill toggle) */}
-            {hasParams && (
-              <div className="space-y-2">
-                <button
-                  type="button"
-                  onClick={() => setParamsOpen((o) => !o)}
-                  className="text-muted-foreground hover:text-foreground hover:bg-muted/50 inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                  aria-expanded={paramsOpen}
-                >
-                  <span
-                    className="transition-transform duration-150"
-                    style={{ display: "inline-block", transform: paramsOpen ? "rotate(90deg)" : "rotate(0deg)" }}
-                    aria-hidden="true"
-                  >
-                    &#9656;
-                  </span>
-                  Parameters
-                </button>
-                {paramsOpen && (
-                  <div className="bg-muted/30 overflow-x-auto rounded-xl border p-3 sm:p-4">
-                    <SchemaParameterDetails
-                      parameters={params}
-                      schema={schema}
-                      actionType={approval.action.type}
-                      resourceDetails={
-                        approval.resource_details as Record<string, unknown> | undefined
-                      }
-                    />
-                  </div>
-                )}
+            {/* Expiry */}
+            <ApprovalSection label="Expiry">
+              <div className="flex items-center gap-2">
+                <CountdownBadge expiresAt={approval.expires_at} />
+                <span className="text-muted-foreground text-sm">
+                  {isExpired ? "This request has expired" : "remaining"}
+                </span>
               </div>
+              {isExpired && (
+                <p className="text-muted-foreground mt-2 text-sm" role="alert">
+                  The agent will need to submit a new request if the action is still needed.
+                </p>
+              )}
+            </ApprovalSection>
+
+            {/* Parameters */}
+            {hasParams && (
+              <ApprovalSection label="Parameters">
+                <SchemaParameterDetails
+                  parameters={params}
+                  schema={schema}
+                  actionType={approval.action.type}
+                  resourceDetails={
+                    approval.resource_details as Record<string, unknown> | undefined
+                  }
+                />
+              </ApprovalSection>
             )}
 
-            {/* Expired notice */}
-            {isExpired && (
-              <div role="alert" className="bg-muted/50 flex items-start gap-2 rounded-lg border p-3">
-                <Clock className="text-muted-foreground mt-0.5 size-4 shrink-0" aria-hidden="true" />
-                <p className="text-muted-foreground text-sm">
-                  This request has expired. The agent will need to submit a new
-                  request if the action is still needed.
-                </p>
-              </div>
-            )}
+            {/* Timeline */}
+            <ApprovalSection label="Timeline">
+              <TimelineView entries={timelineEntries} />
+            </ApprovalSection>
 
             {/* High risk warning */}
             {approval.context.risk_level === "high" && (
@@ -474,9 +495,9 @@ export function ReviewApprovalDialog({
               </div>
             )}
 
-            {/* Action buttons — stacked full-width matching mockup */}
-            <div className="space-y-2 pt-2">
-              {showAutoApproveCheckbox && (
+            {/* Action buttons */}
+            <div className="space-y-3 pt-2">
+              {showAutoApproveCheckbox && !denyInitiated && (
                 <div className="flex items-start gap-3 rounded-lg border p-3">
                   <Checkbox
                     id="auto-approve-future"
@@ -497,53 +518,87 @@ export function ReviewApprovalDialog({
                 </div>
               )}
 
-              <div className="space-y-2">
-                <Label htmlFor="denial-reason" className="text-sm font-medium">
-                  Reason for denial (optional)
-                </Label>
-                <textarea
-                  id="denial-reason"
-                  value={denialReason}
-                  onChange={(event) => setDenialReason(event.target.value)}
-                  disabled={isBusy || isExpired}
-                  maxLength={500}
-                  rows={3}
-                  placeholder="Explain why you're denying this request so the agent can adapt."
-                  className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                />
+              {denyInitiated && (
+                <div className="space-y-2">
+                  <Label htmlFor="denial-reason" className="text-sm font-medium">
+                    Reason for denial (optional)
+                  </Label>
+                  <textarea
+                    id="denial-reason"
+                    value={denialReason}
+                    onChange={(event) => setDenialReason(event.target.value)}
+                    disabled={isBusy || isExpired}
+                    maxLength={500}
+                    rows={3}
+                    autoFocus
+                    placeholder="Explain why you're denying this request so the agent can adapt."
+                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  />
+                </div>
+              )}
+
+              <div className="flex flex-col gap-2 sm:flex-row">
+                {denyInitiated ? (
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="w-full sm:flex-1"
+                    disabled={isBusy || isExpired}
+                    onClick={cancelDeny}
+                  >
+                    Cancel
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    className="w-full border-destructive/40 text-destructive hover:bg-destructive/5 hover:text-destructive sm:flex-1"
+                    disabled={isBusy || isExpired}
+                    onClick={handleDeny}
+                    aria-label={isDenying ? "Denying request…" : undefined}
+                  >
+                    {isDenying ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      "Deny"
+                    )}
+                  </Button>
+                )}
+
+                {denyInitiated ? (
+                  <Button
+                    variant="destructive"
+                    size="lg"
+                    className="w-full sm:flex-1"
+                    disabled={isBusy || isExpired}
+                    onClick={handleDeny}
+                    aria-label={isDenying ? "Confirming denial…" : undefined}
+                  >
+                    {isDenying ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      "Confirm deny"
+                    )}
+                  </Button>
+                ) : (
+                  <Button
+                    size="lg"
+                    className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700 sm:flex-1"
+                    disabled={isBusy || isExpired}
+                    onClick={handleApprove}
+                    aria-label={pendingAction === "approve" ? "Approving request…" : undefined}
+                  >
+                    {pendingAction === "approve" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <>
+                        <Check className="mr-1 size-4" />
+                        Approve
+                      </>
+                    )}
+                  </Button>
+                )}
               </div>
-
-              <Button
-                size="lg"
-                className="w-full bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-600 dark:hover:bg-emerald-700"
-                disabled={isBusy || isExpired}
-                onClick={handleApprove}
-                aria-label={pendingAction === "approve" ? "Approving request…" : undefined}
-              >
-                {pendingAction === "approve" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <>
-                    <Check className="mr-1 size-4" />
-                    Approve
-                  </>
-                )}
-              </Button>
-
-              <Button
-                variant="outline"
-                size="lg"
-                className="w-full"
-                disabled={isBusy || isExpired}
-                onClick={handleDeny}
-                aria-label={isDenying ? "Denying request…" : undefined}
-              >
-                {isDenying ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  "Deny"
-                )}
-              </Button>
             </div>
           </div>
         )}

--- a/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/PendingApprovalsBanner.test.tsx
@@ -260,6 +260,14 @@ describe("PendingApprovalsBanner", () => {
     await user.click(screen.getByRole("button", { name: "Deny" }));
 
     await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Confirm deny" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Confirm deny" }));
+
+    await waitFor(() => {
       expect(mockPost).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rework `SchemaParameterDetails` into a clean key/value list (humanized keys or `x-ui` labels) with full schema metadata tucked behind a collapsed "Developer details" toggle.
- Restructure `ReviewApprovalDialog` into labeled Expiry, Parameters, and Timeline sections; progressive denial-reason disclosure; side-by-side Approve/Deny actions; and narrower mobile-friendly dialog width.
- Update `ApprovalDialog.stories.tsx` and tests to mirror the new markup. Bulk/standing-approval dialogs were reviewed and left unchanged — they do not use the parameter renderer.

Closes #1322

## Test plan

### Claude Code
- [x] `make test-frontend` — 935 tests pass
- [x] Frontend `tsc` + Vite build pass (`make build` Go step skipped in sandbox — Go 1.22 vs go.mod 1.25)
- [x] `SchemaParameterDetails` tests cover clean view + developer toggle
- [x] `PendingApprovalsBanner` deny flow updated for two-step deny

### OpenClaw
- [ ] Visual review of approval dialog on desktop and phone-width viewport in Storybook (`UI/Dialog/Approval Dialog`)
- [ ] Confirm denial progressive disclosure feels right in production

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93f23529-cbeb-4315-a0e5-dca4d47ea6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93f23529-cbeb-4315-a0e5-dca4d47ea6b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

