### PR TITLE
Add protonmail.download_attachment action

### DIFF
--- a/connectors/protonmail/attachment_helpers.go
+++ b/connectors/protonmail/attachment_helpers.go
@@ -1,0 +1,107 @@
+package protonmail
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime/quotedprintable"
+	"strconv"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// formatPartPath renders an IMAP MIME part path as a stable string key (e.g. "2.1").
+func formatPartPath(path []int) string {
+	if len(path) == 0 {
+		return ""
+	}
+	parts := make([]string, len(path))
+	for i, p := range path {
+		parts[i] = strconv.Itoa(p)
+	}
+	return strings.Join(parts, ".")
+}
+
+// parsePartPath parses a MIME part path string (e.g. "2.1") into IMAP part indices.
+func parsePartPath(s string) ([]int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("empty attachment_id")
+	}
+
+	segments := strings.Split(s, ".")
+	path := make([]int, len(segments))
+	for i, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			return nil, fmt.Errorf("invalid attachment_id %q: empty segment", s)
+		}
+		n, err := strconv.Atoi(seg)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("invalid attachment_id %q: segment %q must be a positive integer", s, seg)
+		}
+		path[i] = n
+	}
+	return path, nil
+}
+
+func pathsEqual(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// findAttachmentPart locates a single-part attachment at the given MIME path.
+func findAttachmentPart(bs imap.BodyStructure, path []int) (*imap.BodyStructureSinglePart, bool) {
+	if bs == nil || len(path) == 0 {
+		return nil, false
+	}
+
+	var found *imap.BodyStructureSinglePart
+	bs.Walk(func(walkPath []int, part imap.BodyStructure) bool {
+		if !pathsEqual(walkPath, path) {
+			return true
+		}
+		sp, ok := part.(*imap.BodyStructureSinglePart)
+		if !ok || sp.Filename() == "" {
+			return true
+		}
+		found = sp
+		return true
+	})
+	return found, found != nil
+}
+
+// decodeTransferEncoding decodes a MIME part body according to its Content-Transfer-Encoding.
+func decodeTransferEncoding(raw []byte, encoding string) ([]byte, error) {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "", "7bit", "8bit", "binary":
+		return raw, nil
+	case "base64", "b64":
+		decoder := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(raw))
+		decoded, err := io.ReadAll(decoder)
+		if err != nil {
+			return nil, fmt.Errorf("base64 decode failed: %w", err)
+		}
+		return decoded, nil
+	case "quoted-printable", "qp":
+		decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(raw)))
+		if err != nil {
+			return nil, fmt.Errorf("quoted-printable decode failed: %w", err)
+		}
+		return decoded, nil
+	default:
+		return nil, &connectors.ExternalError{
+			Message: fmt.Sprintf("unsupported Content-Transfer-Encoding: %q", encoding),
+		}
+	}
+}

