### PR TITLE
Proton Mail: add label apply/remove + label discovery actions

### DIFF
--- a/connectors/protonmail/apply_label.go
+++ b/connectors/protonmail/apply_label.go
@@ -1,0 +1,101 @@
+package protonmail
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type applyLabelAction struct {
+	conn *ProtonMailConnector
+}
+
+// applyLabelExpandUIDsFn expands label targets to full conversations. Tests may
+// replace it to avoid a live proxy.
+var applyLabelExpandUIDsFn = expandArchiveUIDs
+
+// applyLabelPerformCopy executes the UID COPY into the label mailbox. Tests may
+// replace it to avoid a live proxy.
+var applyLabelPerformCopy = func(session *imapSession, uids []uint32, labelMailbox string) error {
+	copyCmd := session.client.Copy(uidSetFromMessageIDs(uids), labelMailbox)
+	_, err := copyCmd.Wait()
+	return err
+}
+
+// applyLabelConnectAndSelect opens a read-write IMAP session in the source
+// folder and verifies UIDVALIDITY. Tests may replace it to avoid a live proxy.
+var applyLabelConnectAndSelect = func(creds connectors.Credentials, timeout time.Duration, folder string, store connectors.MailboxUIDValidityStore) (*imapSession, error) {
+	session, err := connectIMAP(creds, timeout)
+	if err != nil {
+		return nil, err
+	}
+	mboxData, err := session.selectMailboxReadWrite(folder)
+	if err != nil {
+		session.close()
+		return nil, err
+	}
+	if err := syncUIDValidity(folder, mboxData, store, uidValidityVerify); err != nil {
+		session.close()
+		return nil, err
+	}
+	return session, nil
+}
+
+func (a *applyLabelAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseLabelMessageParams(req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	session, err := applyLabelConnectAndSelect(req.Credentials, a.conn.timeout, params.Folder, req.MailboxUIDValidity)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	uidsToLabel := params.MessageIDs
+	var threadExpanded bool
+	if includeThreadEnabled(params.IncludeThread) {
+		expanded, err := applyLabelExpandUIDsFn(session, params.MessageIDs)
+		if err != nil {
+			return nil, err
+		}
+		uidsToLabel = expanded
+		threadExpanded = !sameUIDSet(expanded, params.MessageIDs)
+	}
+
+	if err := applyLabelPerformCopy(session, uidsToLabel, params.LabelMailbox); err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "TRYCREATE") || strings.Contains(errMsg, "Mailbox doesn't exist") {
+			return nil, &connectors.ExternalError{
+				Message: fmt.Sprintf("label mailbox %q not found on server — ensure the label exists (call protonmail.list_labels to discover valid names): %v", params.LabelMailbox, err),
+			}
+		}
+		if strings.Contains(strings.ToUpper(errMsg), "UID") || strings.Contains(strings.ToLower(errMsg), "not found") {
+			return nil, &connectors.ValidationError{
+				Message: fmt.Sprintf("one or more message UIDs not found in folder %q", params.Folder),
+			}
+		}
+		return nil, mapIMAPError(err)
+	}
+
+	result := map[string]any{
+		"status":        "label_applied",
+		"folder":        params.Folder,
+		"label":         labelDisplayName(params.LabelMailbox),
+		"label_mailbox": params.LabelMailbox,
+		"labeled":       len(uidsToLabel),
+		"message_ids":   params.MessageIDs,
+	}
+	if includeThreadEnabled(params.IncludeThread) && threadExpanded {
+		result["thread_expanded"] = true
+		result["labeled_uids"] = uidsToLabel
+	}
+	return connectors.JSONResult(result)
+}

