### PR TITLE
Improve calendar start/end datetime formatting (web + mobile)

### DIFF
--- a/frontend/src/components/ActionPreviewSummary.tsx
+++ b/frontend/src/components/ActionPreviewSummary.tsx
@@ -29,6 +29,7 @@ import type { ReactNode } from "react";
 import type { ParametersSchema } from "@/lib/parameterSchema";
 import { renderTemplate, type SummaryPart } from "@/lib/displayTemplate";
 import {
+  formatDateTime,
   formatHighlightValue,
   humanizeKey,
   truncate,
@@ -587,41 +588,6 @@ function pickHighlights(
 function strVal(v: unknown): string | null {
   if (typeof v === "string" && v.length > 0) return v;
   return null;
-}
-
-/** Formats an ISO datetime string for display in summaries. */
-function formatDateTime(iso: string): string {
-  try {
-    // Date-only strings (all-day events) use "YYYY-MM-DD". Parsing them with
-    // `new Date()` treats them as UTC midnight, which shifts the displayed date
-    // by one day in UTC-negative timezones. Format them without a time component
-    // by splitting the string directly to avoid any timezone conversion.
-    const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(iso);
-    if (isDateOnly) {
-      const [year, month, day] = iso.split("-").map(Number);
-      const date = new Date(year!, month! - 1, day!);
-      const now = new Date();
-      const sameYear = date.getFullYear() === now.getFullYear();
-      return date.toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: sameYear ? undefined : "numeric",
-      });
-    }
-    const date = new Date(iso);
-    if (isNaN(date.getTime())) return iso;
-    const now = new Date();
-    const sameYear = date.getFullYear() === now.getFullYear();
-    return date.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: sameYear ? undefined : "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
 }
 
 function formatRecipients(v: unknown): string | null {

--- a/frontend/src/components/previews/EventPreviewLayout.tsx
+++ b/frontend/src/components/previews/EventPreviewLayout.tsx
@@ -1,4 +1,5 @@
 import { Calendar } from "lucide-react";
+import { formatDateTimeRange } from "@/lib/formatValues";
 
 interface EventPreviewLayoutProps {
   parameters: Record<string, unknown>;
@@ -7,15 +8,13 @@ interface EventPreviewLayoutProps {
 
 function parseDate(value: unknown): Date | null {
   if (typeof value !== "string") return null;
+  const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(value);
+  if (isDateOnly) {
+    const [year, month, day] = value.split("-").map(Number);
+    return new Date(year!, month! - 1, day!);
+  }
   const d = new Date(value);
   return isNaN(d.getTime()) ? null : d;
-}
-
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
 }
 
 function formatDuration(startDate: Date, endDate: Date): string {
@@ -37,8 +36,12 @@ export function EventPreviewLayout({
     typeof parameters[fields.title ?? ""] === "string"
       ? (parameters[fields.title ?? ""] as string)
       : null;
-  const startDate = parseDate(parameters[fields.start ?? ""]);
-  const endDate = parseDate(parameters[fields.end ?? ""]);
+  const startRaw = parameters[fields.start ?? ""];
+  const endRaw = parameters[fields.end ?? ""];
+  const startDate = parseDate(startRaw);
+  const endDate = parseDate(endRaw);
+  const startIso = typeof startRaw === "string" ? startRaw : null;
+  const endIso = typeof endRaw === "string" ? endRaw : null;
 
   const monthStr = startDate
     ? startDate.toLocaleDateString(undefined, { month: "short" }).toUpperCase()
@@ -46,6 +49,8 @@ export function EventPreviewLayout({
   const dayStr = startDate ? String(startDate.getDate()) : null;
   const duration =
     startDate && endDate ? formatDuration(startDate, endDate) : null;
+  const timeRange =
+    startIso && endIso ? formatDateTimeRange(startIso, endIso) : null;
 
   return (
     <div className="overflow-hidden rounded-xl border bg-card p-4 shadow-sm">
@@ -78,10 +83,8 @@ export function EventPreviewLayout({
               {title}
             </p>
           )}
-          {startDate && endDate && (
-            <p className="text-muted-foreground text-sm">
-              {formatTime(startDate)} → {formatTime(endDate)}
-            </p>
+          {timeRange && (
+            <p className="text-muted-foreground text-sm">{timeRange}</p>
           )}
           {duration && (
             <p className="text-muted-foreground text-xs">{duration}</p>

--- a/frontend/src/lib/__tests__/displayTemplate.test.ts
+++ b/frontend/src/lib/__tests__/displayTemplate.test.ts
@@ -25,14 +25,13 @@ describe("renderTemplate", () => {
 
   it("renders :datetime directive", () => {
     const parts = renderTemplate("Event on {{start_time:datetime}}", {
-      start_time: "2026-03-15T11:00:00-04:00",
+      start_time: "2026-06-25T20:00:00",
     });
     expect(parts).not.toBeNull();
     expect(parts).toHaveLength(2);
     expect(parts?.[0]).toEqual({ kind: "text", text: "Event on " });
     expect(parts?.[1]?.kind).toBe("value");
-    // Should contain formatted date, not raw ISO string
-    expect(parts?.[1]?.text).toMatch(/Mar/);
+    expect(parts?.[1]?.text).toMatch(/June 25 2026 @ 8PM/);
   });
 
   it("renders :count directive for arrays", () => {

--- a/frontend/src/lib/__tests__/formatValues.test.ts
+++ b/frontend/src/lib/__tests__/formatValues.test.ts
@@ -1,11 +1,57 @@
 import { describe, it, expect } from "vitest";
 import {
   tryFormatDateTime,
+  formatDateTime,
+  formatDateTimeRange,
   humanizeKey,
   formatHighlightValue,
   formatParameterValue,
   truncate,
 } from "../formatValues";
+
+describe("formatDateTime", () => {
+  it("formats on-the-hour timestamps with full month, year, and @ separator", () => {
+    const result = formatDateTime("2026-06-25T20:00:00");
+    expect(result).toMatch(/June 25 2026 @ 8PM/);
+  });
+
+  it("includes minutes when not on the hour", () => {
+    const result = formatDateTime("2026-06-25T20:30:00");
+    expect(result).toMatch(/June 25 2026 @ 8:30PM/);
+  });
+
+  it("formats all-day date-only strings without timezone shift", () => {
+    const result = formatDateTime("2026-03-15");
+    expect(result).toMatch(/Mar/);
+    expect(result).toMatch(/15/);
+    expect(result).not.toMatch(/@/);
+  });
+
+  it("returns the input for invalid date strings", () => {
+    expect(formatDateTime("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("formatDateTimeRange", () => {
+  it("collapses the shared date for same-day events", () => {
+    const result = formatDateTimeRange(
+      "2026-06-25T20:00:00",
+      "2026-06-25T21:00:00",
+    );
+    expect(result).toMatch(/June 25 2026 @ 8PM/);
+    expect(result).toMatch(/9PM/);
+    expect(result).toMatch(/\u2013/);
+  });
+
+  it("shows both full timestamps for multi-day events", () => {
+    const result = formatDateTimeRange(
+      "2026-06-25T20:00:00",
+      "2026-06-26T21:00:00",
+    );
+    expect(result).toMatch(/June 25 2026 @ 8PM/);
+    expect(result).toMatch(/June 26 2026 @ 9PM/);
+  });
+});
 
 describe("tryFormatDateTime", () => {
   it("formats an ISO 8601 datetime string", () => {

--- a/frontend/src/lib/displayTemplate.ts
+++ b/frontend/src/lib/displayTemplate.ts
@@ -13,7 +13,7 @@
  * inserting entries into FORMATTERS.
  */
 
-import { tryFormatDateTime, formatHighlightValue } from "./formatValues";
+import { formatDateTime, formatHighlightValue } from "./formatValues";
 
 /** A segment of the summary — either plain text or a highlighted value. */
 export type SummaryPart =
@@ -35,7 +35,9 @@ export const FORMATTERS = new Map<
 >();
 
 // Built-in formatters
-FORMATTERS.set("datetime", (value) => tryFormatDateTime(value));
+FORMATTERS.set("datetime", (value) =>
+  typeof value === "string" ? formatDateTime(value) : null,
+);
 
 FORMATTERS.set("count", (value) => {
   if (Array.isArray(value)) return String(value.length);

--- a/frontend/src/lib/formatValues.ts
+++ b/frontend/src/lib/formatValues.ts
@@ -6,6 +6,92 @@
  * formatting across the approval UI.
  */
 
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Formats a Date's clock portion as "8PM" or "8:30PM" (12-hour, no space before AM/PM). */
+function formatClockTime(date: Date): string {
+  const minutes = date.getMinutes();
+  const formatted = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    ...(minutes !== 0 ? { minute: "2-digit" } : {}),
+    hour12: true,
+  });
+  return formatted.replace(/\s+(AM|PM)\b/i, "$1");
+}
+
+/**
+ * Formats an all-day calendar date (YYYY-MM-DD) without timezone conversion.
+ * Preserves the existing abbreviated-month style used before this change.
+ */
+function formatAllDayDate(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  const date = new Date(year!, month! - 1, day!);
+  const now = new Date();
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+}
+
+/** Formats the calendar date portion as "June 25 2026" (no comma). */
+function formatDatePart(date: Date): string {
+  const parts = new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).formatToParts(date);
+  const month = parts.find((p) => p.type === "month")?.value ?? "";
+  const day = parts.find((p) => p.type === "day")?.value ?? "";
+  const year = parts.find((p) => p.type === "year")?.value ?? "";
+  return `${month} ${day} ${year}`;
+}
+
+function formatTimedDate(date: Date): string {
+  return `${formatDatePart(date)} @ ${formatClockTime(date)}`;
+}
+
+/**
+ * Formats a calendar event start/end timestamp for display.
+ * Example: "June 25 2026 @ 8PM" (minutes shown only when non-zero).
+ * All-day date-only strings (YYYY-MM-DD) are formatted without a time component
+ * and without timezone conversion.
+ */
+export function formatDateTime(iso: string): string {
+  if (DATE_ONLY_RE.test(iso)) {
+    return formatAllDayDate(iso);
+  }
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return iso;
+  return formatTimedDate(date);
+}
+
+/**
+ * Formats a start/end time range, collapsing the shared date when both fall on
+ * the same local calendar day. Example: "June 25 2026 @ 8PM – 9PM".
+ */
+export function formatDateTimeRange(startIso: string, endIso: string): string {
+  if (DATE_ONLY_RE.test(startIso)) {
+    return formatAllDayDate(startIso);
+  }
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  if (isNaN(start.getTime())) return startIso;
+  if (isNaN(end.getTime())) return formatDateTime(startIso);
+
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  if (sameDay) {
+    const datePart = formatDatePart(start);
+    return `${datePart} @ ${formatClockTime(start)} \u2013 ${formatClockTime(end)}`;
+  }
+  return `${formatDateTime(startIso)} \u2013 ${formatDateTime(endIso)}`;
+}
+
 /**
  * Attempts to parse a string as an ISO 8601 / RFC 3339 datetime and
  * return a human-readable representation. Returns null if the value

--- a/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
+++ b/mobile/src/screens/approvals/__tests__/approvalUtils.test.ts
@@ -11,6 +11,8 @@ import {
   isExpired,
   formatParamValue,
   formatTimestamp,
+  formatDateTime,
+  formatDateTimeRange,
 } from "../approvalUtils";
 
 describe("secondsUntil", () => {
@@ -399,6 +401,37 @@ describe("formatTimestamp", () => {
 
   it("returns input string for invalid date", () => {
     expect(formatTimestamp("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats on-the-hour timestamps with full month, year, and @ separator", () => {
+    const result = formatDateTime("2026-06-25T20:00:00");
+    expect(result).toMatch(/June 25 2026 @ 8PM/);
+  });
+
+  it("includes minutes when not on the hour", () => {
+    const result = formatDateTime("2026-06-25T20:30:00");
+    expect(result).toMatch(/June 25 2026 @ 8:30PM/);
+  });
+
+  it("formats all-day date-only strings without timezone shift", () => {
+    const result = formatDateTime("2026-03-15");
+    expect(result).toMatch(/Mar/);
+    expect(result).toMatch(/15/);
+    expect(result).not.toMatch(/@/);
+  });
+});
+
+describe("formatDateTimeRange", () => {
+  it("collapses the shared date for same-day events", () => {
+    const result = formatDateTimeRange(
+      "2026-06-25T20:00:00",
+      "2026-06-25T21:00:00",
+    );
+    expect(result).toMatch(/June 25 2026 @ 8PM/);
+    expect(result).toMatch(/9PM/);
+    expect(result).toMatch(/\u2013/);
   });
 });
 

--- a/mobile/src/screens/approvals/approvalUtils.ts
+++ b/mobile/src/screens/approvals/approvalUtils.ts
@@ -40,6 +40,90 @@ export function formatTimestamp(iso: string): string {
   });
 }
 
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Formats a Date's clock portion as "8PM" or "8:30PM" (12-hour, no space before AM/PM). */
+function formatClockTime(date: Date): string {
+  const minutes = date.getMinutes();
+  const formatted = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    ...(minutes !== 0 ? { minute: "2-digit" } : {}),
+    hour12: true,
+  });
+  return formatted.replace(/\s+(AM|PM)\b/i, "$1");
+}
+
+/** Formats an all-day calendar date (YYYY-MM-DD) without timezone conversion. */
+function formatAllDayDate(iso: string): string {
+  const [year, month, day] = iso.split("-").map(Number);
+  const date = new Date(year!, month! - 1, day!);
+  const now = new Date();
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: sameYear ? undefined : "numeric",
+  });
+}
+
+function formatTimedDate(date: Date): string {
+  const parts = new Intl.DateTimeFormat(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).formatToParts(date);
+  const month = parts.find((p) => p.type === "month")?.value ?? "";
+  const day = parts.find((p) => p.type === "day")?.value ?? "";
+  const year = parts.find((p) => p.type === "year")?.value ?? "";
+  return `${month} ${day} ${year} @ ${formatClockTime(date)}`;
+}
+
+/**
+ * Formats a calendar event start/end timestamp for display.
+ * Example: "June 25 2026 @ 8PM" (minutes shown only when non-zero).
+ */
+export function formatDateTime(iso: string): string {
+  if (DATE_ONLY_RE.test(iso)) {
+    return formatAllDayDate(iso);
+  }
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return iso;
+  return formatTimedDate(date);
+}
+
+/**
+ * Formats a start/end time range, collapsing the shared date when both fall on
+ * the same local calendar day.
+ */
+export function formatDateTimeRange(startIso: string, endIso: string): string {
+  if (DATE_ONLY_RE.test(startIso)) {
+    return formatAllDayDate(startIso);
+  }
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  if (isNaN(start.getTime())) return startIso;
+  if (isNaN(end.getTime())) return formatDateTime(startIso);
+
+  const sameDay =
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate();
+
+  if (sameDay) {
+    const parts = new Intl.DateTimeFormat(undefined, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).formatToParts(start);
+    const month = parts.find((p) => p.type === "month")?.value ?? "";
+    const day = parts.find((p) => p.type === "day")?.value ?? "";
+    const year = parts.find((p) => p.type === "year")?.value ?? "";
+    const datePart = `${month} ${day} ${year}`;
+    return `${datePart} @ ${formatClockTime(start)} \u2013 ${formatClockTime(end)}`;
+  }
+  return `${formatDateTime(startIso)} \u2013 ${formatDateTime(endIso)}`;
+}
+
 /** Returns seconds remaining until `expiresAt`, clamped to 0. */
 export function secondsUntil(expiresAt: string): number {
   const diff = new Date(expiresAt).getTime() - Date.now();
@@ -179,13 +263,7 @@ function tryFormatDateTime(value: string): string | null {
   if (!/^\d{4}-\d{2}/.test(value)) return null;
   const d = new Date(value);
   if (isNaN(d.getTime())) return null;
-  return d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatDateTime(value);
 }
 
 /** Extracts a non-empty string from an unknown value, or returns null. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #1330

Improves how calendar event **start** and **end** times are rendered on web and mobile. Times now display in a more human-readable format like `June 25 2026 @ 8PM`, using the viewer's local timezone via built-in `Intl`/`Date` (no new date library).

### Changes

- **Web (`frontend/src/lib/formatValues.ts`)**: Added `formatDateTime` and `formatDateTimeRange` helpers with:
  - Full month name + year (`June 25 2026`)
  - `@` separator before time
  - 12-hour clock with minutes omitted on the hour (`8PM` vs `8:30PM`)
  - Same-day range collapse (`June 25 2026 @ 8PM – 9PM`)
  - Preserved all-day `YYYY-MM-DD` handling (no timezone shift, no time shown)

- **Updated render sites**:
  - `EventPreviewLayout.tsx` — event preview time range
  - `ActionPreviewSummary.tsx` — Google Calendar delete/update summaries
  - `displayTemplate.ts` — `:datetime` directive (calendar `start_time` templates)
  - `mobile/approvalUtils.ts` — `tryFormatDateTime` for display templates

- **Left unchanged** (per issue scope): `formatTimestamp` / `formatAbsoluteTime` for created/expires/connected-at timestamps, and relative-time displays.

### Tests

- Added unit tests for `formatDateTime` and `formatDateTimeRange` in frontend vitest and mobile jest.
- Updated display template test expectations.

## Test plan

- [x] `npx vitest run src/lib/__tests__/formatValues.test.ts src/lib/__tests__/displayTemplate.test.ts src/components/__tests__/ActionPreviewSummary.test.tsx`
- [x] `npm test -- --ci src/screens/approvals/__tests__/approvalUtils.test.ts`
- [ ] CI (frontend + mobile checks)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac6c066a-705d-40f9-b1d8-a2e2d5e98db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac6c066a-705d-40f9-b1d8-a2e2d5e98db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