--- a/connectors/protonmail/download_attachment.go
+++ b/connectors/protonmail/download_attachment.go
@@ -92,7 +92,7 @@ func fetchAttachmentContentFromIMAP(
 	ctx context.Context,
 	conn *ProtonMailConnector,
 	creds connectors.Credentials,
-	mailboxUIDValidity map[string]uint32,
+	mailboxUIDValidity connectors.MailboxUIDValidityStore,
 	folder string,
 	messageID uint32,
 	partPath []int,

--- a/connectors/protonmail/download_attachment.go
+++ b/connectors/protonmail/download_attachment.go
@@ -1,0 +1,186 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// fetchAttachmentContent fetches and decodes a single attachment from IMAP.
+// Tests may replace this variable to avoid a live IMAP server.
+var fetchAttachmentContent = fetchAttachmentContentFromIMAP
+
+type downloadAttachmentAction struct {
+	conn *ProtonMailConnector
+}
+
+type downloadAttachmentParams struct {
+	MessageID    uint32 `json:"message_id"`
+	Folder       string `json:"folder"`
+	AttachmentID string `json:"attachment_id"`
+}
+
+func (p *downloadAttachmentParams) validate() error {
+	if p.MessageID == 0 {
+		return &connectors.ValidationError{Message: "missing required parameter: message_id"}
+	}
+	p.AttachmentID = strings.TrimSpace(p.AttachmentID)
+	if p.AttachmentID == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: attachment_id"}
+	}
+	if _, err := parsePartPath(p.AttachmentID); err != nil {
+		return &connectors.ValidationError{Message: fmt.Sprintf("invalid attachment_id: %v", err)}
+	}
+	if p.Folder == "" {
+		p.Folder = "INBOX"
+	}
+	return nil
+}
+
+type downloadAttachmentResult struct {
+	UID           uint32 `json:"uid"`
+	Folder        string `json:"folder"`
+	AttachmentID  string `json:"attachment_id"`
+	Filename      string `json:"filename"`
+	ContentType   string `json:"content_type"`
+	Size          int    `json:"size"`
+	ContentBase64 string `json:"content_base64"`
+}
+
+func (a *downloadAttachmentAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	var params downloadAttachmentParams
+	if err := json.Unmarshal(req.Parameters, &params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	partPath, err := parsePartPath(params.AttachmentID)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid attachment_id: %v", err)}
+	}
+
+	result, err := fetchAttachmentContent(ctx, a.conn, req.Credentials, req.MailboxUIDValidity, params.Folder, params.MessageID, partPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(downloadAttachmentResult{
+		UID:           params.MessageID,
+		Folder:        params.Folder,
+		AttachmentID:  params.AttachmentID,
+		Filename:      result.Filename,
+		ContentType:   result.ContentType,
+		Size:          len(result.Content),
+		ContentBase64: base64.StdEncoding.EncodeToString(result.Content),
+	})
+}
+
+type fetchedAttachment struct {
+	Filename    string
+	ContentType string
+	Content     []byte
+}
+
+func fetchAttachmentContentFromIMAP(
+	ctx context.Context,
+	conn *ProtonMailConnector,
+	creds connectors.Credentials,
+	mailboxUIDValidity map[string]uint32,
+	folder string,
+	messageID uint32,
+	partPath []int,
+) (*fetchedAttachment, error) {
+	_ = ctx
+
+	session, err := connectIMAP(creds, conn.timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	mboxData, err := session.selectMailbox(folder)
+	if err != nil {
+		return nil, err
+	}
+	if err := syncUIDValidity(folder, mboxData, mailboxUIDValidity, uidValidityVerify); err != nil {
+		return nil, err
+	}
+
+	uidSet := imap.UIDSetNum(imap.UID(messageID))
+	bodySection := &imap.FetchItemBodySection{
+		Part: partPath,
+		Peek: true,
+		Partial: &imap.SectionPartial{
+			Offset: 0,
+			Size:   int64(maxBodySize) + 1,
+		},
+	}
+
+	fetchCmd := session.client.Fetch(uidSet, &imap.FetchOptions{
+		UID: true,
+		BodyStructure: &imap.FetchItemBodyStructure{
+			Extended: true,
+		},
+		BodySection: []*imap.FetchItemBodySection{bodySection},
+	})
+	defer fetchCmd.Close()
+
+	msg := fetchCmd.Next()
+	if msg == nil {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("message uid %d not found in folder %q", messageID, folder),
+		}
+	}
+
+	buf, err := msg.Collect()
+	if err != nil {
+		return nil, mapIMAPError(err)
+	}
+	if buf.UID == 0 {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("message uid %d not found in folder %q", messageID, folder),
+		}
+	}
+
+	part, ok := findAttachmentPart(buf.BodyStructure, partPath)
+	if !ok {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("attachment %q not found on message uid %d in folder %q", formatPartPath(partPath), messageID, folder),
+		}
+	}
+
+	raw := buf.FindBodySection(bodySection)
+	if raw == nil {
+		return nil, &connectors.ExternalError{
+			Message: fmt.Sprintf("failed to fetch attachment %q from message uid %d", formatPartPath(partPath), messageID),
+		}
+	}
+	if len(raw) > maxBodySize {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("attachment %q exceeds maximum size of %d bytes", formatPartPath(partPath), maxBodySize),
+		}
+	}
+
+	decoded, err := decodeTransferEncoding(raw, part.Encoding)
+	if err != nil {
+		return nil, err
+	}
+	if len(decoded) > maxBodySize {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("attachment %q exceeds maximum size of %d bytes after decoding", formatPartPath(partPath), maxBodySize),
+		}
+	}
+
+	return &fetchedAttachment{
+		Filename:    part.Filename(),
+		ContentType: part.MediaType(),
+		Content:     decoded,
+	}, nil
+}