--- a/connectors/protonmail/apply_label_test.go
+++ b/connectors/protonmail/apply_label_test.go
@@ -1,0 +1,130 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestApplyLabel_ThreadExpansionCopiesAllUIDs(t *testing.T) {
+	origConnect := applyLabelConnectAndSelect
+	origExpand := applyLabelExpandUIDsFn
+	origCopy := applyLabelPerformCopy
+	t.Cleanup(func() {
+		applyLabelConnectAndSelect = origConnect
+		applyLabelExpandUIDsFn = origExpand
+		applyLabelPerformCopy = origCopy
+	})
+
+	applyLabelConnectAndSelect = func(connectors.Credentials, time.Duration, string, connectors.MailboxUIDValidityStore) (*imapSession, error) {
+		return &imapSession{}, nil
+	}
+	applyLabelExpandUIDsFn = func(threadExpandSession, []uint32) ([]uint32, error) {
+		return []uint32{125, 132, 140}, nil
+	}
+
+	var copiedUIDs []uint32
+	var copiedLabel string
+	applyLabelPerformCopy = func(_ *imapSession, uids []uint32, labelMailbox string) error {
+		copiedUIDs = uids
+		copiedLabel = labelMailbox
+		return nil
+	}
+
+	conn := New()
+	action := &applyLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{
+		"message_id": 140,
+		"label":      "Work",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.apply_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if copiedLabel != "Labels/Work" {
+		t.Errorf("copy dest = %q, want Labels/Work", copiedLabel)
+	}
+	if len(copiedUIDs) != 3 {
+		t.Fatalf("copied %d UIDs, want 3: %v", len(copiedUIDs), copiedUIDs)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(result.Data, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload["thread_expanded"] != true {
+		t.Errorf("thread_expanded = %v, want true", payload["thread_expanded"])
+	}
+}
+
+func TestApplyLabel_IncludeThreadFalseSkipsExpansion(t *testing.T) {
+	origConnect := applyLabelConnectAndSelect
+	origExpand := applyLabelExpandUIDsFn
+	origCopy := applyLabelPerformCopy
+	t.Cleanup(func() {
+		applyLabelConnectAndSelect = origConnect
+		applyLabelExpandUIDsFn = origExpand
+		applyLabelPerformCopy = origCopy
+	})
+
+	applyLabelConnectAndSelect = func(connectors.Credentials, time.Duration, string, connectors.MailboxUIDValidityStore) (*imapSession, error) {
+		return &imapSession{}, nil
+	}
+	applyLabelExpandUIDsFn = func(threadExpandSession, []uint32) ([]uint32, error) {
+		t.Fatal("expandArchiveUIDs should not be called when include_thread is false")
+		return nil, nil
+	}
+
+	var copiedUIDs []uint32
+	applyLabelPerformCopy = func(_ *imapSession, uids []uint32, _ string) error {
+		copiedUIDs = uids
+		return nil
+	}
+
+	conn := New()
+	action := &applyLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{
+		"message_id":     140,
+		"label":          "Work",
+		"include_thread": false,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.apply_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(copiedUIDs) != 1 || copiedUIDs[0] != 140 {
+		t.Fatalf("copied UIDs = %v, want [140]", copiedUIDs)
+	}
+}
+
+func TestApplyLabel_MissingMessageIDs(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &applyLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{"label": "Work"})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.apply_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing message_ids")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}

--- a/connectors/protonmail/label_message_params.go
+++ b/connectors/protonmail/label_message_params.go
@@ -1,0 +1,65 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type labelMessageParams struct {
+	MessageIDs    []uint32 `json:"-"`
+	Folder        string   `json:"folder"`
+	Label         string   `json:"label"`
+	LabelMailbox  string   `json:"-"`
+	IncludeThread *bool    `json:"include_thread"`
+}
+
+func parseLabelMessageParams(raw []byte) (*labelMessageParams, error) {
+	var r struct {
+		uidMessageRaw
+		Label         string `json:"label"`
+		IncludeThread *bool  `json:"include_thread"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+
+	base := &uidMessageParams{Folder: r.Folder}
+	if len(r.MessageIDs) > 0 && string(r.MessageIDs) != "null" {
+		if err := json.Unmarshal(r.MessageIDs, &base.MessageIDs); err != nil {
+			return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid message_ids: %v", err)}
+		}
+	}
+	if r.MessageID != nil {
+		base.MessageIDs = append(base.MessageIDs, *r.MessageID)
+	}
+
+	return &labelMessageParams{
+		MessageIDs:    base.MessageIDs,
+		Folder:        base.Folder,
+		Label:         r.Label,
+		IncludeThread: r.IncludeThread,
+	}, nil
+}
+
+func (p *labelMessageParams) validate() error {
+	base := &uidMessageParams{MessageIDs: p.MessageIDs, Folder: p.Folder}
+	if err := base.validate(); err != nil {
+		return err
+	}
+	p.MessageIDs = base.MessageIDs
+	p.Folder = base.Folder
+
+	labelMailbox, err := validateLabelParam(p.Label)
+	if err != nil {
+		return err
+	}
+	p.LabelMailbox = labelMailbox
+
+	if strings.EqualFold(p.Folder, labelMailbox) {
+		return &connectors.ValidationError{Message: "source folder must differ from the label mailbox"}
+	}
+	return nil
+}

--- a/connectors/protonmail/label_message_params_test.go
+++ b/connectors/protonmail/label_message_params_test.go
@@ -1,0 +1,82 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestParseLabelMessageParams(t *testing.T) {
+	t.Parallel()
+
+	params, err := parseLabelMessageParams([]byte(`{"message_id": 5, "label": "Work"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(params.MessageIDs) != 1 || params.MessageIDs[0] != 5 {
+		t.Errorf("MessageIDs = %v, want [5]", params.MessageIDs)
+	}
+	if params.Label != "Work" {
+		t.Errorf("Label = %q, want Work", params.Label)
+	}
+	if !includeThreadEnabled(params.IncludeThread) {
+		t.Error("expected omitted include_thread to default to enabled")
+	}
+
+	params, err = parseLabelMessageParams([]byte(`{"message_id": 1, "label": "Work", "include_thread": false}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if includeThreadEnabled(params.IncludeThread) {
+		t.Error("expected explicit include_thread=false to disable expansion")
+	}
+}
+
+func TestLabelMessageParams_Validate(t *testing.T) {
+	t.Parallel()
+
+	p := &labelMessageParams{
+		MessageIDs: []uint32{1},
+		Label:      "Work",
+	}
+	if err := p.validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Folder != "INBOX" {
+		t.Errorf("Folder = %q, want INBOX", p.Folder)
+	}
+	if p.LabelMailbox != "Labels/Work" {
+		t.Errorf("LabelMailbox = %q, want Labels/Work", p.LabelMailbox)
+	}
+}
+
+func TestLabelMessageParams_MissingLabel(t *testing.T) {
+	t.Parallel()
+
+	p := &labelMessageParams{MessageIDs: []uint32{1}}
+	err := p.validate()
+	if err == nil {
+		t.Fatal("expected error for missing label")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestLabelMessageParams_SameFolderAndLabelRejected(t *testing.T) {
+	t.Parallel()
+
+	p := &labelMessageParams{
+		MessageIDs: []uint32{1},
+		Folder:     "Labels/Work",
+		Label:      "Work",
+	}
+	err := p.validate()
+	if err == nil {
+		t.Fatal("expected validation error when source folder equals label mailbox")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}

--- a/connectors/protonmail/label_message_params_test.go
+++ b/connectors/protonmail/label_message_params_test.go
@@ -1,7 +1,6 @@
 package protonmail
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/supersuit-tech/permission-slip/connectors"

--- a/connectors/protonmail/labels.go
+++ b/connectors/protonmail/labels.go
@@ -1,0 +1,112 @@
+package protonmail
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+const (
+	labelMailboxPrefix  = "Labels/"
+	folderMailboxPrefix = "Folders/"
+)
+
+// resolveLabelMailbox maps a short label name or full IMAP path to the label
+// mailbox Bridge/hydroxide expose under the Labels/ namespace.
+func resolveLabelMailbox(label string) string {
+	label = strings.TrimSpace(label)
+	if strings.HasPrefix(label, labelMailboxPrefix) {
+		return label
+	}
+	return labelMailboxPrefix + label
+}
+
+func isLabelMailbox(name string) bool {
+	return strings.HasPrefix(name, labelMailboxPrefix)
+}
+
+func validateLabelParam(label string) (string, error) {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return "", &connectors.ValidationError{Message: "missing required parameter: label"}
+	}
+	if strings.HasPrefix(label, folderMailboxPrefix) {
+		return "", &connectors.ValidationError{Message: fmt.Sprintf("%q is a folder path — use protonmail.move_to_folder to move messages between folders", label)}
+	}
+	resolved := resolveLabelMailbox(label)
+	if !isLabelMailbox(resolved) {
+		return "", &connectors.ValidationError{Message: fmt.Sprintf("%q is not a Proton label mailbox — labels must live under the Labels/ namespace", label)}
+	}
+	return resolved, nil
+}
+
+func labelDisplayName(mailbox string) string {
+	if strings.HasPrefix(mailbox, labelMailboxPrefix) {
+		return strings.TrimPrefix(mailbox, labelMailboxPrefix)
+	}
+	return mailbox
+}
+
+func searchUIDsByMessageID(session *imapSession, messageID string) ([]imap.UID, error) {
+	if messageID == "" {
+		return nil, nil
+	}
+	criteria := &imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{
+			Key:   "Message-ID",
+			Value: messageID,
+		}},
+	}
+	searchData, err := session.client.UIDSearch(criteria, nil).Wait()
+	if err != nil {
+		return nil, mapIMAPError(err)
+	}
+	return searchData.AllUIDs(), nil
+}
+
+func findLabelMailboxUIDs(session *imapSession, summaries []emailSummary) ([]uint32, error) {
+	seenMessageIDs := make(map[string]struct{})
+	var labelUIDs []uint32
+
+	for _, summary := range summaries {
+		messageID := summary.MessageIDHeader
+		if messageID == "" {
+			return nil, &connectors.ValidationError{
+				Message: fmt.Sprintf("message UID %d in source folder has no Message-ID header — cannot locate it in the label mailbox", summary.UID),
+			}
+		}
+		if _, ok := seenMessageIDs[messageID]; ok {
+			continue
+		}
+		seenMessageIDs[messageID] = struct{}{}
+
+		matches, err := searchUIDsByMessageID(session, messageID)
+		if err != nil {
+			return nil, err
+		}
+		if len(matches) == 0 {
+			return nil, &connectors.ValidationError{
+				Message: fmt.Sprintf("message with Message-ID %q is not present in the label mailbox", messageID),
+			}
+		}
+		for _, uid := range matches {
+			labelUIDs = append(labelUIDs, uint32(uid))
+		}
+	}
+	return deduplicateUint32(labelUIDs), nil
+}
+
+func mapLabelMailboxError(err error, labelMailbox string) error {
+	if err == nil {
+		return nil
+	}
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "TRYCREATE") || strings.Contains(errMsg, "Mailbox doesn't exist") {
+		return &connectors.ExternalError{
+			Message: fmt.Sprintf("label mailbox %q not found on server — ensure the label exists (call protonmail.list_labels to discover valid names): %v", labelMailbox, err),
+		}
+	}
+	return mapIMAPError(err)
+}

--- a/connectors/protonmail/labels_test.go
+++ b/connectors/protonmail/labels_test.go
@@ -1,0 +1,88 @@
+package protonmail
+
+import (
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestResolveLabelMailbox(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Work", "Labels/Work"},
+		{"Labels/Work", "Labels/Work"},
+		{"Labels/Parent/Child", "Labels/Parent/Child"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveLabelMailbox(tc.input); got != tc.want {
+				t.Errorf("resolveLabelMailbox(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateLabelParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		label   string
+		want    string
+		wantErr bool
+	}{
+		{name: "short name", label: "Work", want: "Labels/Work"},
+		{name: "full path", label: "Labels/Work", want: "Labels/Work"},
+		{name: "empty", label: "", wantErr: true},
+		{name: "folder path rejected", label: "Folders/Projects", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateLabelParam(tc.label)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !connectors.IsValidationError(err) {
+					t.Errorf("expected ValidationError, got %T", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLabelDisplayName(t *testing.T) {
+	t.Parallel()
+	if got := labelDisplayName("Labels/Work"); got != "Work" {
+		t.Errorf("got %q, want Work", got)
+	}
+	if got := labelDisplayName("Labels/Parent/Child"); got != "Parent/Child" {
+		t.Errorf("got %q, want Parent/Child", got)
+	}
+}
+
+func TestIsLabelMailbox(t *testing.T) {
+	t.Parallel()
+	if !isLabelMailbox("Labels/Work") {
+		t.Error("expected Labels/Work to be a label mailbox")
+	}
+	if isLabelMailbox("INBOX") {
+		t.Error("expected INBOX not to be a label mailbox")
+	}
+	if isLabelMailbox("Folders/Projects") {
+		t.Error("expected Folders/Projects not to be a label mailbox")
+	}
+}

--- a/connectors/protonmail/list_labels.go
+++ b/connectors/protonmail/list_labels.go
@@ -1,0 +1,52 @@
+package protonmail
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type listLabelsAction struct {
+	conn *ProtonMailConnector
+}
+
+func (a *listLabelsAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	session, err := connectIMAP(req.Credentials, a.conn.timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	listCmd := session.client.List("", "*", nil)
+	mailboxes, err := listCmd.Collect()
+	if err != nil {
+		return nil, mapIMAPError(err)
+	}
+
+	labels := make([]map[string]any, 0)
+	for _, mbox := range mailboxes {
+		if mbox == nil || !isLabelMailbox(mbox.Mailbox) {
+			continue
+		}
+		entry := map[string]any{
+			"name":    labelDisplayName(mbox.Mailbox),
+			"mailbox": mbox.Mailbox,
+		}
+		if len(mbox.Attrs) > 0 {
+			attrs := make([]string, 0, len(mbox.Attrs))
+			for _, attr := range mbox.Attrs {
+				attrs = append(attrs, string(attr))
+			}
+			entry["attributes"] = attrs
+		}
+		if mbox.Delim != 0 {
+			entry["delimiter"] = string(mbox.Delim)
+		}
+		labels = append(labels, entry)
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"labels": labels,
+		"total":  len(labels),
+	})
+}

--- a/connectors/protonmail/manifest.go
+++ b/connectors/protonmail/manifest.go
@@ -351,6 +351,33 @@ func (c *ProtonMailConnector) Manifest() *connectors.ConnectorManifest {
 				DisplayTemplate:  "Delete email",
 				ParametersSchema: uidMessageParametersSchema(),
 			},
+			{
+				ActionType:       "protonmail.apply_label",
+				Name:             "Apply Label",
+				Description:      "Apply a Proton label to one or more emails via IMAP COPY into the label mailbox (message stays in its source folder)",
+				RiskLevel:        "medium",
+				DisplayTemplate:  "Apply label {{label}} to email in {{folder}}",
+				ParametersSchema: labelMessageParametersSchema(),
+			},
+			{
+				ActionType:       "protonmail.remove_label",
+				Name:             "Remove Label",
+				Description:      "Remove a Proton label from one or more emails via STORE \\Deleted + UID EXPUNGE in the label mailbox",
+				RiskLevel:        "medium",
+				DisplayTemplate:  "Remove label {{label}} from email in {{folder}}",
+				ParametersSchema: labelMessageParametersSchema(),
+			},
+			{
+				ActionType:      "protonmail.list_labels",
+				Name:            "List Labels",
+				Description:     "List Proton labels exposed as IMAP mailboxes under the Labels/ namespace",
+				RiskLevel:       "low",
+				DisplayTemplate: "List Proton labels",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"properties": {}
+				}`)),
+			},
 		},
 
 		RequiredCredentials: []connectors.ManifestCredential{

--- a/connectors/protonmail/manifest_schema_helpers.go
+++ b/connectors/protonmail/manifest_schema_helpers.go
@@ -35,6 +35,45 @@ func uidMessageParametersSchema() json.RawMessage {
 	}`))
 }
 
+func labelMessageParametersSchema() json.RawMessage {
+	return json.RawMessage(connectors.TrimIndent(`{
+		"type": "object",
+		"required": ["label"],
+		"anyOf": [
+			{"required": ["message_id"]},
+			{"required": ["message_ids"]}
+		],
+		"properties": {
+			"message_id": {
+				"type": "integer",
+				"minimum": 1,
+				"description": "Stable IMAP UID of a single email. By default the whole conversation is labeled (matching archive_email thread expansion). Set include_thread to false to label only this exact UID."
+			},
+			"message_ids": {
+				"type": "array",
+				"items": {"type": "integer", "minimum": 1},
+				"minItems": 1,
+				"maxItems": 50,
+				"description": "Stable IMAP UIDs to label (batch). Combined unique count of message_id + message_ids must not exceed 50. By default each UID's whole conversation is labeled. Set include_thread to false to label only the exact UIDs listed."
+			},
+			"folder": {
+				"type": "string",
+				"default": "INBOX",
+				"description": "Source mailbox folder containing the emails"
+			},
+			"label": {
+				"type": "string",
+				"description": "Proton label to apply or remove. Accepts a short name (e.g. Work) or full IMAP mailbox path under Labels/ (e.g. Labels/Work). Call protonmail.list_labels to discover valid labels."
+			},
+			"include_thread": {
+				"type": "boolean",
+				"default": true,
+				"description": "When true (default), label every message in the conversation, not just the listed UIDs — matching archive_email thread expansion. Set to false to label only the exact UIDs provided."
+			}
+		}
+	}`))
+}
+
 func moveToFolderParametersSchema() json.RawMessage {
 	return json.RawMessage(connectors.TrimIndent(`{
 		"type": "object",

--- a/connectors/protonmail/manifest_templates.go
+++ b/connectors/protonmail/manifest_templates.go
@@ -78,5 +78,26 @@ func protonmailTemplates() []connectors.ManifestTemplate {
 			Description: "Agent can move emails to another folder.",
 			Parameters:  json.RawMessage(`{"folder":"INBOX","target_folder":"*","message_id":"*"}`),
 		},
+		{
+			ID:          "tpl_protonmail_apply_label",
+			ActionType:  "protonmail.apply_label",
+			Name:        "Apply Proton labels",
+			Description: "Agent can apply Proton labels to emails without moving them from their folder.",
+			Parameters:  json.RawMessage(`{"folder":"INBOX","label":"*","message_id":"*","message_ids":"*","include_thread":"*"}`),
+		},
+		{
+			ID:          "tpl_protonmail_remove_label",
+			ActionType:  "protonmail.remove_label",
+			Name:        "Remove Proton labels",
+			Description: "Agent can remove Proton labels from emails.",
+			Parameters:  json.RawMessage(`{"folder":"INBOX","label":"*","message_id":"*","message_ids":"*","include_thread":"*"}`),
+		},
+		{
+			ID:          "tpl_protonmail_list_labels",
+			ActionType:  "protonmail.list_labels",
+			Name:        "List Proton labels",
+			Description: "Agent can list available Proton labels.",
+			Parameters:  json.RawMessage(`{}`),
+		},
 	}
 }

--- a/connectors/protonmail/protonmail.go
+++ b/connectors/protonmail/protonmail.go
@@ -3,7 +3,7 @@
 // Mail Bridge (official, x86_64) or hydroxide (open-source, ARM-friendly). Both
 // expose the same loopback IMAP/SMTP surface that this connector targets.
 //
-// Actions: send_email, reply_email (SMTP); read/search/inbox, archive/move/delete, flags, download_attachment (IMAP).
+// Actions: send_email, reply_email (SMTP); read/search/inbox, archive/move/delete, labels, flags, download_attachment (IMAP).
 package protonmail
 
 import (
@@ -63,6 +63,9 @@ func (c *ProtonMailConnector) Actions() map[string]connectors.Action {
 		"protonmail.unflag":              newUnflagAction(c),
 		"protonmail.move_to_folder":      &moveToFolderAction{conn: c},
 		"protonmail.delete":              &deleteEmailAction{conn: c},
+		"protonmail.apply_label":         &applyLabelAction{conn: c},
+		"protonmail.remove_label":        &removeLabelAction{conn: c},
+		"protonmail.list_labels":         &listLabelsAction{conn: c},
 	}
 }
 

--- a/connectors/protonmail/protonmail_test.go
+++ b/connectors/protonmail/protonmail_test.go
@@ -38,6 +38,9 @@ func TestProtonMailConnector_Actions(t *testing.T) {
 		"protonmail.unflag",
 		"protonmail.move_to_folder",
 		"protonmail.delete",
+		"protonmail.apply_label",
+		"protonmail.remove_label",
+		"protonmail.list_labels",
 	}
 	for _, name := range expected {
 		if _, ok := actions[name]; !ok {
@@ -194,6 +197,9 @@ func TestProtonMailConnector_Manifest(t *testing.T) {
 		"protonmail.unflag",
 		"protonmail.move_to_folder",
 		"protonmail.delete",
+		"protonmail.apply_label",
+		"protonmail.remove_label",
+		"protonmail.list_labels",
 	}
 	if len(m.Actions) != len(expectedActions) {
 		t.Fatalf("Manifest().Actions has %d items, want %d", len(m.Actions), len(expectedActions))

--- a/connectors/protonmail/remove_label.go
+++ b/connectors/protonmail/remove_label.go
@@ -1,0 +1,136 @@
+package protonmail
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type removeLabelAction struct {
+	conn *ProtonMailConnector
+}
+
+// removeLabelExpandUIDsFn expands remove targets to full conversations. Tests may
+// replace it to avoid a live proxy.
+var removeLabelExpandUIDsFn = expandArchiveUIDs
+
+// removeLabelFetchEnvelopesFn fetches source-folder envelopes for label removal.
+// Tests may replace it to avoid a live proxy.
+var removeLabelFetchEnvelopesFn = func(session *imapSession, uidSet imap.UIDSet) ([]emailSummary, error) {
+	return session.fetchEnvelopes(uidSet)
+}
+
+// removeLabelFindLabelUIDsFn maps source messages to UIDs in the label mailbox.
+// Tests may replace it to avoid a live proxy.
+var removeLabelFindLabelUIDsFn = findLabelMailboxUIDs
+
+// removeLabelSelectLabelMailbox selects the label mailbox read-write. Tests may
+// replace it to avoid a live proxy.
+var removeLabelSelectLabelMailbox = func(session *imapSession, labelMailbox string) error {
+	_, err := session.selectMailboxReadWrite(labelMailbox)
+	if err != nil {
+		return mapLabelMailboxError(err, labelMailbox)
+	}
+	return nil
+}
+
+// removeLabelMarkDeletedAndExpunge marks label-mailbox copies deleted and
+// expunges them. Tests may replace it to avoid a live proxy.
+var removeLabelMarkDeletedAndExpunge = func(session *imapSession, labelUIDs []uint32) error {
+	uidSet := uidSetFromMessageIDs(labelUIDs)
+	if err := storeMessageFlags(session, uidSet, imap.StoreFlagsAdd, []imap.Flag{imap.FlagDeleted}); err != nil {
+		return mapIMAPError(err)
+	}
+	expungeCmd := session.client.UIDExpunge(uidSet)
+	if _, err := expungeCmd.Collect(); err != nil {
+		return mapIMAPError(err)
+	}
+	return nil
+}
+
+// removeLabelConnectAndSelect opens a read-write IMAP session in the source
+// folder and verifies UIDVALIDITY. Tests may replace it to avoid a live proxy.
+var removeLabelConnectAndSelect = func(creds connectors.Credentials, timeout time.Duration, folder string, store connectors.MailboxUIDValidityStore) (*imapSession, error) {
+	session, err := connectIMAP(creds, timeout)
+	if err != nil {
+		return nil, err
+	}
+	mboxData, err := session.selectMailboxReadWrite(folder)
+	if err != nil {
+		session.close()
+		return nil, err
+	}
+	if err := syncUIDValidity(folder, mboxData, store, uidValidityVerify); err != nil {
+		session.close()
+		return nil, err
+	}
+	return session, nil
+}
+
+func (a *removeLabelAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseLabelMessageParams(req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	session, err := removeLabelConnectAndSelect(req.Credentials, a.conn.timeout, params.Folder, req.MailboxUIDValidity)
+	if err != nil {
+		return nil, err
+	}
+	defer session.close()
+
+	uidsToProcess := params.MessageIDs
+	var threadExpanded bool
+	if includeThreadEnabled(params.IncludeThread) {
+		expanded, err := removeLabelExpandUIDsFn(session, params.MessageIDs)
+		if err != nil {
+			return nil, err
+		}
+		uidsToProcess = expanded
+		threadExpanded = !sameUIDSet(expanded, params.MessageIDs)
+	}
+
+	summaries, err := removeLabelFetchEnvelopesFn(session, uidSetFromMessageIDs(uidsToProcess))
+	if err != nil {
+		return nil, mapUIDNotFoundError(err, params.Folder)
+	}
+	if len(summaries) == 0 {
+		return nil, &connectors.ValidationError{
+			Message: fmt.Sprintf("one or more message UIDs not found in folder %q", params.Folder),
+		}
+	}
+
+	if err := removeLabelSelectLabelMailbox(session, params.LabelMailbox); err != nil {
+		return nil, err
+	}
+
+	labelUIDs, err := removeLabelFindLabelUIDsFn(session, summaries)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := removeLabelMarkDeletedAndExpunge(session, labelUIDs); err != nil {
+		return nil, err
+	}
+
+	result := map[string]any{
+		"status":        "label_removed",
+		"folder":        params.Folder,
+		"label":         labelDisplayName(params.LabelMailbox),
+		"label_mailbox": params.LabelMailbox,
+		"removed":       len(labelUIDs),
+		"message_ids":   params.MessageIDs,
+	}
+	if includeThreadEnabled(params.IncludeThread) && threadExpanded {
+		result["thread_expanded"] = true
+		result["removed_uids"] = uidsToProcess
+	}
+	return connectors.JSONResult(result)
+}

--- a/connectors/protonmail/remove_label.go
+++ b/connectors/protonmail/remove_label.go
@@ -3,7 +3,6 @@ package protonmail
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/emersion/go-imap/v2"

--- a/connectors/protonmail/remove_label_test.go
+++ b/connectors/protonmail/remove_label_test.go
@@ -1,0 +1,183 @@
+package protonmail
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestRemoveLabel_ExpungesLabelMailboxUIDs(t *testing.T) {
+	origConnect := removeLabelConnectAndSelect
+	origExpand := removeLabelExpandUIDsFn
+	origFetch := removeLabelFetchEnvelopesFn
+	origSelect := removeLabelSelectLabelMailbox
+	origFind := removeLabelFindLabelUIDsFn
+	origExpunge := removeLabelMarkDeletedAndExpunge
+	t.Cleanup(func() {
+		removeLabelConnectAndSelect = origConnect
+		removeLabelExpandUIDsFn = origExpand
+		removeLabelFetchEnvelopesFn = origFetch
+		removeLabelSelectLabelMailbox = origSelect
+		removeLabelFindLabelUIDsFn = origFind
+		removeLabelMarkDeletedAndExpunge = origExpunge
+	})
+
+	removeLabelConnectAndSelect = func(connectors.Credentials, time.Duration, string, connectors.MailboxUIDValidityStore) (*imapSession, error) {
+		return &imapSession{}, nil
+	}
+	removeLabelExpandUIDsFn = func(threadExpandSession, []uint32) ([]uint32, error) {
+		return []uint32{140}, nil
+	}
+	removeLabelFetchEnvelopesFn = func(_ *imapSession, _ imap.UIDSet) ([]emailSummary, error) {
+		return []emailSummary{{
+			UID:             140,
+			MessageIDHeader: "<msg-140@example.com>",
+			Subject:         "Hello",
+		}}, nil
+	}
+	removeLabelSelectLabelMailbox = func(_ *imapSession, labelMailbox string) error {
+		if labelMailbox != "Labels/Work" {
+			t.Fatalf("select label mailbox = %q, want Labels/Work", labelMailbox)
+		}
+		return nil
+	}
+	removeLabelFindLabelUIDsFn = func(_ *imapSession, summaries []emailSummary) ([]uint32, error) {
+		if len(summaries) != 1 || summaries[0].MessageIDHeader != "<msg-140@example.com>" {
+			t.Fatalf("unexpected summaries: %+v", summaries)
+		}
+		return []uint32{9001}, nil
+	}
+
+	var expungedUIDs []uint32
+	removeLabelMarkDeletedAndExpunge = func(_ *imapSession, labelUIDs []uint32) error {
+		expungedUIDs = labelUIDs
+		return nil
+	}
+
+	conn := New()
+	action := &removeLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{
+		"message_id": 140,
+		"label":      "Work",
+	})
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.remove_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(expungedUIDs) != 1 || expungedUIDs[0] != 9001 {
+		t.Fatalf("expunged UIDs = %v, want [9001]", expungedUIDs)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(result.Data, &payload); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if payload["status"] != "label_removed" {
+		t.Errorf("status = %v, want label_removed", payload["status"])
+	}
+}
+
+func TestFindLabelMailboxUIDs_RequiresMessageID(t *testing.T) {
+	t.Parallel()
+
+	_, err := findLabelMailboxUIDs(&imapSession{}, []emailSummary{{
+		UID: 1,
+	}})
+	if err == nil {
+		t.Fatal("expected error for missing Message-ID")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestRemoveLabel_MissingLabel(t *testing.T) {
+	t.Parallel()
+
+	conn := New()
+	action := &removeLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{"message_id": 1})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.remove_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing label")
+	}
+	if !connectors.IsValidationError(err) {
+		t.Errorf("expected ValidationError, got %T", err)
+	}
+}
+
+func TestRemoveLabel_IncludeThreadFalseSkipsExpansion(t *testing.T) {
+	origConnect := removeLabelConnectAndSelect
+	origExpand := removeLabelExpandUIDsFn
+	origFetch := removeLabelFetchEnvelopesFn
+	origSelect := removeLabelSelectLabelMailbox
+	origFind := removeLabelFindLabelUIDsFn
+	origExpunge := removeLabelMarkDeletedAndExpunge
+	t.Cleanup(func() {
+		removeLabelConnectAndSelect = origConnect
+		removeLabelExpandUIDsFn = origExpand
+		removeLabelFetchEnvelopesFn = origFetch
+		removeLabelSelectLabelMailbox = origSelect
+		removeLabelFindLabelUIDsFn = origFind
+		removeLabelMarkDeletedAndExpunge = origExpunge
+	})
+
+	removeLabelConnectAndSelect = func(connectors.Credentials, time.Duration, string, connectors.MailboxUIDValidityStore) (*imapSession, error) {
+		return &imapSession{}, nil
+	}
+	removeLabelExpandUIDsFn = func(threadExpandSession, []uint32) ([]uint32, error) {
+		t.Fatal("expandArchiveUIDs should not be called when include_thread is false")
+		return nil, nil
+	}
+
+	var fetchedUIDs []uint32
+	removeLabelFetchEnvelopesFn = func(_ *imapSession, uidSet imap.UIDSet) ([]emailSummary, error) {
+		if nums, ok := uidSet.Nums(); ok {
+			for _, uid := range nums {
+				fetchedUIDs = append(fetchedUIDs, uint32(uid))
+			}
+		}
+		return []emailSummary{{
+			UID:             140,
+			MessageIDHeader: "<msg-140@example.com>",
+		}}, nil
+	}
+	removeLabelSelectLabelMailbox = func(_ *imapSession, _ string) error { return nil }
+	removeLabelFindLabelUIDsFn = func(_ *imapSession, _ []emailSummary) ([]uint32, error) {
+		return []uint32{9001}, nil
+	}
+	removeLabelMarkDeletedAndExpunge = func(_ *imapSession, _ []uint32) error { return nil }
+
+	conn := New()
+	action := &removeLabelAction{conn: conn}
+	params, _ := json.Marshal(map[string]any{
+		"message_id":     140,
+		"label":          "Work",
+		"include_thread": false,
+	})
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "protonmail.remove_label",
+		Parameters:  params,
+		Credentials: validCreds(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fetchedUIDs) != 1 || fetchedUIDs[0] != 140 {
+		t.Fatalf("fetched UIDs = %v, want [140]", fetchedUIDs)
+	}
+}

--- a/connectors/protonmail/resolve_resource_details.go
+++ b/connectors/protonmail/resolve_resource_details.go
@@ -24,6 +24,8 @@ func (c *ProtonMailConnector) ResolveResourceDetails(ctx context.Context, action
 		return c.resolveReadEmailDetails(ctx, params, creds)
 	case "protonmail.archive_email":
 		return c.resolveArchiveEmailDetails(ctx, params, creds)
+	case "protonmail.apply_label", "protonmail.remove_label":
+		return c.resolveLabelMessageDetails(ctx, params, creds)
 	case "protonmail.reply_email":
 		return c.resolveReplyEmailDetails(ctx, params, creds)
 	case "protonmail.mark_read",
@@ -127,6 +129,30 @@ func (c *ProtonMailConnector) resolveArchiveEmailDetails(ctx context.Context, pa
 	}
 
 	return c.resolveMessageDetailsForUIDs(ctx, creds, archiveParams.Folder, uids)
+}
+
+func (c *ProtonMailConnector) resolveLabelMessageDetails(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	labelParams, err := parseLabelMessageParams(params)
+	if err != nil {
+		log.Printf("protonmail: resolve label message details: parse params: %v", err)
+		return nil, nil
+	}
+	if err := labelParams.validate(); err != nil {
+		log.Printf("protonmail: resolve label message details: invalid params: %v", err)
+		return nil, nil
+	}
+
+	uids := labelParams.MessageIDs
+	if includeThreadEnabled(labelParams.IncludeThread) {
+		expanded, err := expandArchiveUIDsForApproval(ctx, c, creds, labelParams.Folder, labelParams.MessageIDs)
+		if err != nil {
+			log.Printf("protonmail: resolve label message details: thread expansion (folder %q, %d uids): %v", labelParams.Folder, len(labelParams.MessageIDs), err)
+			return c.resolveMessageDetailsForUIDs(ctx, creds, labelParams.Folder, labelParams.MessageIDs)
+		}
+		uids = expanded
+	}
+
+	return c.resolveMessageDetailsForUIDs(ctx, creds, labelParams.Folder, uids)
 }
 
 // expandArchiveUIDsForApproval is the IMAP-backed thread expansion used at

--- a/docs/connectors/protonmail.md
+++ b/docs/connectors/protonmail.md
@@ -22,6 +22,21 @@ If you're currently self-hosting on ARM hardware, we recommend running Permissio
 | `protonmail.read_email` | low | Read one message by stable IMAP UID |
 | `protonmail.download_attachment` | low | Download one attachment by MIME part path (`part_id` from `read_email`) |
 | `protonmail.archive_email` | medium | Move messages to Archive (IMAP UID MOVE) |
+| `protonmail.apply_label` | medium | Apply a Proton label via IMAP COPY (message stays in its folder) |
+| `protonmail.remove_label` | medium | Remove a Proton label via STORE \\Deleted + UID EXPUNGE in the label mailbox |
+| `protonmail.list_labels` | low | List Proton labels under the Labels/ IMAP namespace |
+
+### Folders vs labels
+
+Proton Mail Bridge exposes **folders** and **labels** as separate IMAP mailbox hierarchies:
+
+- **Folders** (`Folders/…` plus system mailboxes like `INBOX`, `Archive`, `Trash`) are **exclusive** — a message lives in exactly one folder. Use `protonmail.move_to_folder` or `protonmail.archive_email` to relocate mail.
+- **Labels** (`Labels/…`) are **additive** — applying a label keeps the message in its source folder and adds the label. Use `protonmail.apply_label` (IMAP **COPY** into the label mailbox), not `move_to_folder`.
+- **Discovery** — call `protonmail.list_labels` before apply/remove to discover valid label names. `protonmail.list_folders` is unchanged and still lists all mailboxes (including labels); prefer `list_labels` when you only need labels.
+
+`protonmail.flag` / `protonmail.unflag` set the IMAP `\Flagged` star — that is **not** the same as a Proton label.
+
+By default, `protonmail.apply_label` and `protonmail.remove_label` expand to the **entire conversation** (same thread semantics as `protonmail.archive_email`). Pass `"include_thread": false` to act on only the listed UID(s).
 
 ### Archiving whole conversations
 

--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -472,6 +472,20 @@ const ACTION_DESCRIBERS: Record<string, ActionDescriber> = {
     return summary;
   },
 
+  "protonmail.apply_label": (params, rd) => {
+    const label = strVal(params.label);
+    const suffix = label ? ` (label ${label})` : null;
+    return protonmailUIDActionSummary("Apply label to email", rd, suffix);
+  },
+
+  "protonmail.remove_label": (params, rd) => {
+    const label = strVal(params.label);
+    const suffix = label ? ` (label ${label})` : null;
+    return protonmailUIDActionSummary("Remove label from email", rd, suffix);
+  },
+
+  "protonmail.list_labels": () => [text("List Proton labels")],
+
   "protonmail.delete": (_params, rd) => protonmailUIDActionSummary("Delete email", rd),
 };
 

--- a/frontend/src/lib/emailEnrichment.ts
+++ b/frontend/src/lib/emailEnrichment.ts
@@ -20,6 +20,8 @@ const EMAIL_DETAIL_ACTION_TYPES = new Set([
   "protonmail.unflag",
   "protonmail.move_to_folder",
   "protonmail.delete",
+  "protonmail.apply_label",
+  "protonmail.remove_label",
 ]);
 
 /** Keys enrichment writes: flat single-message fields, batch map, or reply ref. */

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -380,6 +380,20 @@ const ACTION_FORMATTERS: Record<string, ActionFormatter> = {
     return protonmailUIDActionSummary("Move email", rd, suffix);
   },
 
+  "protonmail.apply_label": (params, rd) => {
+    const label = strVal(params.label);
+    const suffix = label ? ` (label ${label})` : null;
+    return protonmailUIDActionSummary("Apply label to email", rd, suffix);
+  },
+
+  "protonmail.remove_label": (params, rd) => {
+    const label = strVal(params.label);
+    const suffix = label ? ` (label ${label})` : null;
+    return protonmailUIDActionSummary("Remove label from email", rd, suffix);
+  },
+
+  "protonmail.list_labels": () => "List Proton labels",
+
   "protonmail.delete": (_params, rd) => protonmailUIDActionSummary("Delete email", rd),
 };
 

--- a/mobile/src/screens/approvals/emailEnrichment.ts
+++ b/mobile/src/screens/approvals/emailEnrichment.ts
@@ -20,6 +20,8 @@ const EMAIL_DETAIL_ACTION_TYPES = new Set([
   "protonmail.unflag",
   "protonmail.move_to_folder",
   "protonmail.delete",
+  "protonmail.apply_label",
+  "protonmail.remove_label",
 ]);
 
 /** Keys enrichment writes: flat single-message fields, batch map, or reply ref. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `protonmail.apply_label` (IMAP COPY into `Labels/` mailboxes, message stays in source folder) with UID batching and `include_thread` expansion matching `archive_email`.
- Add `protonmail.remove_label` (Message-ID lookup in the label mailbox, then STORE `\Deleted` + UID EXPUNGE to detach the label without deleting the source message).
- Add `protonmail.list_labels` to discover labels under the `Labels/` namespace; update docs, manifest templates, approval enrichment, and web/mobile preview summaries.

Closes #1329

## Test plan

### Claude Code
- [x] `gofmt` on all new/changed Go files
- [x] Frontend: `npx vitest run src/components/__tests__/ActionPreviewSummary.test.tsx`
- [x] Mobile: `npm test -- --ci` for approvalUtils + emailEnrichment tests
- [ ] Backend: `go test ./connectors/protonmail/...` (not run locally — sandbox Go module resolution blocked; CI will verify)

### OpenClaw
- [ ] Verify against real Proton Bridge that `remove_label` detaches the label without deleting the message in its source folder
- [ ] Confirm `apply_label` COPY keeps the message in INBOX while adding the label
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c273c067-54b5-4e99-b188-f5b4f9e9df5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c273c067-54b5-4e99-b188-f5b4f9e9df5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

