### PR TITLE
Constraint engine: verified metadata constraints for Proton Mail archive

### DIFF
--- a/api/action_config_validate.go
+++ b/api/action_config_validate.go
@@ -33,7 +33,9 @@ func ValidateConfigurationReference(
 	deps *Deps,
 	configID string,
 	agentID int64,
+	userID string,
 	actionType string,
+	connectorInstanceID string,
 	parameters json.RawMessage,
 ) *ConfigValidationResult {
 	// 1. Look up the configuration for this agent.
@@ -75,7 +77,7 @@ func ValidateConfigurationReference(
 	// Wildcard configs allow any parameters — skip validation entirely.
 	// SECURITY: Safe for the same reason as step 3 — standing approvals gate execution.
 	if ac.ActionType != db.WildcardActionType {
-		if err := db.ValidateParametersAgainstConfig(ac.Parameters, parameters); err != nil {
+		if err := validateActionConstraints(r.Context(), deps, agentID, userID, actionType, connectorInstanceID, ac.Parameters, parameters); err != nil {
 			var configErr *db.ConfigValidationError
 			if errors.As(err, &configErr) {
 				resp := BadRequest(ErrInvalidParameters, "Parameters do not comply with configuration constraints")
@@ -83,6 +85,11 @@ func ValidateConfigurationReference(
 					"parameter":        configErr.Parameter,
 					"constraint_error": configErr.Reason,
 				}
+				RespondError(w, r, http.StatusBadRequest, resp)
+				return nil
+			}
+			if errors.Is(err, db.ErrMetadataUnresolved) {
+				resp := BadRequest(ErrInvalidParameters, "Could not verify action metadata for configuration constraints")
 				RespondError(w, r, http.StatusBadRequest, resp)
 				return nil
 			}

--- a/api/action_config_validate_test.go
+++ b/api/action_config_validate_test.go
@@ -52,13 +52,13 @@ func setupConfigValidateTest(t *testing.T, params []byte) (db.DBTX, string, int6
 func TestValidateConfigurationReference_Success(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":"supersuit-tech/webapp","title":"*","body":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"Fix bug","body":"Details here"}`)
 
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result == nil {
 		t.Fatalf("expected success, got error: %s", w.Body.String())
 	}
@@ -70,7 +70,7 @@ func TestValidateConfigurationReference_Success(t *testing.T) {
 func TestValidateConfigurationReference_WildcardAcceptsAnyValue(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"data":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	// Wildcard should accept string, number, array, object, boolean, null.
 	tests := []struct {
@@ -90,7 +90,7 @@ func TestValidateConfigurationReference_WildcardAcceptsAnyValue(t *testing.T) {
 			// No t.Parallel() — subtests share the same DB transaction.
 			deps, w, r := newTestRequest(tx)
 
-			result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, json.RawMessage(tc.execParams))
+			result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", json.RawMessage(tc.execParams))
 			if result == nil {
 				t.Errorf("expected wildcard to accept %s, got error: %s", tc.name, w.Body.String())
 			}
@@ -107,7 +107,7 @@ func TestValidateConfigurationReference_ConfigNotFound(t *testing.T) {
 
 	deps, w, r := newTestRequest(tx)
 
-	result := ValidateConfigurationReference(w, r, deps, "ac_nonexistent", agentID, "test.action", json.RawMessage(`{}`))
+	result := ValidateConfigurationReference(w, r, deps, "ac_nonexistent", agentID, uid, "test.action", "", json.RawMessage(`{}`))
 	if result != nil {
 		t.Fatal("expected nil result for nonexistent config")
 	}
@@ -138,7 +138,7 @@ func TestValidateConfigurationReference_DisabledConfig(t *testing.T) {
 
 	// Disabled configs are filtered out by GetActiveActionConfigForAgent, so we
 	// expect the same "not found" response as a nonexistent config.
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, json.RawMessage(`{}`))
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", json.RawMessage(`{}`))
 	if result != nil {
 		t.Fatal("expected nil result for disabled config")
 	}
@@ -151,12 +151,12 @@ func TestValidateConfigurationReference_DisabledConfig(t *testing.T) {
 func TestValidateConfigurationReference_ActionTypeMismatch(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":"test/repo"}`)
-	tx, _, agentID, _, _, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, _, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Supply a different action type than the config's action_type.
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, "different.action", json.RawMessage(`{"repo":"test/repo"}`))
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, "different.action", "", json.RawMessage(`{"repo":"test/repo"}`))
 	if result != nil {
 		t.Fatal("expected nil result for action type mismatch")
 	}
@@ -169,13 +169,13 @@ func TestValidateConfigurationReference_ActionTypeMismatch(t *testing.T) {
 func TestValidateConfigurationReference_FixedParamMismatch(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":"supersuit-tech/webapp","title":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Provide a different repo value.
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/api","title":"Bug fix"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for param mismatch")
 	}
@@ -188,13 +188,13 @@ func TestValidateConfigurationReference_FixedParamMismatch(t *testing.T) {
 func TestValidateConfigurationReference_ExtraParam(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":"supersuit-tech/webapp"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Provide an extra parameter not in the config.
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/webapp","extra":"value"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for extra param")
 	}
@@ -207,13 +207,13 @@ func TestValidateConfigurationReference_ExtraParam(t *testing.T) {
 func TestValidateConfigurationReference_MissingFixedParam(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":"supersuit-tech/webapp","label":"bug"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Only provide repo but miss label.
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/webapp"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for missing fixed param")
 	}
@@ -236,7 +236,7 @@ func TestValidateConfigurationReference_WrongAgent(t *testing.T) {
 	deps, w, r := newTestRequest(tx)
 
 	// Try to use a config that belongs to a different agent.
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID2, "test.action", json.RawMessage(`{"repo":"test/repo"}`))
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID2, uid2, "test.action", "", json.RawMessage(`{"repo":"test/repo"}`))
 	if result != nil {
 		t.Fatal("expected nil result for wrong agent")
 	}
@@ -252,12 +252,12 @@ func TestValidateConfigurationReference_PatternMatch(t *testing.T) {
 	t.Parallel()
 	// Config uses suffix pattern: email must end with @mycompany.com
 	params := []byte(`{"to":{"$pattern":"*@mycompany.com"},"subject":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	execParams := json.RawMessage(`{"to":"alice@mycompany.com","subject":"Hello"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result == nil {
 		t.Fatalf("expected success for pattern match, got error: %s", w.Body.String())
 	}
@@ -267,12 +267,12 @@ func TestValidateConfigurationReference_PatternPrefixMatch(t *testing.T) {
 	t.Parallel()
 	// Config uses prefix pattern: repo must start with supersuit-tech/
 	params := []byte(`{"repo":{"$pattern":"supersuit-tech/*"},"title":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"Fix bug"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result == nil {
 		t.Fatalf("expected success for prefix pattern match, got error: %s", w.Body.String())
 	}
@@ -281,13 +281,13 @@ func TestValidateConfigurationReference_PatternPrefixMatch(t *testing.T) {
 func TestValidateConfigurationReference_PatternMismatch(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"to":{"$pattern":"*@mycompany.com"},"subject":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Email doesn't match the pattern
 	execParams := json.RawMessage(`{"to":"alice@other.com","subject":"Hello"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for pattern mismatch")
 	}
@@ -300,13 +300,13 @@ func TestValidateConfigurationReference_PatternMismatch(t *testing.T) {
 func TestValidateConfigurationReference_PatternMissing(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"repo":{"$pattern":"supersuit-tech/*"},"title":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Missing the repo pattern parameter (only providing wildcard title)
 	execParams := json.RawMessage(`{"title":"Fix bug"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for missing pattern param")
 	}
@@ -319,13 +319,13 @@ func TestValidateConfigurationReference_PatternMissing(t *testing.T) {
 func TestValidateConfigurationReference_PatternRejectsNonString(t *testing.T) {
 	t.Parallel()
 	params := []byte(`{"tag":{"$pattern":"v*"}}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	// Provide a number instead of a string for a pattern param
 	execParams := json.RawMessage(`{"tag":42}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result != nil {
 		t.Fatal("expected nil result for non-string pattern value")
 	}
@@ -339,12 +339,12 @@ func TestValidateConfigurationReference_MixedFixedPatternWildcard(t *testing.T) 
 	t.Parallel()
 	// All three types: fixed repo org, pattern on branch, wildcard on message
 	params := []byte(`{"repo":"supersuit-tech/webapp","branch":{"$pattern":"release/*"},"message":"*"}`)
-	tx, _, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
+	tx, uid, agentID, _, actionType, configID := setupConfigValidateTest(t, params)
 
 	deps, w, r := newTestRequest(tx)
 
 	execParams := json.RawMessage(`{"repo":"supersuit-tech/webapp","branch":"release/v2.1","message":"Deploy"}`)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, actionType, execParams)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
 	if result == nil {
 		t.Fatalf("expected success for mixed config, got error: %s", w.Body.String())
 	}
@@ -386,7 +386,7 @@ func setupWildcardConfigTest(t *testing.T) (db.DBTX, string, int64, string, stri
 
 func TestValidateConfigurationReference_WildcardMatchesAnyActionType(t *testing.T) {
 	t.Parallel()
-	tx, _, agentID, connID, configID := setupWildcardConfigTest(t)
+	tx, uid, agentID, connID, configID := setupWildcardConfigTest(t)
 
 	// Wildcard config should accept any action type.
 	actionTypes := []string{
@@ -399,7 +399,7 @@ func TestValidateConfigurationReference_WildcardMatchesAnyActionType(t *testing.
 		t.Run(at, func(t *testing.T) {
 			deps, w, r := newTestRequest(tx)
 			execParams := json.RawMessage(`{"any_param":"any_value"}`)
-			result := ValidateConfigurationReference(w, r, deps, configID, agentID, at, execParams)
+			result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, at, "", execParams)
 			if result == nil {
 				t.Errorf("expected wildcard config to match action type %q, got error: %s", at, w.Body.String())
 			}
@@ -426,7 +426,7 @@ func TestValidateConfigurationReference_WildcardDisabledConfig(t *testing.T) {
 	// A disabled wildcard config should be rejected. The query filters by
 	// status='active', so it returns not-found (400) rather than found-but-disabled (403).
 	deps, w, r := newTestRequest(tx)
-	result := ValidateConfigurationReference(w, r, deps, configID, agentID, connID+".some_action", json.RawMessage(`{}`))
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, connID+".some_action", "", json.RawMessage(`{}`))
 	if result != nil {
 		t.Fatal("expected nil result for disabled wildcard config")
 	}
@@ -438,7 +438,7 @@ func TestValidateConfigurationReference_WildcardDisabledConfig(t *testing.T) {
 
 func TestValidateConfigurationReference_WildcardAcceptsAnyParameters(t *testing.T) {
 	t.Parallel()
-	tx, _, agentID, connID, configID := setupWildcardConfigTest(t)
+	tx, uid, agentID, connID, configID := setupWildcardConfigTest(t)
 
 	// Wildcard config should accept any parameters (including extra ones).
 	tests := []struct {
@@ -455,7 +455,7 @@ func TestValidateConfigurationReference_WildcardAcceptsAnyParameters(t *testing.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			deps, w, r := newTestRequest(tx)
-			result := ValidateConfigurationReference(w, r, deps, configID, agentID, connID+".some_action", json.RawMessage(tc.execParams))
+			result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, connID+".some_action", "", json.RawMessage(tc.execParams))
 			if result == nil {
 				t.Errorf("expected wildcard config to accept %s, got error: %s", tc.name, w.Body.String())
 			}

--- a/api/agent_approvals.go
+++ b/api/agent_approvals.go
@@ -236,7 +236,7 @@ func handleAgentRequestApproval(deps *Deps) http.HandlerFunc {
 
 		// Optional: validate configuration reference — sees canonical keys after normalization.
 		if req.Configuration != nil {
-			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
+			result := ValidateConfigurationReference(w, r, deps, req.Configuration.ConfigurationID, agent.AgentID, agent.ApproverID, actionType, connectorInstanceID, actionParams)
 			if result == nil {
 				return // error already written
 			}

--- a/api/agent_approvals_bulk.go
+++ b/api/agent_approvals_bulk.go
@@ -373,7 +373,7 @@ func prepareBulkItems(w http.ResponseWriter, r *http.Request, deps *Deps, agent 
 		}
 
 		if item.Configuration != nil {
-			result := ValidateConfigurationReference(w, r, deps, item.Configuration.ConfigurationID, agent.AgentID, actionType, actionParams)
+			result := ValidateConfigurationReference(w, r, deps, item.Configuration.ConfigurationID, agent.AgentID, agent.ApproverID, actionType, connectorInstanceID, actionParams)
 			if result == nil {
 				return nil, fmt.Errorf("invalid configuration")
 			}
@@ -520,7 +520,14 @@ func attemptStandingApprovalForBulk(ctx context.Context, deps *Deps, agent *db.A
 			sa = candidate
 			break
 		}
-		if err := db.ValidateParametersAgainstConfig(candidate.Constraints, item.actionParams); err != nil {
+		if err := validateActionConstraints(ctx, deps, agent.AgentID, agent.ApproverID, item.actionType, item.connectorInstanceID, candidate.Constraints, item.actionParams); err != nil {
+			configErr, unresolved := constraintMatchErr(err)
+			if unresolved || configErr != nil {
+				continue
+			}
+			log.Printf("[%s] BulkRequest standing approval constraint validation for %s: %v",
+				TraceID(ctx), candidate.StandingApprovalID, err)
+			CaptureError(ctx, err)
 			continue
 		}
 		sa = candidate

--- a/api/constraint_validate.go
+++ b/api/constraint_validate.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+)
+
+// constraintMetadataResolveTimeout bounds verified metadata lookup on the
+// constraint-matching path (standing approvals, action configs, bulk).
+const constraintMetadataResolveTimeout = 30 * time.Second
+
+// validateActionConstraints checks execution parameters and optional $meta
+// constraints. When the configuration includes $meta constraints, verified
+// metadata is resolved via the connector before matching.
+func validateActionConstraints(
+	ctx context.Context,
+	deps *Deps,
+	agentID int64,
+	userID string,
+	actionType string,
+	connectorInstanceID string,
+	configConstraints json.RawMessage,
+	execParams json.RawMessage,
+) error {
+	if !configHasMetaConstraints(configConstraints) {
+		return db.ValidateParametersAgainstConfig(configConstraints, execParams, nil)
+	}
+
+	resolvedMeta, err := resolveConstraintMetadata(ctx, deps, agentID, userID, actionType, connectorInstanceID, execParams)
+	if err != nil {
+		return err
+	}
+
+	var metaBytes json.RawMessage
+	if resolvedMeta != nil {
+		metaBytes, err = json.Marshal(resolvedMeta)
+		if err != nil {
+			return err
+		}
+	}
+
+	return db.ValidateParametersAgainstConfig(configConstraints, execParams, metaBytes)
+}
+
+func configHasMetaConstraints(configConstraints json.RawMessage) bool {
+	if len(configConstraints) == 0 || string(configConstraints) == "null" {
+		return false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(configConstraints, &obj); err != nil {
+		return false
+	}
+	meta, ok := obj[db.MetaNamespaceKey]
+	return ok && len(meta) > 0 && string(meta) != "null" && string(meta) != "{}"
+}
+
+func resolveConstraintMetadata(
+	ctx context.Context,
+	deps *Deps,
+	agentID int64,
+	userID string,
+	actionType string,
+	connectorInstanceID string,
+	execParams json.RawMessage,
+) (map[string]any, error) {
+	if deps == nil || deps.Connectors == nil {
+		return nil, db.ErrMetadataUnresolved
+	}
+
+	parts := strings.SplitN(actionType, ".", 2)
+	if len(parts) != 2 {
+		return nil, db.ErrMetadataUnresolved
+	}
+	connectorID := parts[0]
+
+	conn, ok := deps.Connectors.Get(connectorID)
+	if !ok {
+		return nil, db.ErrMetadataUnresolved
+	}
+
+	resolver, ok := conn.(connectors.ConstraintMetadataResolver)
+	if !ok {
+		return nil, db.ErrMetadataUnresolved
+	}
+
+	resolveCtx, cancel := context.WithTimeout(ctx, constraintMetadataResolveTimeout)
+	defer cancel()
+	resolveCtx, creds := resolveResourceDetailsContext(resolveCtx, deps, agentID, userID, actionType, connectorID, connectorInstanceID)
+
+	meta, err := resolver.ResolveConstraintMetadata(resolveCtx, actionType, execParams, creds)
+	if err != nil {
+		if errors.Is(err, connectors.ErrConstraintMetadataUnavailable) {
+			log.Printf("[%s] ResolveConstraintMetadata unavailable for %s: %v", TraceID(ctx), actionType, err)
+			return nil, db.ErrMetadataUnresolved
+		}
+		log.Printf("[%s] ResolveConstraintMetadata failed for %s: %v", TraceID(ctx), actionType, err)
+		return nil, db.ErrMetadataUnresolved
+	}
+	if meta == nil {
+		return nil, db.ErrMetadataUnresolved
+	}
+	return meta, nil
+}
+
+// constraintMatchErr reports whether a constraint validation error should be
+// treated as a non-match (fall through) rather than a hard failure.
+func constraintMatchErr(err error) (configErr *db.ConfigValidationError, unresolved bool) {
+	if errors.Is(err, db.ErrMetadataUnresolved) {
+		return nil, true
+	}
+	var cve *db.ConfigValidationError
+	if errors.As(err, &cve) {
+		return cve, false
+	}
+	return nil, false
+}

--- a/api/constraint_validate_test.go
+++ b/api/constraint_validate_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/db"
+	"github.com/supersuit-tech/permission-slip/db/testhelper"
+)
+
+type mockMetadataConnector struct {
+	mockConnector
+	metadata map[string]any
+	metaErr  error
+}
+
+func (c *mockMetadataConnector) ResolveConstraintMetadata(_ context.Context, actionType string, _ json.RawMessage, _ connectors.Credentials) (map[string]any, error) {
+	if c.metaErr != nil {
+		return nil, c.metaErr
+	}
+	return c.metadata, nil
+}
+
+func setupProtonArchiveStandingApprovalTest(t *testing.T, constraints []byte, metadata map[string]any) (db.DBTX, http.Handler, int64, []byte, string) {
+	t.Helper()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+
+	pubKeySSH, privKey, err := GenerateEd25519OpenSSHKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	agentID := testhelper.InsertAgentWithPublicKey(t, tx, uid, "registered", pubKeySSH)
+
+	testhelper.InsertConnector(t, tx, "protonmail")
+	testhelper.InsertConnectorAction(t, tx, "protonmail", "protonmail.archive_email", "Archive Email")
+
+	saID := testhelper.GenerateID(t, "sa_")
+	testhelper.InsertStandingApprovalFull(t, tx, saID, agentID, uid, testhelper.StandingApprovalOpts{
+		ActionType:  "protonmail.archive_email",
+		Constraints: constraints,
+	})
+
+	action := &mockAction{result: &connectors.ActionResult{Data: json.RawMessage(`{"status":"archived"}`)}}
+	metaConn := &mockMetadataConnector{
+		mockConnector: mockConnector{
+			id:      "protonmail",
+			actions: map[string]connectors.Action{"protonmail.archive_email": action},
+		},
+		metadata: metadata,
+	}
+	registry := connectors.NewRegistry()
+	registry.Register(metaConn)
+
+	deps := &Deps{DB: tx, Connectors: registry, JWTSigningSecret: testJWTSecret}
+	router := NewRouter(deps)
+
+	return tx, router, agentID, privKey, saID
+}
+
+func setupProtonArchiveConfigTest(t *testing.T, params []byte) (db.DBTX, string, int64, string, string) {
+	t.Helper()
+	tx := testhelper.SetupTestDB(t)
+	uid := testhelper.GenerateUID(t)
+	testhelper.InsertUser(t, tx, uid, "u_"+uid[:8])
+	agentID := testhelper.InsertAgentWithStatus(t, tx, uid, "registered")
+	testhelper.InsertConnector(t, tx, "protonmail")
+	testhelper.InsertConnectorAction(t, tx, "protonmail", "protonmail.archive_email", "Archive Email")
+
+	configID := testhelper.GenerateID(t, "ac_")
+	testhelper.InsertActionConfigFull(t, tx, configID, agentID, uid, "protonmail", "protonmail.archive_email", testhelper.ActionConfigOpts{
+		Name:       "Archive Alice Only",
+		Parameters: params,
+	})
+	return tx, uid, agentID, configID, "protonmail.archive_email"
+}
+
+func TestRequestApproval_AutoApprove_MetaSenderMatch(t *testing.T) {
+	t.Parallel()
+	tx, router, agentID, privKey, saID := setupProtonArchiveStandingApprovalTest(t,
+		[]byte(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`),
+		map[string]any{"sender": "alice@example.com"},
+	)
+
+	reqBody := `{"request_id":"meta-sender-match-001","action":{"type":"protonmail.archive_email","parameters":{"message_id":42,"folder":"INBOX"}},"context":{"description":"archive"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Status != "approved" {
+		t.Errorf("expected approved, got %q", resp.Status)
+	}
+	if resp.StandingApprovalID != saID {
+		t.Errorf("expected standing approval %q, got %q", saID, resp.StandingApprovalID)
+	}
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 1)
+}
+
+func TestRequestApproval_AutoApprove_MetaSenderMismatchFallsThrough(t *testing.T) {
+	t.Parallel()
+	_, router, agentID, privKey, _ := setupProtonArchiveStandingApprovalTest(t,
+		[]byte(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`),
+		map[string]any{"sender": "bob@example.com"},
+	)
+
+	reqBody := `{"request_id":"meta-sender-mismatch-001","action":{"type":"protonmail.archive_email","parameters":{"message_id":42,"folder":"INBOX"}},"context":{"description":"archive"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 pending, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Status != "pending" {
+		t.Errorf("expected pending fallthrough, got %q", resp.Status)
+	}
+}
+
+func TestRequestApproval_AutoApprove_SpoofedSenderParamIgnored(t *testing.T) {
+	t.Parallel()
+	tx, router, agentID, privKey, saID := setupProtonArchiveStandingApprovalTest(t,
+		[]byte(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`),
+		map[string]any{"sender": "bob@example.com"},
+	)
+
+	reqBody := `{"request_id":"meta-sender-spoof-001","action":{"type":"protonmail.archive_email","parameters":{"message_id":42,"folder":"INBOX","sender":"alice@example.com"}},"context":{"description":"archive"}}`
+	r := signedJSONRequest(t, http.MethodPost, "/approvals/request", reqBody, privKey, agentID)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp agentRequestApprovalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Status == "approved" {
+		t.Fatal("spoofed sender param must not auto-approve when verified sender differs")
+	}
+	testhelper.RequireStandingApprovalExecutionCount(t, tx, saID, 0)
+}
+
+func TestValidateConfigurationReference_MetaSenderEnforced(t *testing.T) {
+	t.Parallel()
+	params := []byte(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	tx, uid, agentID, configID, actionType := setupProtonArchiveConfigTest(t, params)
+
+	conn := &mockMetadataConnector{
+		mockConnector: mockConnector{id: "protonmail"},
+		metadata:      map[string]any{"sender": "alice@example.com"},
+	}
+	registry := connectors.NewRegistry()
+	registry.Register(conn)
+
+	deps, w, r := newTestRequest(tx)
+	deps.Connectors = registry
+
+	execParams := json.RawMessage(`{"message_id":42,"folder":"INBOX"}`)
+	result := ValidateConfigurationReference(w, r, deps, configID, agentID, uid, actionType, "", execParams)
+	if result == nil {
+		t.Fatalf("expected success, got: %s", w.Body.String())
+	}
+
+	conn.metadata = map[string]any{"sender": "bob@example.com"}
+	deps2, w2, r2 := newTestRequest(tx)
+	deps2.Connectors = registry
+	result = ValidateConfigurationReference(w2, r2, deps2, configID, agentID, uid, actionType, "", execParams)
+	if result != nil {
+		t.Fatal("expected metadata mismatch to fail validation")
+	}
+	if w2.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w2.Code)
+	}
+}

--- a/api/standing_approval_match.go
+++ b/api/standing_approval_match.go
@@ -33,9 +33,12 @@ func tryStandingApprovalAutoApprove(w http.ResponseWriter, r *http.Request, deps
 			sa = candidate
 			break
 		}
-		if err := db.ValidateParametersAgainstConfig(candidate.Constraints, params); err != nil {
-			var configErr *db.ConfigValidationError
-			if errors.As(err, &configErr) {
+		if err := validateActionConstraints(r.Context(), deps, agent.AgentID, agent.ApproverID, actionType, connectorInstanceID, candidate.Constraints, params); err != nil {
+			configErr, unresolved := constraintMatchErr(err)
+			if unresolved {
+				continue
+			}
+			if configErr != nil {
 				continue
 			}
 			// Corrupt constraint JSON — log, report to error tracker, and skip

--- a/api/standing_approvals.go
+++ b/api/standing_approvals.go
@@ -780,6 +780,44 @@ func validateStandingApprovalConstraints(raw json.RawMessage) ([]byte, error) {
 	allWildcard := true
 	mutated := false
 	for key, v := range obj {
+		if key == db.MetaNamespaceKey {
+			var metaObj map[string]json.RawMessage
+			if err := json.Unmarshal(v, &metaObj); err != nil {
+				return nil, errors.New("$meta constraints must be a JSON object")
+			}
+			metaMutated := false
+			for metaKey, metaVal := range metaObj {
+				if string(metaVal) == "null" {
+					return nil, errors.New("constraint values must not be null; use \"*\" for a wildcard or omit the key entirely")
+				}
+				var s string
+				if json.Unmarshal(metaVal, &s) == nil {
+					if s == "*" {
+						continue
+					}
+					allWildcard = false
+					if strings.Contains(s, "*") {
+						wrapped, err := json.Marshal(map[string]string{db.PatternKey: s})
+						if err != nil {
+							return nil, fmt.Errorf("failed to wrap pattern for %q: %w", metaKey, err)
+						}
+						metaObj[metaKey] = wrapped
+						metaMutated = true
+					}
+				} else {
+					allWildcard = false
+				}
+			}
+			if metaMutated {
+				if normalized, err := json.Marshal(metaObj); err != nil {
+					return nil, fmt.Errorf("failed to normalize $meta constraints: %w", err)
+				} else {
+					obj[key] = normalized
+					mutated = true
+				}
+			}
+			continue
+		}
 		if string(v) == "null" {
 			return nil, errors.New("constraint values must not be null; use \"*\" for a wildcard or omit the key entirely")
 		}

--- a/connectors/constraint_metadata.go
+++ b/connectors/constraint_metadata.go
@@ -1,0 +1,23 @@
+package connectors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+// ErrConstraintMetadataUnavailable indicates verified metadata could not be
+// resolved for the requested action parameters (e.g. IMAP fetch failed).
+var ErrConstraintMetadataUnavailable = errors.New("constraint metadata unavailable")
+
+// ConstraintMetadataResolver is optionally implemented by connectors that can
+// resolve verified metadata for constraint matching. Values are fetched from
+// the external service (e.g. real email From headers) — never from agent-supplied
+// parameters.
+type ConstraintMetadataResolver interface {
+	// ResolveConstraintMetadata returns verified metadata for the target
+	// resource(s) referenced by params. For batch or thread-expanded actions,
+	// every message in the effective set must be represented (e.g. all senders
+	// in a "senders" array) so callers can enforce fail-closed matching.
+	ResolveConstraintMetadata(ctx context.Context, actionType string, params json.RawMessage, creds Credentials) (map[string]any, error)
+}

--- a/connectors/protonmail/resolve_constraint_metadata.go
+++ b/connectors/protonmail/resolve_constraint_metadata.go
@@ -1,0 +1,94 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+var angleAddrRe = regexp.MustCompile(`<([^>]+)>`)
+
+// ResolveConstraintMetadata returns verified email metadata for constraint
+// matching. Currently supports archive_email with batch and thread expansion.
+func (c *ProtonMailConnector) ResolveConstraintMetadata(ctx context.Context, actionType string, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	switch actionType {
+	case "protonmail.archive_email":
+		return c.resolveArchiveConstraintMetadata(ctx, params, creds)
+	default:
+		return nil, connectors.ErrConstraintMetadataUnavailable
+	}
+}
+
+func (c *ProtonMailConnector) resolveArchiveConstraintMetadata(ctx context.Context, params json.RawMessage, creds connectors.Credentials) (map[string]any, error) {
+	archiveParams, err := parseArchiveParams(params)
+	if err != nil {
+		return nil, connectors.ErrConstraintMetadataUnavailable
+	}
+	if err := validateArchiveParams(archiveParams); err != nil {
+		return nil, connectors.ErrConstraintMetadataUnavailable
+	}
+
+	uids := archiveParams.MessageIDs
+	if includeThreadEnabled(archiveParams.IncludeThread) {
+		expanded, expandErr := expandArchiveUIDsForApproval(ctx, c, creds, archiveParams.Folder, archiveParams.MessageIDs)
+		if expandErr != nil {
+			return nil, fmt.Errorf("%w: thread expansion: %v", connectors.ErrConstraintMetadataUnavailable, expandErr)
+		}
+		uids = expanded
+	}
+
+	metaByUID, err := resolveMessageEnvelopes(ctx, c, creds, archiveParams.Folder, uids, connectors.MailboxUIDValidityFromContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("%w: envelope fetch: %v", connectors.ErrConstraintMetadataUnavailable, err)
+	}
+	if len(metaByUID) == 0 {
+		return nil, connectors.ErrConstraintMetadataUnavailable
+	}
+
+	senders := make([]string, 0, len(uids))
+	for _, uid := range uids {
+		meta, ok := metaByUID[uid]
+		if !ok {
+			return nil, connectors.ErrConstraintMetadataUnavailable
+		}
+		sender, ok := primarySenderAddress(meta.From)
+		if !ok {
+			return nil, connectors.ErrConstraintMetadataUnavailable
+		}
+		senders = append(senders, sender)
+	}
+
+	result := map[string]any{
+		"senders": senders,
+	}
+	if len(senders) == 1 {
+		result["sender"] = senders[0]
+	}
+	return result, nil
+}
+
+// primarySenderAddress extracts the first From address as a bare email suitable
+// for pattern matching (strips display names and angle-bracket formatting).
+func primarySenderAddress(from []string) (string, bool) {
+	if len(from) == 0 {
+		return "", false
+	}
+	return normalizeEmailAddress(from[0])
+}
+
+func normalizeEmailAddress(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if matches := angleAddrRe.FindStringSubmatch(raw); len(matches) == 2 {
+		return strings.TrimSpace(matches[1]), true
+	}
+	return raw, true
+}
+
+var _ connectors.ConstraintMetadataResolver = (*ProtonMailConnector)(nil)

--- a/connectors/protonmail/resolve_constraint_metadata_test.go
+++ b/connectors/protonmail/resolve_constraint_metadata_test.go
@@ -1,0 +1,97 @@
+package protonmail
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestPrimarySenderAddress(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   []string
+		want string
+		ok   bool
+	}{
+		{[]string{"alice@example.com"}, "alice@example.com", true},
+		{[]string{"Alice <alice@example.com>"}, "alice@example.com", true},
+		{[]string{}, "", false},
+		{[]string{""}, "", false},
+	}
+	for _, tc := range tests {
+		got, ok := primarySenderAddress(tc.in)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("primarySenderAddress(%v) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestResolveArchiveConstraintMetadata_SingleMessage(t *testing.T) {
+	t.Parallel()
+	orig := resolveMessageEnvelopes
+	t.Cleanup(func() { resolveMessageEnvelopes = orig })
+
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, folder string, uids []uint32, _ connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		if folder != "INBOX" || len(uids) != 1 || uids[0] != 99 {
+			t.Fatalf("unexpected fetch: folder=%q uids=%v", folder, uids)
+		}
+		return map[uint32]emailEnvelopeMetadata{
+			99: {From: []string{"Alice <alice@example.com>"}},
+		}, nil
+	}
+
+	conn := New()
+	params := json.RawMessage(`{"message_id":99,"folder":"INBOX","include_thread":false}`)
+	meta, err := conn.ResolveConstraintMetadata(context.Background(), "protonmail.archive_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("ResolveConstraintMetadata: %v", err)
+	}
+	if meta["sender"] != "alice@example.com" {
+		t.Fatalf("sender = %v, want alice@example.com", meta["sender"])
+	}
+}
+
+func TestResolveArchiveConstraintMetadata_ThreadExpansionUsesAllSenders(t *testing.T) {
+	t.Parallel()
+	origEnvelopes := resolveMessageEnvelopes
+	origExpand := expandArchiveUIDsForApproval
+	t.Cleanup(func() {
+		resolveMessageEnvelopes = origEnvelopes
+		expandArchiveUIDsForApproval = origExpand
+	})
+
+	expandArchiveUIDsForApproval = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ string, _ []uint32) ([]uint32, error) {
+		return []uint32{10, 11}, nil
+	}
+	resolveMessageEnvelopes = func(_ context.Context, _ *ProtonMailConnector, _ connectors.Credentials, _ string, uids []uint32, _ connectors.MailboxUIDValidityStore) (map[uint32]emailEnvelopeMetadata, error) {
+		return map[uint32]emailEnvelopeMetadata{
+			10: {From: []string{"alice@example.com"}},
+			11: {From: []string{"bob@example.com"}},
+		}, nil
+	}
+
+	conn := New()
+	params := json.RawMessage(`{"message_id":10,"folder":"INBOX","include_thread":true}`)
+	meta, err := conn.ResolveConstraintMetadata(context.Background(), "protonmail.archive_email", params, validCreds())
+	if err != nil {
+		t.Fatalf("ResolveConstraintMetadata: %v", err)
+	}
+	senders, ok := meta["senders"].([]string)
+	if !ok || len(senders) != 2 {
+		t.Fatalf("senders = %v, want two addresses", meta["senders"])
+	}
+	if _, hasSingle := meta["sender"]; hasSingle {
+		t.Fatal("expected no singular sender field for multi-message batch")
+	}
+}
+
+func TestResolveArchiveConstraintMetadata_UnknownAction(t *testing.T) {
+	t.Parallel()
+	conn := New()
+	_, err := conn.ResolveConstraintMetadata(context.Background(), "protonmail.read_inbox", json.RawMessage(`{}`), validCreds())
+	if err == nil {
+		t.Fatal("expected error for unsupported action")
+	}
+}

--- a/db/action_config_validate.go
+++ b/db/action_config_validate.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -45,6 +46,15 @@ func IsWildcard(raw json.RawMessage) bool {
 // parameters JSONB column — never as bare strings containing "*". This avoids
 // ambiguity with fixed values that happen to contain the "*" character.
 const PatternKey = "$pattern"
+
+// MetaNamespaceKey is the reserved configuration key for constraints on
+// server-resolved metadata (e.g. verified email sender). Nested fields use the
+// same wildcard/pattern/fixed syntax as regular parameters.
+const MetaNamespaceKey = "$meta"
+
+// ErrMetadataUnresolved indicates $meta constraints are present but verified
+// metadata was not supplied to the constraint engine.
+var ErrMetadataUnresolved = errors.New("constraint metadata unresolved")
 
 // IsPattern reports whether a JSON-encoded parameter value is a glob pattern
 // wrapper: a JSON object of the form {"$pattern": "<glob>"}. The glob string
@@ -128,10 +138,50 @@ func ValidateConfigParameters(params json.RawMessage) error {
 		return fmt.Errorf("parameters must be a JSON object")
 	}
 	for key, raw := range m {
+		if key == MetaNamespaceKey {
+			if err := validateMetaNamespaceConfig(raw); err != nil {
+				return err
+			}
+			continue
+		}
 		if pattern, ok := extractPattern(raw); ok {
 			if !strings.Contains(pattern, "*") {
 				return &ConfigValidationError{
 					Parameter: key,
+					Reason:    fmt.Sprintf("$pattern value %q must contain at least one '*' wildcard; use a plain string for fixed values", pattern),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateMetaNamespaceConfig(raw json.RawMessage) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return &ConfigValidationError{
+			Parameter: MetaNamespaceKey,
+			Reason:    "must be a JSON object",
+		}
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return &ConfigValidationError{
+			Parameter: MetaNamespaceKey,
+			Reason:    "must be a JSON object",
+		}
+	}
+	if len(meta) == 0 {
+		return &ConfigValidationError{
+			Parameter: MetaNamespaceKey,
+			Reason:    "must contain at least one metadata constraint",
+		}
+	}
+	for key, value := range meta {
+		param := MetaNamespaceKey + "." + key
+		if pattern, ok := extractPattern(value); ok {
+			if !strings.Contains(pattern, "*") {
+				return &ConfigValidationError{
+					Parameter: param,
 					Reason:    fmt.Sprintf("$pattern value %q must contain at least one '*' wildcard; use a plain string for fixed values", pattern),
 				}
 			}
@@ -163,14 +213,22 @@ func (e *ConfigValidationError) Error() string {
 //   - Missing parameters that are fixed or pattern in the configuration are rejected.
 //   - Missing wildcard parameters are allowed (the agent chose not to provide them).
 //
-// Both configParams and execParams are raw JSONB (JSON objects). Returns nil if
-// validation passes, or a *ConfigValidationError describing the first violation.
-func ValidateParametersAgainstConfig(configParams, execParams json.RawMessage) error {
+// Both configParams and execParams are raw JSONB (JSON objects). When the
+// configuration includes a $meta namespace, resolvedMeta must contain the
+// server-resolved metadata object; otherwise ErrMetadataUnresolved is returned.
+// Returns nil if validation passes, or a *ConfigValidationError describing the
+// first violation.
+func ValidateParametersAgainstConfig(configParams, execParams, resolvedMeta json.RawMessage) error {
 	var config map[string]json.RawMessage
 	if len(configParams) == 0 || string(configParams) == "{}" {
 		config = map[string]json.RawMessage{}
 	} else if err := json.Unmarshal(configParams, &config); err != nil {
 		return fmt.Errorf("invalid configuration parameters: %w", err)
+	}
+
+	metaConstraints, hasMeta := config[MetaNamespaceKey]
+	if hasMeta {
+		delete(config, MetaNamespaceKey)
 	}
 
 	var exec map[string]json.RawMessage
@@ -254,6 +312,109 @@ func ValidateParametersAgainstConfig(configParams, execParams json.RawMessage) e
 		}
 	}
 
+	if hasMeta {
+		if err := validateResolvedMetaConstraints(metaConstraints, resolvedMeta); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateResolvedMetaConstraints(metaConstraints, resolvedMeta json.RawMessage) error {
+	var constraints map[string]json.RawMessage
+	if err := json.Unmarshal(metaConstraints, &constraints); err != nil {
+		return fmt.Errorf("invalid $meta constraints: %w", err)
+	}
+	if len(constraints) == 0 {
+		return nil
+	}
+	if len(resolvedMeta) == 0 || string(resolvedMeta) == "null" {
+		return ErrMetadataUnresolved
+	}
+
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(resolvedMeta, &meta); err != nil {
+		return fmt.Errorf("invalid resolved metadata: %w", err)
+	}
+
+	for key, configValue := range constraints {
+		param := MetaNamespaceKey + "." + key
+		if err := validateConstraintValueAgainstSource(param, configValue, meta[key]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateConstraintValueAgainstSource(param string, configValue, sourceValue json.RawMessage) error {
+	if IsWildcard(configValue) {
+		return nil
+	}
+
+	if pattern, ok := ExtractPattern(configValue); ok {
+		return validatePatternConstraint(param, pattern, sourceValue)
+	}
+
+	if len(sourceValue) == 0 {
+		return &ConfigValidationError{
+			Parameter: param,
+			Reason:    "required metadata field is missing",
+		}
+	}
+	if !jsonValuesEqual(configValue, sourceValue) {
+		return &ConfigValidationError{
+			Parameter: param,
+			Reason:    "metadata value does not match configured value",
+		}
+	}
+	return nil
+}
+
+func validatePatternConstraint(param, pattern string, sourceValue json.RawMessage) error {
+	if len(sourceValue) == 0 {
+		return &ConfigValidationError{
+			Parameter: param,
+			Reason:    fmt.Sprintf("required metadata field is missing for pattern %q", pattern),
+		}
+	}
+
+	var values []string
+	if err := json.Unmarshal(sourceValue, &values); err == nil {
+		for _, value := range values {
+			if err := validateStringPattern(param, pattern, value); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	var value string
+	if err := json.Unmarshal(sourceValue, &value); err != nil {
+		return &ConfigValidationError{
+			Parameter: param,
+			Reason:    fmt.Sprintf("metadata value must be a string or array of strings matching pattern %q", pattern),
+		}
+	}
+	return validateStringPattern(param, pattern, value)
+}
+
+func validateStringPattern(param, pattern, value string) error {
+	if strings.Contains(pattern, "*") {
+		if !MatchPattern(pattern, value) {
+			return &ConfigValidationError{
+				Parameter: param,
+				Reason:    fmt.Sprintf("metadata value %q does not match pattern %q", value, pattern),
+			}
+		}
+		return nil
+	}
+	if value != pattern {
+		return &ConfigValidationError{
+			Parameter: param,
+			Reason:    fmt.Sprintf("metadata value %q does not match pattern %q", value, pattern),
+		}
+	}
 	return nil
 }
 

--- a/db/action_config_validate.go
+++ b/db/action_config_validate.go
@@ -340,7 +340,11 @@ func validateResolvedMetaConstraints(metaConstraints, resolvedMeta json.RawMessa
 
 	for key, configValue := range constraints {
 		param := MetaNamespaceKey + "." + key
-		if err := validateConstraintValueAgainstSource(param, configValue, meta[key]); err != nil {
+		sourceValue := meta[key]
+		if len(sourceValue) == 0 && key == "sender" {
+			sourceValue = meta["senders"]
+		}
+		if err := validateConstraintValueAgainstSource(param, configValue, sourceValue); err != nil {
 			return err
 		}
 	}

--- a/db/action_config_validate_test.go
+++ b/db/action_config_validate_test.go
@@ -590,7 +590,7 @@ func TestValidateParametersAgainstConfig_PlainStringWithStarRejectsGlobMatch(t *
 
 func TestValidateParametersAgainstConfig_MetaSenderPatternMatch(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	config := json.RawMessage(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
 	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX"}`)
 	meta := json.RawMessage(`{"sender":"alice@example.com"}`)
 
@@ -601,7 +601,7 @@ func TestValidateParametersAgainstConfig_MetaSenderPatternMatch(t *testing.T) {
 
 func TestValidateParametersAgainstConfig_MetaSenderPatternMismatch(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	config := json.RawMessage(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
 	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX"}`)
 	meta := json.RawMessage(`{"sender":"bob@example.com"}`)
 
@@ -617,7 +617,7 @@ func TestValidateParametersAgainstConfig_MetaSenderPatternMismatch(t *testing.T)
 
 func TestValidateParametersAgainstConfig_MetaSendersArrayAllMustMatch(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
+	config := json.RawMessage(`{"message_ids":"*","$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
 	exec := json.RawMessage(`{"message_ids":[1,2]}`)
 	meta := json.RawMessage(`{"senders":["a@alice.com","b@alice.com"]}`)
 
@@ -628,7 +628,7 @@ func TestValidateParametersAgainstConfig_MetaSendersArrayAllMustMatch(t *testing
 
 func TestValidateParametersAgainstConfig_MetaSendersArrayOneMismatch(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
+	config := json.RawMessage(`{"message_ids":"*","$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
 	exec := json.RawMessage(`{"message_ids":[1,2]}`)
 	meta := json.RawMessage(`{"senders":["a@alice.com","b@other.com"]}`)
 
@@ -640,7 +640,7 @@ func TestValidateParametersAgainstConfig_MetaSendersArrayOneMismatch(t *testing.
 
 func TestValidateParametersAgainstConfig_MetaUnresolved(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	config := json.RawMessage(`{"message_id":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
 	exec := json.RawMessage(`{"message_id":42}`)
 
 	err := ValidateParametersAgainstConfig(config, exec, nil)
@@ -651,7 +651,7 @@ func TestValidateParametersAgainstConfig_MetaUnresolved(t *testing.T) {
 
 func TestValidateParametersAgainstConfig_SpoofedSenderParamRejected(t *testing.T) {
 	t.Parallel()
-	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	config := json.RawMessage(`{"message_id":"*","folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
 	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX","sender":"alice@example.com"}`)
 	meta := json.RawMessage(`{"sender":"bob@example.com"}`)
 

--- a/db/action_config_validate_test.go
+++ b/db/action_config_validate_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -149,7 +150,7 @@ func TestValidateParametersAgainstConfig_AllFixed(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp","label":"bug"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","label":"bug"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
@@ -159,7 +160,7 @@ func TestValidateParametersAgainstConfig_FixedMismatch(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/api"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for mismatched fixed param")
 	}
@@ -177,7 +178,7 @@ func TestValidateParametersAgainstConfig_WildcardAcceptsAny(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"*","body":"*"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"Fix login bug","body":"The login page crashes"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
@@ -188,7 +189,7 @@ func TestValidateParametersAgainstConfig_WildcardOmittedIsOK(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"*","body":"*"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"My issue"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error for omitted wildcard param, got: %v", err)
 	}
 }
@@ -198,7 +199,7 @@ func TestValidateParametersAgainstConfig_MissingFixedParam(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp","label":"bug"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for missing fixed param")
 	}
@@ -216,7 +217,7 @@ func TestValidateParametersAgainstConfig_ExtraParam(t *testing.T) {
 	config := json.RawMessage(`{"repo":"supersuit-tech/webapp"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","extra":"value"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for extra param")
 	}
@@ -235,7 +236,7 @@ func TestValidateParametersAgainstConfig_EmptyConfig(t *testing.T) {
 	config := json.RawMessage(`{}`)
 	exec := json.RawMessage(`{}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error for empty config and exec, got: %v", err)
 	}
 }
@@ -245,7 +246,7 @@ func TestValidateParametersAgainstConfig_EmptyConfigRejectsExec(t *testing.T) {
 	config := json.RawMessage(`{}`)
 	exec := json.RawMessage(`{"foo":"bar"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for param not in empty config")
 	}
@@ -257,7 +258,7 @@ func TestValidateParametersAgainstConfig_ComplexValues(t *testing.T) {
 	config := json.RawMessage(`{"to":["alice@example.com","bob@example.com"],"subject":"*"}`)
 	exec := json.RawMessage(`{"to":["alice@example.com","bob@example.com"],"subject":"Hello"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error for matching complex value, got: %v", err)
 	}
 }
@@ -267,7 +268,7 @@ func TestValidateParametersAgainstConfig_ComplexValueMismatch(t *testing.T) {
 	config := json.RawMessage(`{"to":["alice@example.com"],"subject":"*"}`)
 	exec := json.RawMessage(`{"to":["bob@example.com"],"subject":"Hello"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for mismatched array value")
 	}
@@ -278,7 +279,7 @@ func TestValidateParametersAgainstConfig_NumericValues(t *testing.T) {
 	config := json.RawMessage(`{"amount":9900,"currency":"USD"}`)
 	exec := json.RawMessage(`{"amount":9900,"currency":"USD"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
@@ -288,7 +289,7 @@ func TestValidateParametersAgainstConfig_NumericMismatch(t *testing.T) {
 	config := json.RawMessage(`{"amount":9900}`)
 	exec := json.RawMessage(`{"amount":5000}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for mismatched numeric value")
 	}
@@ -297,7 +298,7 @@ func TestValidateParametersAgainstConfig_NumericMismatch(t *testing.T) {
 func TestValidateParametersAgainstConfig_NullConfig(t *testing.T) {
 	t.Parallel()
 	// Nil/empty config should be treated as empty object.
-	if err := ValidateParametersAgainstConfig(nil, json.RawMessage(`{}`)); err != nil {
+	if err := ValidateParametersAgainstConfig(nil, json.RawMessage(`{}`), nil); err != nil {
 		t.Errorf("expected no error for nil config, got: %v", err)
 	}
 }
@@ -307,7 +308,7 @@ func TestValidateParametersAgainstConfig_BooleanValues(t *testing.T) {
 	config := json.RawMessage(`{"draft":true,"title":"*"}`)
 	exec := json.RawMessage(`{"draft":true,"title":"My PR"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
 }
@@ -332,7 +333,7 @@ func TestValidateParametersAgainstConfig_WildcardWithAnyType(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if err := ValidateParametersAgainstConfig(config, tc.exec); err != nil {
+			if err := ValidateParametersAgainstConfig(config, tc.exec, nil); err != nil {
 				t.Errorf("expected wildcard to accept %s, got: %v", tc.name, err)
 			}
 		})
@@ -347,7 +348,7 @@ func TestValidateParametersAgainstConfig_PatternSuffix(t *testing.T) {
 	config := json.RawMessage(`{"to":{"$pattern":"*@mycompany.com"},"subject":"*"}`)
 	exec := json.RawMessage(`{"to":"alice@mycompany.com","subject":"Hello"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected pattern suffix to match, got: %v", err)
 	}
 }
@@ -358,7 +359,7 @@ func TestValidateParametersAgainstConfig_PatternPrefix(t *testing.T) {
 	config := json.RawMessage(`{"repo":{"$pattern":"supersuit-tech/*"},"title":"*"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","title":"Fix bug"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected pattern prefix to match, got: %v", err)
 	}
 }
@@ -369,7 +370,7 @@ func TestValidateParametersAgainstConfig_PatternInfix(t *testing.T) {
 	config := json.RawMessage(`{"env":{"$pattern":"test-*-prod"},"cmd":"*"}`)
 	exec := json.RawMessage(`{"env":"test-us-east-prod","cmd":"deploy"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected pattern infix to match, got: %v", err)
 	}
 }
@@ -379,7 +380,7 @@ func TestValidateParametersAgainstConfig_PatternMismatch(t *testing.T) {
 	config := json.RawMessage(`{"to":{"$pattern":"*@mycompany.com"}}`)
 	exec := json.RawMessage(`{"to":"alice@other.com"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for pattern mismatch")
 	}
@@ -414,7 +415,7 @@ func TestValidateParametersAgainstConfig_PatternRequiresString(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := ValidateParametersAgainstConfig(config, tc.exec)
+			err := ValidateParametersAgainstConfig(config, tc.exec, nil)
 			if err == nil {
 				t.Errorf("expected pattern to reject %s value", tc.name)
 			}
@@ -435,7 +436,7 @@ func TestValidateParametersAgainstConfig_PatternMissing(t *testing.T) {
 	config := json.RawMessage(`{"repo":{"$pattern":"supersuit-tech/*"},"title":"*"}`)
 	exec := json.RawMessage(`{"title":"Bug fix"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for missing pattern parameter")
 	}
@@ -457,7 +458,7 @@ func TestValidateParametersAgainstConfig_PatternWithFixedAndWildcard(t *testing.
 	config := json.RawMessage(`{"repo":{"$pattern":"supersuit-tech/*"},"label":"bug","title":"*"}`)
 	exec := json.RawMessage(`{"repo":"supersuit-tech/webapp","label":"bug","title":"Fix login"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected mixed config to pass, got: %v", err)
 	}
 }
@@ -468,7 +469,7 @@ func TestValidateParametersAgainstConfig_PatternMultipleWildcards(t *testing.T) 
 	config := json.RawMessage(`{"env":{"$pattern":"*-*-prod"}}`)
 	exec := json.RawMessage(`{"env":"us-east-prod"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected multi-wildcard pattern to match, got: %v", err)
 	}
 }
@@ -535,7 +536,7 @@ func TestValidateParametersAgainstConfig_PatternWithoutStarExactMatch(t *testing
 	config := json.RawMessage(`{"tag":{"$pattern":"hello"}}`)
 	exec := json.RawMessage(`{"tag":"hello"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected $pattern without * to match exact string, got: %v", err)
 	}
 }
@@ -545,7 +546,7 @@ func TestValidateParametersAgainstConfig_PatternWithoutStarMismatch(t *testing.T
 	config := json.RawMessage(`{"tag":{"$pattern":"hello"}}`)
 	exec := json.RawMessage(`{"tag":"world"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error for mismatched value against $pattern without *")
 	}
@@ -567,7 +568,7 @@ func TestValidateParametersAgainstConfig_PlainStringWithStarIsFixedValue(t *test
 	config := json.RawMessage(`{"tag":"v*-release"}`)
 	exec := json.RawMessage(`{"tag":"v*-release"}`)
 
-	if err := ValidateParametersAgainstConfig(config, exec); err != nil {
+	if err := ValidateParametersAgainstConfig(config, exec, nil); err != nil {
 		t.Errorf("expected exact match for plain string with star, got: %v", err)
 	}
 }
@@ -579,8 +580,91 @@ func TestValidateParametersAgainstConfig_PlainStringWithStarRejectsGlobMatch(t *
 	config := json.RawMessage(`{"tag":"v*-release"}`)
 	exec := json.RawMessage(`{"tag":"v1.0-release"}`)
 
-	err := ValidateParametersAgainstConfig(config, exec)
+	err := ValidateParametersAgainstConfig(config, exec, nil)
 	if err == nil {
 		t.Fatal("expected error: plain string with * should require exact match, not glob")
+	}
+}
+
+// ── $meta namespace tests ───────────────────────────────────────────────────
+
+func TestValidateParametersAgainstConfig_MetaSenderPatternMatch(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX"}`)
+	meta := json.RawMessage(`{"sender":"alice@example.com"}`)
+
+	if err := ValidateParametersAgainstConfig(config, exec, meta); err != nil {
+		t.Fatalf("expected match, got: %v", err)
+	}
+}
+
+func TestValidateParametersAgainstConfig_MetaSenderPatternMismatch(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX"}`)
+	meta := json.RawMessage(`{"sender":"bob@example.com"}`)
+
+	err := ValidateParametersAgainstConfig(config, exec, meta)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	cve, ok := err.(*ConfigValidationError)
+	if !ok || cve.Parameter != "$meta.sender" {
+		t.Fatalf("expected $meta.sender error, got %T %v", err, err)
+	}
+}
+
+func TestValidateParametersAgainstConfig_MetaSendersArrayAllMustMatch(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
+	exec := json.RawMessage(`{"message_ids":[1,2]}`)
+	meta := json.RawMessage(`{"senders":["a@alice.com","b@alice.com"]}`)
+
+	if err := ValidateParametersAgainstConfig(config, exec, meta); err != nil {
+		t.Fatalf("expected all senders to match, got: %v", err)
+	}
+}
+
+func TestValidateParametersAgainstConfig_MetaSendersArrayOneMismatch(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"*@alice.com"}}}`)
+	exec := json.RawMessage(`{"message_ids":[1,2]}`)
+	meta := json.RawMessage(`{"senders":["a@alice.com","b@other.com"]}`)
+
+	err := ValidateParametersAgainstConfig(config, exec, meta)
+	if err == nil {
+		t.Fatal("expected error when one sender does not match")
+	}
+}
+
+func TestValidateParametersAgainstConfig_MetaUnresolved(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	exec := json.RawMessage(`{"message_id":42}`)
+
+	err := ValidateParametersAgainstConfig(config, exec, nil)
+	if !errors.Is(err, ErrMetadataUnresolved) {
+		t.Fatalf("expected ErrMetadataUnresolved, got %v", err)
+	}
+}
+
+func TestValidateParametersAgainstConfig_SpoofedSenderParamRejected(t *testing.T) {
+	t.Parallel()
+	config := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"alice@example.com"}}}`)
+	exec := json.RawMessage(`{"message_id":42,"folder":"INBOX","sender":"alice@example.com"}`)
+	meta := json.RawMessage(`{"sender":"bob@example.com"}`)
+
+	err := ValidateParametersAgainstConfig(config, exec, meta)
+	if err == nil {
+		t.Fatal("expected failure: spoofed sender in params must not satisfy $meta constraint")
+	}
+}
+
+func TestValidateConfigParameters_AllowsMetaNamespace(t *testing.T) {
+	t.Parallel()
+	params := json.RawMessage(`{"folder":"*","$meta":{"sender":{"$pattern":"*@example.com"}}}`)
+	if err := ValidateConfigParameters(params); err != nil {
+		t.Fatalf("expected valid $meta config, got: %v", err)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extend the shared constraint engine (`db/action_config_validate.go`) with a reserved `$meta` namespace that matches against server-resolved metadata instead of agent-supplied parameters.
- Add `ConstraintMetadataResolver` and wire metadata resolution at the shared evaluation point used by action configurations, standing approvals, and bulk matching (`api/constraint_validate.go`).
- Implement Proton Mail `archive_email` metadata resolution (verified sender from IMAP envelopes, including batch/thread expansion) in `connectors/protonmail/resolve_constraint_metadata.go`.

Standing approvals and action configs can now express constraints like:

```json
{
  "message_id": "*",
  "folder": "*",
  "$meta": {
    "sender": {"$pattern": "alice@example.com"}
  }
}
```

Matching uses the real From header fetched from the connector. A spoofed `sender` value in the request payload cannot satisfy the constraint.

Closes #1336

## Test plan

### Claude Code
- [x] `gofmt` syntax check on all changed Go files
- [x] Unit tests added for `$meta` constraint matching in `db/action_config_validate_test.go`
- [x] Unit tests added for Proton Mail metadata resolution in `connectors/protonmail/resolve_constraint_metadata_test.go`
- [x] API integration tests for standing approval auto-approve and action config enforcement in `api/constraint_validate_test.go`
- [ ] Full `make test-backend` — not run locally (sandbox Go module graph limitation); CI will verify

### OpenClaw
- [ ] Create a standing approval for `protonmail.archive_email` with `$meta.sender` pattern and confirm auto-approve fires only for matching real senders against a live Proton Bridge instance
- [ ] Confirm non-matching sender falls through to manual approval
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd696583-fd75-428a-95c4-4bf44b3285b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd696583-fd75-428a-95c4-4bf44b3285b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