--- a/connectors/protonmail/download_attachment_test.go
+++ b/connectors/protonmail/download_attachment_test.go
@@ -15,7 +15,7 @@ func TestDownloadAttachment_Success(t *testing.T) {
 	t.Parallel()
 
 	old := fetchAttachmentContent
-	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, folder string, messageID uint32, partPath []int) (*fetchedAttachment, error) {
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ connectors.MailboxUIDValidityStore, folder string, messageID uint32, partPath []int) (*fetchedAttachment, error) {
 		if folder != "INBOX" || messageID != 42 || formatPartPath(partPath) != "2.1" {
 			return nil, fmt.Errorf("unexpected fetch args: folder=%q messageID=%d path=%v", folder, messageID, partPath)
 		}
@@ -72,7 +72,7 @@ func TestDownloadAttachment_MessageNotFound(t *testing.T) {
 	t.Parallel()
 
 	old := fetchAttachmentContent
-	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ connectors.MailboxUIDValidityStore, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
 		return nil, &connectors.ValidationError{Message: `message uid 99 not found in folder "INBOX"`}
 	}
 	t.Cleanup(func() { fetchAttachmentContent = old })
@@ -102,7 +102,7 @@ func TestDownloadAttachment_AttachmentNotFound(t *testing.T) {
 	t.Parallel()
 
 	old := fetchAttachmentContent
-	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ connectors.MailboxUIDValidityStore, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
 		return nil, &connectors.ValidationError{Message: `attachment "9.9" not found on message uid 42 in folder "INBOX"`}
 	}
 	t.Cleanup(func() { fetchAttachmentContent = old })
@@ -132,7 +132,7 @@ func TestDownloadAttachment_Oversized(t *testing.T) {
 	t.Parallel()
 
 	old := fetchAttachmentContent
-	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ connectors.MailboxUIDValidityStore, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
 		return nil, &connectors.ValidationError{
 			Message: fmt.Sprintf("attachment %q exceeds maximum size of %d bytes", "2.1", maxBodySize),
 		}

--- a/connectors/protonmail/download_attachment_test.go
+++ b/connectors/protonmail/download_attachment_test.go
@@ -1,0 +1,314 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestDownloadAttachment_Success(t *testing.T) {
+	t.Parallel()
+
+	old := fetchAttachmentContent
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, folder string, messageID uint32, partPath []int) (*fetchedAttachment, error) {
+		if folder != "INBOX" || messageID != 42 || formatPartPath(partPath) != "2.1" {
+			return nil, fmt.Errorf("unexpected fetch args: folder=%q messageID=%d path=%v", folder, messageID, partPath)
+		}
+		return &fetchedAttachment{
+			Filename:    "report.pdf",
+			ContentType: "application/pdf",
+			Content:     []byte("pdf-bytes"),
+		}, nil
+	}
+	t.Cleanup(func() { fetchAttachmentContent = old })
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(downloadAttachmentParams{
+		MessageID:    42,
+		Folder:       "INBOX",
+		AttachmentID: "2.1",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+	if data["filename"] != "report.pdf" {
+		t.Errorf("expected filename report.pdf, got %v", data["filename"])
+	}
+	if data["content_type"] != "application/pdf" {
+		t.Errorf("expected content_type application/pdf, got %v", data["content_type"])
+	}
+	if int(data["size"].(float64)) != len("pdf-bytes") {
+		t.Errorf("expected size %d, got %v", len("pdf-bytes"), data["size"])
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(data["content_base64"].(string))
+	if err != nil {
+		t.Fatalf("failed to decode content_base64: %v", err)
+	}
+	if string(decoded) != "pdf-bytes" {
+		t.Errorf("expected decoded content %q, got %q", "pdf-bytes", string(decoded))
+	}
+}
+
+func TestDownloadAttachment_MessageNotFound(t *testing.T) {
+	t.Parallel()
+
+	old := fetchAttachmentContent
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+		return nil, &connectors.ValidationError{Message: `message uid 99 not found in folder "INBOX"`}
+	}
+	t.Cleanup(func() { fetchAttachmentContent = old })
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(downloadAttachmentParams{
+		MessageID:    99,
+		AttachmentID: "2.1",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown message")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDownloadAttachment_AttachmentNotFound(t *testing.T) {
+	t.Parallel()
+
+	old := fetchAttachmentContent
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+		return nil, &connectors.ValidationError{Message: `attachment "9.9" not found on message uid 42 in folder "INBOX"`}
+	}
+	t.Cleanup(func() { fetchAttachmentContent = old })
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(downloadAttachmentParams{
+		MessageID:    42,
+		AttachmentID: "9.9",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown attachment")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDownloadAttachment_Oversized(t *testing.T) {
+	t.Parallel()
+
+	old := fetchAttachmentContent
+	fetchAttachmentContent = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ map[string]uint32, _ string, _ uint32, _ []int) (*fetchedAttachment, error) {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("attachment %q exceeds maximum size of %d bytes", "2.1", maxBodySize),
+		}
+	}
+	t.Cleanup(func() { fetchAttachmentContent = old })
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(downloadAttachmentParams{
+		MessageID:    42,
+		AttachmentID: "2.1",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for oversized attachment")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Errorf("expected oversize message, got: %v", err)
+	}
+}
+
+func TestDownloadAttachment_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  []byte(`{invalid`),
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDownloadAttachment_MissingMessageID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{
+		"attachment_id": "2.1",
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDownloadAttachment_MissingAttachmentID(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &downloadAttachmentAction{conn: conn}
+
+	params, _ := json.Marshal(map[string]any{
+		"message_id": 42,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.download_attachment",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing attachment_id")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got: %T", err)
+	}
+}
+
+func TestDownloadAttachmentParams_Defaults(t *testing.T) {
+	t.Parallel()
+
+	p := &downloadAttachmentParams{
+		MessageID:    1,
+		AttachmentID: "2.1",
+	}
+	if err := p.validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Folder != "INBOX" {
+		t.Errorf("expected default folder INBOX, got %q", p.Folder)
+	}
+}
+
+func TestParsePartPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input   string
+		want    []int
+		wantErr bool
+	}{
+		{"2.1", []int{2, 1}, false},
+		{"1", []int{1}, false},
+		{"", nil, true},
+		{"0.1", nil, true},
+		{"2.a", nil, true},
+		{"2..1", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parsePartPath(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parsePartPath(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && !pathsEqual(got, tt.want) {
+				t.Errorf("parsePartPath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPartPath(t *testing.T) {
+	t.Parallel()
+
+	if got := formatPartPath([]int{2, 1}); got != "2.1" {
+		t.Errorf("formatPartPath([]int{2,1}) = %q, want 2.1", got)
+	}
+	if got := formatPartPath(nil); got != "" {
+		t.Errorf("formatPartPath(nil) = %q, want empty", got)
+	}
+}
+
+func TestDecodeTransferEncoding(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("SGVsbG8=")
+	decoded, err := decodeTransferEncoding(raw, "base64")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(decoded) != "Hello" {
+		t.Errorf("expected Hello, got %q", string(decoded))
+	}
+
+	plain, err := decodeTransferEncoding([]byte("plain"), "7bit")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(plain) != "plain" {
+		t.Errorf("expected plain, got %q", string(plain))
+	}
+
+	qpRaw := []byte("Hello=20World")
+	qpDecoded, err := decodeTransferEncoding(qpRaw, "quoted-printable")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(qpDecoded) != "Hello World" {
+		t.Errorf("expected 'Hello World', got %q", string(qpDecoded))
+	}
+}

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -227,6 +227,34 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				}`)),
 			},
 			{
+				ActionType:      "protonmail.download_attachment",
+				Name:            "Download Attachment",
+				Description:     "Download a single attachment from an email by MIME part path",
+				RiskLevel:       "low",
+				DisplayTemplate: "Download attachment from email in {{folder}}",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["message_id", "attachment_id"],
+					"properties": {
+						"message_id": {
+							"type": "integer",
+							"minimum": 1,
+							"description": "Stable IMAP UID of the email within the folder (from read_inbox or search_emails results)"
+						},
+						"attachment_id": {
+							"type": "string",
+							"minLength": 1,
+							"description": "MIME part path identifying the attachment (from read_email attachments[].part_id, e.g. \"2.1\")"
+						},
+						"folder": {
+							"type": "string",
+							"default": "INBOX",
+							"description": "Mailbox folder containing the email"
+						}
+					}
+				}`)),
+			},
+			{
 				ActionType:      "protonmail.archive_email",
 				Name:            "Archive Email",
 				Description:     "Move one or more emails to the Archive folder via IMAP MOVE, archiving whole conversations by default",

--- a/connectors/protonmail/manifest_templates.go
+++ b/connectors/protonmail/manifest_templates.go
@@ -44,6 +44,13 @@ func protonmailTemplates() []connectors.ManifestTemplate {
 			Parameters:  json.RawMessage(`{"folder":"INBOX","message_id":"*"}`),
 		},
 		{
+			ID:          "tpl_protonmail_download_attachment",
+			ActionType:  "protonmail.download_attachment",
+			Name:        "Download an email attachment",
+			Description: "Agent can download the content of an email attachment.",
+			Parameters:  json.RawMessage(`{"folder":"INBOX","message_id":"*","attachment_id":"*"}`),
+		},
+		{
 			ID:          "tpl_protonmail_archive",
 			ActionType:  "protonmail.archive_email",
 			Name:        "Archive emails",

--- a/connectors/protonmail/protonmail.go
+++ b/connectors/protonmail/protonmail.go
@@ -3,7 +3,7 @@
 // Mail Bridge (official, x86_64) or hydroxide (open-source, ARM-friendly). Both
 // expose the same loopback IMAP/SMTP surface that this connector targets.
 //
-// Actions: send_email, reply_email (SMTP); read/search/inbox, archive/move/delete, flags (IMAP).
+// Actions: send_email, reply_email (SMTP); read/search/inbox, archive/move/delete, flags, download_attachment (IMAP).
 package protonmail
 
 import (
@@ -49,19 +49,20 @@ func (c *ProtonMailConnector) ID() string { return "protonmail" }
 // Actions returns the registered action handlers keyed by action_type.
 func (c *ProtonMailConnector) Actions() map[string]connectors.Action {
 	return map[string]connectors.Action{
-		"protonmail.send_email":     &sendEmailAction{conn: c},
-		"protonmail.reply_email":    &replyEmailAction{conn: c},
-		"protonmail.read_inbox":     &readInboxAction{conn: c},
-		"protonmail.search_emails":  &searchEmailsAction{conn: c},
-		"protonmail.read_email":     &readEmailAction{conn: c},
-		"protonmail.archive_email":  &archiveEmailAction{conn: c},
-		"protonmail.list_folders":   &listFoldersAction{conn: c},
-		"protonmail.mark_read":      newMarkReadAction(c),
-		"protonmail.mark_unread":    newMarkUnreadAction(c),
-		"protonmail.flag":           newFlagAction(c),
-		"protonmail.unflag":         newUnflagAction(c),
-		"protonmail.move_to_folder": &moveToFolderAction{conn: c},
-		"protonmail.delete":         &deleteEmailAction{conn: c},
+		"protonmail.send_email":          &sendEmailAction{conn: c},
+		"protonmail.reply_email":         &replyEmailAction{conn: c},
+		"protonmail.read_inbox":          &readInboxAction{conn: c},
+		"protonmail.search_emails":       &searchEmailsAction{conn: c},
+		"protonmail.read_email":          &readEmailAction{conn: c},
+		"protonmail.download_attachment": &downloadAttachmentAction{conn: c},
+		"protonmail.archive_email":       &archiveEmailAction{conn: c},
+		"protonmail.list_folders":        &listFoldersAction{conn: c},
+		"protonmail.mark_read":           newMarkReadAction(c),
+		"protonmail.mark_unread":         newMarkUnreadAction(c),
+		"protonmail.flag":                newFlagAction(c),
+		"protonmail.unflag":              newUnflagAction(c),
+		"protonmail.move_to_folder":      &moveToFolderAction{conn: c},
+		"protonmail.delete":              &deleteEmailAction{conn: c},
 	}
 }
 

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -29,6 +29,7 @@ func TestProtonMailConnector_Actions(t *testing.T) {
 		"protonmail.read_inbox",
 		"protonmail.search_emails",
 		"protonmail.read_email",
+		"protonmail.download_attachment",
 		"protonmail.archive_email",
 		"protonmail.list_folders",
 		"protonmail.mark_read",
@@ -184,6 +185,7 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 		"protonmail.read_inbox",
 		"protonmail.search_emails",
 		"protonmail.read_email",
+		"protonmail.download_attachment",
 		"protonmail.archive_email",
 		"protonmail.list_folders",
 		"protonmail.mark_read",
@@ -282,7 +284,7 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 			if a.RiskLevel != "medium" {
 				t.Errorf("%s risk_level = %q, want medium", a.ActionType, a.RiskLevel)
 			}
-		case "protonmail.read_inbox", "protonmail.search_emails", "protonmail.read_email":
+		case "protonmail.read_inbox", "protonmail.search_emails", "protonmail.read_email", "protonmail.download_attachment":
 			if a.RiskLevel != "low" {
 				t.Errorf("%s risk_level = %q, want low", a.ActionType, a.RiskLevel)
 			}

--- a/connectors/protonmail/read_email.go
+++ b/connectors/protonmail/read_email.go
@@ -20,7 +20,8 @@ import (
 const maxBodySize = 1024 * 1024
 
 // readEmailAction fetches a single email by stable UID, returning the full
-// body, headers, and attachment metadata (but not attachment content).
+// body, headers, and attachment metadata (including part_id for download_attachment,
+// but not attachment content).
 type readEmailAction struct {
 	conn *ProtonMailConnector
 }
@@ -57,6 +58,7 @@ type emailDetail struct {
 }
 
 type attachmentInfo struct {
+	PartID      string `json:"part_id"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	Size        uint32 `json:"size"`
@@ -144,6 +146,7 @@ func (a *readEmailAction) Execute(ctx context.Context, req connectors.ActionRequ
 			if sp, ok := part.(*imap.BodyStructureSinglePart); ok {
 				if fn := sp.Filename(); fn != "" {
 					detail.Attachments = append(detail.Attachments, attachmentInfo{
+						PartID:      formatPartPath(path),
 						Filename:    fn,
 						ContentType: sp.MediaType(),
 						Size:        sp.Size,

--- a/docs/connectors/protonmail.md
+++ b/docs/connectors/protonmail.md
@@ -20,6 +20,7 @@ If you're currently self-hosting on ARM hardware, we recommend running Permissio
 | `protonmail.read_inbox` | low | List recent messages in a folder |
 | `protonmail.search_emails` | low | Search by subject, sender, or date |
 | `protonmail.read_email` | low | Read one message by stable IMAP UID |
+| `protonmail.download_attachment` | low | Download one attachment by MIME part path (`part_id` from `read_email`) |
 | `protonmail.archive_email` | medium | Move messages to Archive (IMAP UID MOVE) |
 
 ### Archiving whole conversations
@@ -33,6 +34,8 @@ The approval card lists every message that will be archived when thread expansio
 ### Message identifiers (breaking change)
 
 `read_inbox` and `search_emails` return each message's **stable IMAP UID** (with its `folder`) instead of volatile sequence numbers. `read_email` and `archive_email` accept that same UID as `message_id` / `message_ids`, scoped by `folder`.
+
+`read_email` lists attachment metadata including a `part_id` (MIME part path, e.g. `"2.1"`). Pass that `part_id` to `protonmail.download_attachment` along with the same `message_id` and `folder` to fetch the attachment bytes (base64-encoded in the JSON result). Attachments larger than 1 MB are rejected with a clear error.
 
 Sequence numbers shift whenever another message is deleted or moved; UIDs do not. Permission Slip records **UIDVALIDITY** server-side per folder so pending approvals still target the same mailbox generation — if the folder is recreated, execution fails safe instead of acting on the wrong message.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1328

Adds the ability to download individual email attachment content from the Proton Mail connector.

- **New action `protonmail.download_attachment`** — takes `message_id`, `folder`, and `attachment_id` (MIME part path, e.g. `"2.1"`), fetches the part via IMAP `BODY.PEEK`, decodes Content-Transfer-Encoding, and returns base64-encoded bytes in the JSON result.
- **`read_email` now exposes `part_id`** on each attachment entry so callers can round-trip from metadata to download.
- **1 MB size cap** (same as `maxBodySize` in `read_email`) — oversized attachments return a clear validation error rather than truncated binary.
- **Unit tests** cover successful download, unknown message, unknown attachment, oversize handling, and helper functions (path parsing, transfer decoding).
- **Docs** updated in `docs/connectors/protonmail.md`.

## Test plan

- [x] `gofmt` on all changed Go files
- [ ] `go test ./connectors/protonmail/...` (not run locally — sandbox Go toolchain cannot resolve the full module graph; relying on CI)
- [ ] CI green on PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf0c7ecb-6628-4ede-b9fc-0aafc72c64ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf0c7ecb-6628-4ede-b9fc-0aafc72c64ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

