### PR TITLE
Add Tresorit connector with shared S3 SigV4 signing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ These connectors are wired up but have not yet been end-to-end verified. If you 
 | Square | 🔴 Untested |
 | Stripe | 🔴 Untested |
 | Supabase | 🔴 Untested |
+| Tresorit | 🔴 Untested |
 | Trello | 🔴 Untested |
 | Twilio | 🔴 Untested |
 | Vercel | 🔴 Untested |

--- a/connectors/all/all.go
+++ b/connectors/all/all.go
@@ -60,6 +60,7 @@ import (
 	_ "github.com/supersuit-tech/permission-slip/connectors/stripe"
 	_ "github.com/supersuit-tech/permission-slip/connectors/supabase"
 	_ "github.com/supersuit-tech/permission-slip/connectors/trello"
+	_ "github.com/supersuit-tech/permission-slip/connectors/tresorit"
 	_ "github.com/supersuit-tech/permission-slip/connectors/twilio"
 	_ "github.com/supersuit-tech/permission-slip/connectors/vercel"
 	_ "github.com/supersuit-tech/permission-slip/connectors/walmart"

--- a/connectors/aws/aws.go
+++ b/connectors/aws/aws.go
@@ -7,20 +7,17 @@ package aws
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
 	_ "embed"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/connectors/s3sigv4"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -440,113 +437,17 @@ func (c *AWSConnector) do(ctx context.Context, creds connectors.Credentials, met
 func (c *AWSConnector) signV4(req *http.Request, creds connectors.Credentials, payload []byte) error {
 	accessKey, _ := creds.Get("access_key_id")
 	secretKey, _ := creds.Get("secret_access_key")
+	sessionToken, _ := creds.Get("session_token")
 
-	now := time.Now().UTC()
-	datestamp := now.Format("20060102")
-	amzdate := now.Format("20060102T150405Z")
-
-	// Extract service and region from the host.
-	// Host format: <service>.<region>.amazonaws.com
-	service, region := parseServiceHost(req.Host)
-
-	req.Header.Set("X-Amz-Date", amzdate)
-	req.Header.Set("Host", req.Host)
-
-	// Add security token header if session token is present.
-	sessionToken, hasToken := creds.Get("session_token")
-	if hasToken && sessionToken != "" {
-		req.Header.Set("X-Amz-Security-Token", sessionToken)
-	}
-
-	// Compute payload hash and set X-Amz-Content-Sha256 header.
-	// S3 requires this header for Signature V4 Authorization-header requests.
-	payloadHash := sha256Hex(payload)
-	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
-	canonicalHeaders, signedHeaders := buildCanonicalHeaders(req)
-	canonicalQuerystring := ""
-	if req.URL.RawQuery != "" {
-		canonicalQuerystring = req.URL.RawQuery
-	}
-	canonicalRequest := strings.Join([]string{
-		req.Method,
-		req.URL.Path,
-		canonicalQuerystring,
-		canonicalHeaders,
-		signedHeaders,
-		payloadHash,
-	}, "\n")
-
-	// Create string to sign.
-	credentialScope := datestamp + "/" + region + "/" + service + "/aws4_request"
-	stringToSign := strings.Join([]string{
-		"AWS4-HMAC-SHA256",
-		amzdate,
-		credentialScope,
-		sha256Hex([]byte(canonicalRequest)),
-	}, "\n")
-
-	// Calculate signature.
-	signingKey := deriveSigningKey(secretKey, datestamp, region, service)
-	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
-
-	// Set authorization header.
-	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		accessKey, credentialScope, signedHeaders, signature)
-	req.Header.Set("Authorization", authHeader)
-
-	return nil
-}
-
-// parseServiceHost extracts service and region from an AWS hostname.
-// For standard hosts like "ec2.us-east-1.amazonaws.com", returns ("ec2", "us-east-1").
-// For S3 path-style "s3.us-east-1.amazonaws.com", returns ("s3", "us-east-1").
-// For global endpoints like "monitoring.us-east-1.amazonaws.com", returns ("monitoring", "us-east-1").
-func parseServiceHost(host string) (service, region string) {
-	host = strings.TrimSuffix(host, ".amazonaws.com")
-	parts := strings.SplitN(host, ".", 2)
-	if len(parts) == 2 {
-		return parts[0], parts[1]
-	}
-	return host, "us-east-1"
-}
-
-func sha256Hex(data []byte) string {
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:])
-}
-
-func hmacSHA256(key, data []byte) []byte {
-	h := hmac.New(sha256.New, key)
-	h.Write(data)
-	return h.Sum(nil)
-}
-
-func deriveSigningKey(secret, datestamp, region, service string) []byte {
-	kDate := hmacSHA256([]byte("AWS4"+secret), []byte(datestamp))
-	kRegion := hmacSHA256(kDate, []byte(region))
-	kService := hmacSHA256(kRegion, []byte(service))
-	return hmacSHA256(kService, []byte("aws4_request"))
+	service, region := s3sigv4.ParseServiceHost(req.Host)
+	return s3sigv4.SignRequest(req, s3sigv4.Credentials{
+		AccessKeyID:     accessKey,
+		SecretAccessKey: secretKey,
+		SessionToken:    sessionToken,
+	}, payload, s3sigv4.SigningConfig{
+		Region:  region,
+		Service: service,
+	})
 }
 
 func ptrBool(b bool) *bool { return &b }
-
-func buildCanonicalHeaders(req *http.Request) (canonicalHeaders, signedHeaders string) {
-	headers := make(map[string]string)
-	var names []string
-	for name := range req.Header {
-		lower := strings.ToLower(name)
-		if lower == "host" || lower == "content-type" || strings.HasPrefix(lower, "x-amz-") {
-			headers[lower] = strings.TrimSpace(req.Header.Get(name))
-			names = append(names, lower)
-		}
-	}
-	sort.Strings(names)
-
-	var canonical, signed []string
-	for _, name := range names {
-		canonical = append(canonical, name+":"+headers[name])
-		signed = append(signed, name)
-	}
-
-	return strings.Join(canonical, "\n") + "\n", strings.Join(signed, ";")
-}

--- a/connectors/aws/aws_test.go
+++ b/connectors/aws/aws_test.go
@@ -184,31 +184,3 @@ func TestAWSConnector_ImplementsInterface(t *testing.T) {
 	var _ connectors.Connector = (*AWSConnector)(nil)
 	var _ connectors.ManifestProvider = (*AWSConnector)(nil)
 }
-
-func TestParseServiceHost(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		host        string
-		wantService string
-		wantRegion  string
-	}{
-		{"ec2.us-east-1.amazonaws.com", "ec2", "us-east-1"},
-		{"s3.us-west-2.amazonaws.com", "s3", "us-west-2"},
-		{"monitoring.eu-west-1.amazonaws.com", "monitoring", "eu-west-1"},
-		{"rds.ap-southeast-1.amazonaws.com", "rds", "ap-southeast-1"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			t.Parallel()
-			service, region := parseServiceHost(tt.host)
-			if service != tt.wantService {
-				t.Errorf("service = %q, want %q", service, tt.wantService)
-			}
-			if region != tt.wantRegion {
-				t.Errorf("region = %q, want %q", region, tt.wantRegion)
-			}
-		})
-	}
-}

--- a/connectors/aws/create_presigned_url.go
+++ b/connectors/aws/create_presigned_url.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/connectors/s3sigv4"
 )
 
 // createPresignedURLAction implements connectors.Action for aws.create_presigned_url.
@@ -69,7 +70,7 @@ func (a *createPresignedURLAction) Execute(_ context.Context, req connectors.Act
 	host := s3Host(params.Region)
 	// URI-encode each path segment per SigV4 rules, preserving "/" separators.
 	// S3 object keys can contain spaces, +, ?, # and other reserved characters.
-	objectPath := "/" + uriEncodePath(params.Bucket+"/"+params.Key)
+	objectPath := "/" + s3sigv4.URIEncodePath(params.Bucket+"/"+params.Key)
 	credentialScope := datestamp + "/" + params.Region + "/s3/aws4_request"
 
 	// Build canonical query string for presigned URL.
@@ -99,12 +100,12 @@ func (a *createPresignedURLAction) Execute(_ context.Context, req connectors.Act
 		"AWS4-HMAC-SHA256",
 		amzdate,
 		credentialScope,
-		sha256Hex([]byte(canonicalRequest)),
+		s3sigv4.SHA256Hex([]byte(canonicalRequest)),
 	}, "\n")
 
 	// Derive signing key using the shared helper from aws.go.
-	signingKey := deriveSigningKey(secretKey, datestamp, params.Region, "s3")
-	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+	signingKey := s3sigv4.DeriveSigningKey(secretKey, datestamp, params.Region, "s3")
+	signature := hex.EncodeToString(s3sigv4.HMACSHA256(signingKey, []byte(stringToSign)))
 
 	presignedURL := fmt.Sprintf("https://%s%s?%s&X-Amz-Signature=%s",
 		host, objectPath, canonicalQuerystring, signature)

--- a/connectors/aws/validation.go
+++ b/connectors/aws/validation.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"regexp"
 	"strings"
 	"time"

--- a/connectors/aws/validation.go
+++ b/connectors/aws/validation.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/connectors/s3sigv4"
 )
 
 // validBucketName matches S3 bucket naming rules: 3-63 lowercase alphanumeric
@@ -65,15 +66,9 @@ func validateInstanceID(id string) error {
 	return nil
 }
 
-// uriEncodePath encodes a path string per AWS SigV4 rules: each segment is
-// percent-encoded but "/" separators are preserved. This is necessary because
-// S3 object keys can contain spaces, +, ?, # and other reserved characters.
+// uriEncodePath encodes a path string per AWS SigV4 rules.
 func uriEncodePath(path string) string {
-	segments := strings.Split(path, "/")
-	for i, seg := range segments {
-		segments[i] = url.PathEscape(seg)
-	}
-	return strings.Join(segments, "/")
+	return s3sigv4.URIEncodePath(path)
 }
 
 // validateBucketName checks that an S3 bucket name follows AWS naming rules:

--- a/connectors/s3sigv4/sign.go
+++ b/connectors/s3sigv4/sign.go
@@ -1,0 +1,145 @@
+// Package s3sigv4 implements AWS Signature Version 4 request signing.
+// Shared by the aws and tresorit connectors for S3-compatible APIs.
+package s3sigv4
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Credentials holds the access key material for SigV4 signing.
+type Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string // optional
+}
+
+// SigningConfig identifies the AWS region and service for the signature.
+type SigningConfig struct {
+	Region  string
+	Service string
+}
+
+// SignRequest signs req with AWS Signature Version 4 using the given
+// credentials, payload bytes, and signing configuration.
+func SignRequest(req *http.Request, creds Credentials, payload []byte, cfg SigningConfig) error {
+	return signRequestAt(req, creds, payload, cfg, time.Now().UTC())
+}
+
+func signRequestAt(req *http.Request, creds Credentials, payload []byte, cfg SigningConfig, now time.Time) error {
+	datestamp := now.Format("20060102")
+	amzdate := now.Format("20060102T150405Z")
+
+	req.Header.Set("X-Amz-Date", amzdate)
+	req.Header.Set("Host", req.Host)
+
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+
+	payloadHash := SHA256Hex(payload)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	canonicalHeaders, signedHeaders := BuildCanonicalHeaders(req)
+	canonicalQuerystring := ""
+	if req.URL.RawQuery != "" {
+		canonicalQuerystring = req.URL.RawQuery
+	}
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		req.URL.Path,
+		canonicalQuerystring,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	credentialScope := datestamp + "/" + cfg.Region + "/" + cfg.Service + "/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzdate,
+		credentialScope,
+		SHA256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := DeriveSigningKey(creds.SecretAccessKey, datestamp, cfg.Region, cfg.Service)
+	signature := hex.EncodeToString(HMACSHA256(signingKey, []byte(stringToSign)))
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		creds.AccessKeyID, credentialScope, signedHeaders, signature)
+	req.Header.Set("Authorization", authHeader)
+
+	return nil
+}
+
+// ParseServiceHost extracts service and region from an AWS hostname.
+// For standard hosts like "ec2.us-east-1.amazonaws.com", returns ("ec2", "us-east-1").
+func ParseServiceHost(host string) (service, region string) {
+	host = strings.TrimSuffix(host, ".amazonaws.com")
+	parts := strings.SplitN(host, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return host, "us-east-1"
+}
+
+// SHA256Hex returns the lowercase hex-encoded SHA-256 digest of data.
+func SHA256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// HMACSHA256 returns the HMAC-SHA256 of data using key.
+func HMACSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// DeriveSigningKey derives the SigV4 signing key from the secret key.
+func DeriveSigningKey(secret, datestamp, region, service string) []byte {
+	kDate := HMACSHA256([]byte("AWS4"+secret), []byte(datestamp))
+	kRegion := HMACSHA256(kDate, []byte(region))
+	kService := HMACSHA256(kRegion, []byte(service))
+	return HMACSHA256(kService, []byte("aws4_request"))
+}
+
+// BuildCanonicalHeaders builds the canonical headers and signed headers
+// strings for SigV4.
+func BuildCanonicalHeaders(req *http.Request) (canonicalHeaders, signedHeaders string) {
+	headers := make(map[string]string)
+	var names []string
+	for name := range req.Header {
+		lower := strings.ToLower(name)
+		if lower == "host" || lower == "content-type" || strings.HasPrefix(lower, "x-amz-") {
+			headers[lower] = strings.TrimSpace(req.Header.Get(name))
+			names = append(names, lower)
+		}
+	}
+	sort.Strings(names)
+
+	var canonical, signed []string
+	for _, name := range names {
+		canonical = append(canonical, name+":"+headers[name])
+		signed = append(signed, name)
+	}
+
+	return strings.Join(canonical, "\n") + "\n", strings.Join(signed, ";")
+}
+
+// URIEncodePath encodes a path string per AWS SigV4 rules: each segment is
+// percent-encoded but "/" separators are preserved.
+func URIEncodePath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return strings.Join(segments, "/")
+}

--- a/connectors/s3sigv4/sign_test.go
+++ b/connectors/s3sigv4/sign_test.go
@@ -1,0 +1,172 @@
+package s3sigv4
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseServiceHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		host        string
+		wantService string
+		wantRegion  string
+	}{
+		{"ec2.us-east-1.amazonaws.com", "ec2", "us-east-1"},
+		{"s3.us-west-2.amazonaws.com", "s3", "us-west-2"},
+		{"monitoring.eu-west-1.amazonaws.com", "monitoring", "eu-west-1"},
+		{"rds.ap-southeast-1.amazonaws.com", "rds", "ap-southeast-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			t.Parallel()
+			service, region := ParseServiceHost(tt.host)
+			if service != tt.wantService {
+				t.Errorf("service = %q, want %q", service, tt.wantService)
+			}
+			if region != tt.wantRegion {
+				t.Errorf("region = %q, want %q", region, tt.wantRegion)
+			}
+		})
+	}
+}
+
+func TestSHA256Hex(t *testing.T) {
+	t.Parallel()
+	got := SHA256Hex([]byte(""))
+	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	if got != want {
+		t.Errorf("SHA256Hex(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestDeriveSigningKeyDeterministic(t *testing.T) {
+	t.Parallel()
+	k1 := DeriveSigningKey("secret", "20240101", "us-east-1", "s3")
+	k2 := DeriveSigningKey("secret", "20240101", "us-east-1", "s3")
+	if len(k1) != 32 {
+		t.Fatalf("signing key length = %d, want 32", len(k1))
+	}
+	for i := range k1 {
+		if k1[i] != k2[i] {
+			t.Fatal("DeriveSigningKey is not deterministic")
+		}
+	}
+}
+
+func TestBuildCanonicalHeaders(t *testing.T) {
+	t.Parallel()
+	req, err := http.NewRequest(http.MethodGet, "https://s3.us-east-1.amazonaws.com/bucket", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Host", "s3.us-east-1.amazonaws.com")
+	req.Header.Set("X-Amz-Date", "20240101T000000Z")
+	req.Header.Set("X-Amz-Content-Sha256", "abc")
+
+	canonical, signed := BuildCanonicalHeaders(req)
+	if signed != "host;x-amz-content-sha256;x-amz-date" {
+		t.Errorf("signed headers = %q", signed)
+	}
+	if !stringsContains(canonical, "host:s3.us-east-1.amazonaws.com") {
+		t.Errorf("canonical headers missing host: %q", canonical)
+	}
+}
+
+func stringsContains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestSignRequestAWSStyle(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, "https://s3.us-east-1.amazonaws.com/my-bucket?list-type=2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "s3.us-east-1.amazonaws.com"
+
+	creds := Credentials{
+		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+		SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+	}
+	cfg := SigningConfig{Region: "us-east-1", Service: "s3"}
+	fixed := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := signRequestAt(req, creds, nil, cfg, fixed); err != nil {
+		t.Fatalf("signRequestAt() error: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if auth == "" {
+		t.Fatal("Authorization header is empty")
+	}
+	if !stringsContains(auth, "Credential=AKIAIOSFODNN7EXAMPLE/20240101/us-east-1/s3/aws4_request") {
+		t.Errorf("unexpected Authorization: %s", auth)
+	}
+	if req.Header.Get("X-Amz-Date") != "20240101T000000Z" {
+		t.Errorf("X-Amz-Date = %q", req.Header.Get("X-Amz-Date"))
+	}
+}
+
+func TestSignRequestCustomHTTPEndpoint(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodGet, "http://127.0.0.1:3000/my-tresor?list-type=2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Host = "127.0.0.1:3000"
+
+	creds := Credentials{
+		AccessKeyID:     "client-id",
+		SecretAccessKey: "client-secret",
+	}
+	cfg := SigningConfig{Region: "us-east-1", Service: "s3"}
+	fixed := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	if err := signRequestAt(req, creds, nil, cfg, fixed); err != nil {
+		t.Fatalf("signRequestAt() error: %v", err)
+	}
+
+	auth := req.Header.Get("Authorization")
+	if auth == "" {
+		t.Fatal("Authorization header is empty")
+	}
+	if !stringsContains(auth, "Credential=client-id/20240601/us-east-1/s3/aws4_request") {
+		t.Errorf("unexpected Authorization: %s", auth)
+	}
+	if req.URL.Scheme != "http" {
+		t.Errorf("scheme = %q, want http", req.URL.Scheme)
+	}
+}
+
+func TestURIEncodePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in, want string
+	}{
+		{"bucket/key", "bucket/key"},
+		{"bucket/my file.txt", "bucket/my%20file.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			if got := URIEncodePath(tt.in); got != tt.want {
+				t.Errorf("URIEncodePath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/connectors/testsetup_test.go
+++ b/connectors/testsetup_test.go
@@ -34,10 +34,10 @@ func TestBuiltInProvidersAreRegistered(t *testing.T) {
 // is missing, the count will drop and this test will fail.
 func TestBuiltInConnectorsAreRegistered(t *testing.T) {
 	got := connectors.BuiltInConnectors()
-	// There are 56 active built-in connectors; kroger is disabled via
+	// There are 57 active built-in connectors; kroger is disabled via
 	// connectors/kroger/disabled (embedded in the binary via //go:embed).
 	// Update this number when adding, removing, or re-enabling connectors.
-	const expected = 57
+	const expected = 58
 	if len(got) != expected {
 		t.Fatalf("expected %d built-in connectors, got %d — did you forget to add register.go or a blank import in connectors/all?", expected, len(got))
 	}

--- a/connectors/tresorit/README.md
+++ b/connectors/tresorit/README.md
@@ -40,7 +40,7 @@ Saving credentials runs a live `ListBuckets` against the gateway. If the contain
 | Action | Risk | Description |
 |--------|------|-------------|
 | `tresorit.list_files` | low | List files/folders in a Tresor (`tresor` = bucket name), optional `prefix` |
-| `tresorit.download_file` | low | Download a file; content returned as base64 |
+| `tresorit.download_file` | medium | Download a file; content returned as base64 |
 | `tresorit.upload_file` | medium | Upload a file from base64 `content` |
 | `tresorit.create_folder` | medium | Create a folder (S3 prefix marker) |
 | `tresorit.delete_file` | high | Permanently delete a file |

--- a/connectors/tresorit/README.md
+++ b/connectors/tresorit/README.md
@@ -1,0 +1,66 @@
+# Tresorit connector
+
+Permission Slip integrates with [Tresorit's S3-compatible API](https://support.tresorit.com/hc/en-us/articles/33971802915858-Tresorit-API) through a **local gateway** that runs in your environment (Docker). End-to-end encryption happens inside that gateway — Permission Slip is a SigV4-signed S3 client against your loopback endpoint.
+
+This mirrors the [Proton Mail connector](../protonmail/) pattern: local proxy, custom credentials, and a live reachability check when credentials are saved.
+
+## Prerequisites
+
+1. **Tresorit API access** — currently Early Adopter / waitlist-gated. Email support@tresorit.com to request access.
+2. **Docker** — run the gateway from [tresorit/s3-api](https://github.com/tresorit/s3-api).
+3. **Permission Slip on the same host** — the gateway listens on loopback (default `http://127.0.0.1:3000`).
+
+## Gateway setup
+
+1. Clone and configure the Tresorit S3 API deployment per the upstream README.
+2. Log in so `credentials.json` is generated with `client_id` and `client_secret`.
+3. Start the gateway (`docker compose up` or equivalent).
+4. Confirm it responds:
+
+```bash
+AWS_ACCESS_KEY_ID="<client_id>" \
+AWS_SECRET_ACCESS_KEY="<client_secret>" \
+aws s3api list-buckets --endpoint-url http://127.0.0.1:3000 --region us-east-1
+```
+
+Tresorit requires **path-style** addressing and a fixed region of `us-east-1`.
+
+## Credentials
+
+| Field | Description |
+|-------|-------------|
+| `access_key` | `client_id` from the gateway's `credentials.json` |
+| `secret_key` | `client_secret` from `credentials.json` (stored as a secret) |
+| `endpoint_url` | Gateway URL, e.g. `http://127.0.0.1:3000` |
+
+Saving credentials runs a live `ListBuckets` against the gateway. If the container is not running or the URL is wrong, validation fails with an actionable error.
+
+## Actions
+
+| Action | Risk | Description |
+|--------|------|-------------|
+| `tresorit.list_files` | low | List files/folders in a Tresor (`tresor` = bucket name), optional `prefix` |
+| `tresorit.download_file` | low | Download a file; content returned as base64 |
+| `tresorit.upload_file` | medium | Upload a file from base64 `content` |
+| `tresorit.create_folder` | medium | Create a folder (S3 prefix marker) |
+| `tresorit.delete_file` | high | Permanently delete a file |
+
+### Parameters
+
+- **tresor** — Tresor name as exposed by the gateway (S3 bucket).
+- **key** / **path** — Object key within the Tresor. Folders use a trailing `/`.
+- **content** — Base64-encoded bytes for uploads (same convention as Dropbox).
+
+## Architecture notes
+
+- Signing reuses the shared `connectors/s3sigv4` helper (also used by the AWS connector for SigV4).
+- No OAuth — custom credentials only.
+- HTTP is supported for loopback gateways; terminate TLS locally if required.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Connection refused on credential save | Gateway not running or wrong `endpoint_url` |
+| 403 SignatureDoesNotMatch | Wrong `access_key` / `secret_key` |
+| 404 on list/download | Wrong Tresor name or file path |

--- a/connectors/tresorit/create_folder.go
+++ b/connectors/tresorit/create_folder.go
@@ -1,0 +1,46 @@
+package tresorit
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type createFolderAction struct {
+	conn *TresoritConnector
+}
+
+type createFolderParams struct {
+	Tresor string `json:"tresor"`
+	Path   string `json:"path"`
+}
+
+func (p *createFolderParams) validate() error {
+	if err := validateTresorName(p.Tresor); err != nil {
+		return err
+	}
+	if err := validateObjectKey(p.Path, "path"); err != nil {
+		return err
+	}
+	if !stringsHasSuffix(p.Path, "/") {
+		p.Path += "/"
+	}
+	return nil
+}
+
+func (a *createFolderAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[createFolderParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = a.conn.do(ctx, req.Credentials, "PUT", objectPath(params.Tresor, params.Path), "", []byte{}, "application/octet-stream")
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"tresor": params.Tresor,
+		"path":   params.Path,
+	})
+}

--- a/connectors/tresorit/create_folder_test.go
+++ b/connectors/tresorit/create_folder_test.go
@@ -1,0 +1,76 @@
+package tresorit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestCreateFolder_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/my-tresor/projects/new/" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	conn := newTestConnector(&http.Client{
+		Transport: &testTransport{inner: srv.Client().Transport, testURL: srv.URL},
+	})
+	action := &createFolderAction{conn: conn}
+
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.create_folder",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","path":"projects/new"}`),
+		Credentials: validCredsWithEndpoint(srv.URL),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+}
+
+func TestDeleteFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/my-tresor/docs/old.txt" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	conn := newTestConnector(&http.Client{
+		Transport: &testTransport{inner: srv.Client().Transport, testURL: srv.URL},
+	})
+	action := &deleteFileAction{conn: conn}
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.delete_file",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","key":"docs/old.txt"}`),
+		Credentials: validCredsWithEndpoint(srv.URL),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if data["deleted"] != true {
+		t.Errorf("deleted = %v", data["deleted"])
+	}
+}

--- a/connectors/tresorit/delete_file.go
+++ b/connectors/tresorit/delete_file.go
@@ -1,0 +1,41 @@
+package tresorit
+
+import (
+	"context"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type deleteFileAction struct {
+	conn *TresoritConnector
+}
+
+type deleteFileParams struct {
+	Tresor string `json:"tresor"`
+	Key    string `json:"key"`
+}
+
+func (p *deleteFileParams) validate() error {
+	if err := validateTresorName(p.Tresor); err != nil {
+		return err
+	}
+	return validateObjectKey(p.Key, "key")
+}
+
+func (a *deleteFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[deleteFileParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = a.conn.do(ctx, req.Credentials, "DELETE", objectPath(params.Tresor, params.Key), "", nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"tresor":  params.Tresor,
+		"key":     params.Key,
+		"deleted": true,
+	})
+}

--- a/connectors/tresorit/download_file.go
+++ b/connectors/tresorit/download_file.go
@@ -1,0 +1,44 @@
+package tresorit
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type downloadFileAction struct {
+	conn *TresoritConnector
+}
+
+type downloadFileParams struct {
+	Tresor string `json:"tresor"`
+	Key    string `json:"key"`
+}
+
+func (p *downloadFileParams) validate() error {
+	if err := validateTresorName(p.Tresor); err != nil {
+		return err
+	}
+	return validateObjectKey(p.Key, "key")
+}
+
+func (a *downloadFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[downloadFileParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := a.conn.do(ctx, req.Credentials, "GET", objectPath(params.Tresor, params.Key), "", nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"tresor":   params.Tresor,
+		"key":      params.Key,
+		"content":  base64.StdEncoding.EncodeToString(respBody),
+		"size":     len(respBody),
+		"encoding": "base64",
+	})
+}

--- a/connectors/tresorit/download_file_test.go
+++ b/connectors/tresorit/download_file_test.go
@@ -1,0 +1,63 @@
+package tresorit
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestDownloadFile_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/my-tresor/docs/report.pdf" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello tresorit"))
+	}))
+	defer srv.Close()
+
+	conn := newTestConnector(&http.Client{
+		Transport: &testTransport{inner: srv.Client().Transport, testURL: srv.URL},
+	})
+	action := &downloadFileAction{conn: conn}
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.download_file",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","key":"docs/report.pdf"}`),
+		Credentials: validCredsWithEndpoint(srv.URL),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, _ := base64.StdEncoding.DecodeString(data["content"].(string))
+	if string(got) != "hello tresorit" {
+		t.Errorf("content = %q", string(got))
+	}
+}
+
+func TestDownloadFile_MissingKey(t *testing.T) {
+	t.Parallel()
+	action := &downloadFileAction{conn: New()}
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.download_file",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}

--- a/connectors/tresorit/health_check.go
+++ b/connectors/tresorit/health_check.go
@@ -1,0 +1,41 @@
+package tresorit
+
+import (
+	"context"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+// testListBuckets may be replaced in tests to avoid a running gateway.
+var testListBuckets = func(ctx context.Context, conn *TresoritConnector, creds connectors.Credentials, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := conn.do(ctx, creds, "GET", "/", "", nil, "")
+	return err
+}
+
+// TestGatewayConnection verifies reachability of the local Tresorit S3 gateway
+// by issuing a ListBuckets request.
+func TestGatewayConnection(ctx context.Context, conn *TresoritConnector, creds connectors.Credentials, timeout time.Duration) error {
+	if err := validateCredentialShape(creds); err != nil {
+		return err
+	}
+	if err := testListBuckets(ctx, conn, creds, timeout); err != nil {
+		return mapGatewayError(err)
+	}
+	return nil
+}
+
+func mapGatewayError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if connectors.IsValidationError(err) || connectors.IsAuthError(err) ||
+		connectors.IsExternalError(err) || connectors.IsTimeoutError(err) {
+		return err
+	}
+	return &connectors.ExternalError{
+		Message: "Tresorit gateway unreachable — confirm the Docker container is running and endpoint_url points to it (default http://127.0.0.1:3000)",
+	}
+}

--- a/connectors/tresorit/health_check_test.go
+++ b/connectors/tresorit/health_check_test.go
@@ -1,0 +1,37 @@
+package tresorit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestTestGatewayConnection_success(t *testing.T) {
+	old := testListBuckets
+	testListBuckets = func(_ context.Context, _ *TresoritConnector, _ connectors.Credentials, _ time.Duration) error {
+		return nil
+	}
+	t.Cleanup(func() { testListBuckets = old })
+
+	if err := TestGatewayConnection(t.Context(), New(), validCreds(), time.Second); err != nil {
+		t.Fatalf("TestGatewayConnection() error = %v, want nil", err)
+	}
+}
+
+func TestTestGatewayConnection_authFailure(t *testing.T) {
+	old := testListBuckets
+	testListBuckets = func(_ context.Context, _ *TresoritConnector, _ connectors.Credentials, _ time.Duration) error {
+		return &connectors.AuthError{Message: "SignatureDoesNotMatch"}
+	}
+	t.Cleanup(func() { testListBuckets = old })
+
+	err := TestGatewayConnection(t.Context(), New(), validCreds(), time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !connectors.IsAuthError(err) {
+		t.Fatalf("expected AuthError, got %T: %v", err, err)
+	}
+}

--- a/connectors/tresorit/helpers_test.go
+++ b/connectors/tresorit/helpers_test.go
@@ -1,0 +1,44 @@
+package tresorit
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func validCreds() connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		credKeyAccessKey:   "test-access-key",
+		credKeySecretKey:   "test-secret-key",
+		credKeyEndpointURL: "http://127.0.0.1:3000",
+	})
+}
+
+func validCredsWithEndpoint(endpoint string) connectors.Credentials {
+	return connectors.NewCredentials(map[string]string{
+		credKeyAccessKey:   "test-access-key",
+		credKeySecretKey:   "test-secret-key",
+		credKeyEndpointURL: endpoint,
+	})
+}
+
+type testTransport struct {
+	inner   http.RoundTripper
+	testURL string
+}
+
+func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	testReq := req.Clone(req.Context())
+	parsed, err := url.Parse(t.testURL)
+	if err != nil {
+		return nil, err
+	}
+	testReq.URL.Scheme = parsed.Scheme
+	testReq.URL.Host = parsed.Host
+	return t.inner.RoundTrip(testReq)
+}
+
+func newTestConnector(client *http.Client) *TresoritConnector {
+	return &TresoritConnector{client: client}
+}

--- a/connectors/tresorit/list_files.go
+++ b/connectors/tresorit/list_files.go
@@ -1,0 +1,106 @@
+package tresorit
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type listFilesAction struct {
+	conn *TresoritConnector
+}
+
+type listFilesParams struct {
+	Tresor  string `json:"tresor"`
+	Prefix  string `json:"prefix"`
+	MaxKeys int    `json:"max_keys"`
+}
+
+func (p *listFilesParams) validate() error {
+	if err := validateTresorName(p.Tresor); err != nil {
+		return err
+	}
+	if p.MaxKeys == 0 {
+		p.MaxKeys = 1000
+	}
+	if p.MaxKeys < 1 || p.MaxKeys > 1000 {
+		return &connectors.ValidationError{Message: "max_keys must be between 1 and 1000"}
+	}
+	return nil
+}
+
+type listBucketResult struct {
+	XMLName     xml.Name `xml:"ListBucketResult"`
+	Name        string   `xml:"Name"`
+	Prefix      string   `xml:"Prefix"`
+	IsTruncated bool     `xml:"IsTruncated"`
+	Contents    []struct {
+		Key          string `xml:"Key"`
+		LastModified string `xml:"LastModified"`
+		Size         int64  `xml:"Size"`
+		ETag         string `xml:"ETag"`
+	} `xml:"Contents"`
+	CommonPrefixes []struct {
+		Prefix string `xml:"Prefix"`
+	} `xml:"CommonPrefixes"`
+}
+
+type fileInfo struct {
+	Key          string `json:"key"`
+	LastModified string `json:"last_modified,omitempty"`
+	Size         int64  `json:"size"`
+	IsFolder     bool   `json:"is_folder"`
+}
+
+func (a *listFilesAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[listFilesParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	qp := url.Values{}
+	qp.Set("list-type", "2")
+	qp.Set("max-keys", strconv.Itoa(params.MaxKeys))
+	if params.Prefix != "" {
+		qp.Set("prefix", params.Prefix)
+	}
+	qp.Set("delimiter", "/")
+
+	respBody, err := a.conn.do(ctx, req.Credentials, "GET", objectPath(params.Tresor, ""), qp.Encode(), nil, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var xmlResp listBucketResult
+	if err := xml.Unmarshal(respBody, &xmlResp); err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("parsing Tresorit list response: %v", err)}
+	}
+
+	files := make([]fileInfo, 0, len(xmlResp.Contents)+len(xmlResp.CommonPrefixes))
+	for _, prefix := range xmlResp.CommonPrefixes {
+		files = append(files, fileInfo{Key: prefix.Prefix, IsFolder: true})
+	}
+	for _, obj := range xmlResp.Contents {
+		if obj.Key == params.Prefix && obj.Size == 0 && stringsHasSuffix(obj.Key, "/") {
+			continue
+		}
+		files = append(files, fileInfo{
+			Key:          obj.Key,
+			LastModified: obj.LastModified,
+			Size:         obj.Size,
+			IsFolder:     stringsHasSuffix(obj.Key, "/"),
+		})
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"tresor":       params.Tresor,
+		"prefix":       params.Prefix,
+		"files":        files,
+		"count":        len(files),
+		"is_truncated": xmlResp.IsTruncated,
+	})
+}

--- a/connectors/tresorit/list_files_test.go
+++ b/connectors/tresorit/list_files_test.go
@@ -1,0 +1,74 @@
+package tresorit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestListFiles_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/my-tresor" {
+			t.Errorf("path = %s, want /my-tresor", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>my-tresor</Name>
+  <Prefix>docs/</Prefix>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>docs/report.pdf</Key>
+    <LastModified>2024-01-01T00:00:00Z</LastModified>
+    <Size>1024</Size>
+  </Contents>
+  <CommonPrefixes>
+    <Prefix>docs/archive/</Prefix>
+  </CommonPrefixes>
+</ListBucketResult>`))
+	}))
+	defer srv.Close()
+
+	conn := newTestConnector(&http.Client{
+		Transport: &testTransport{inner: srv.Client().Transport, testURL: srv.URL},
+	})
+	action := &listFilesAction{conn: conn}
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.list_files",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","prefix":"docs/"}`),
+		Credentials: validCredsWithEndpoint(srv.URL),
+	})
+	if err != nil {
+		t.Fatalf("Execute() unexpected error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshaling result: %v", err)
+	}
+	if data["count"] != float64(2) {
+		t.Errorf("count = %v, want 2", data["count"])
+	}
+}
+
+func TestListFiles_MissingTresor(t *testing.T) {
+	t.Parallel()
+	action := &listFilesAction{conn: New()}
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.list_files",
+		Parameters:  json.RawMessage(`{}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}

--- a/connectors/tresorit/logo.svg
+++ b/connectors/tresorit/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="#00A94F">
+  <rect x="4" y="8" width="32" height="26" rx="3" fill="#00A94F"/>
+  <path d="M20 8 L34 8 L34 14 L20 20 Z" fill="#008C41"/>
+  <rect x="10" y="16" width="20" height="3" rx="1" fill="#ffffff" opacity="0.9"/>
+  <rect x="10" y="22" width="14" height="3" rx="1" fill="#ffffff" opacity="0.7"/>
+</svg>

--- a/connectors/tresorit/manifest.go
+++ b/connectors/tresorit/manifest.go
@@ -1,0 +1,190 @@
+package tresorit
+
+import (
+	_ "embed"
+	"encoding/json"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+//go:embed logo.svg
+var logoSVG string
+
+func (c *TresoritConnector) Manifest() *connectors.ConnectorManifest {
+	return &connectors.ConnectorManifest{
+		ID:          "tresorit",
+		Name:        "Tresorit",
+		Description: "Read and write files in Tresorit via the local S3-compatible API gateway. The gateway Docker container must be running on the same host as Permission Slip.",
+		Status:      "early_preview",
+		LogoSVG:     logoSVG,
+		Actions: []connectors.ManifestAction{
+			{
+				ActionType:  "tresorit.list_files",
+				Name:        "List Files",
+				Description: "List files and folders in a Tresor, optionally filtered by prefix",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["tresor"],
+					"properties": {
+						"tresor": {
+							"type": "string",
+							"description": "Tresor name (S3 bucket name in the gateway)"
+						},
+						"prefix": {
+							"type": "string",
+							"description": "Optional folder prefix to scope the listing"
+						},
+						"max_keys": {
+							"type": "integer",
+							"default": 1000,
+							"minimum": 1,
+							"maximum": 1000,
+							"description": "Maximum number of keys to return"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "tresorit.download_file",
+				Name:        "Download File",
+				Description: "Download a file from a Tresor (content returned as base64)",
+				RiskLevel:   "low",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["tresor", "key"],
+					"properties": {
+						"tresor": {
+							"type": "string",
+							"description": "Tresor name"
+						},
+						"key": {
+							"type": "string",
+							"description": "File path within the Tresor"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "tresorit.upload_file",
+				Name:        "Upload File",
+				Description: "Upload a file to a Tresor (content as base64)",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["tresor", "key", "content"],
+					"properties": {
+						"tresor": {
+							"type": "string",
+							"description": "Tresor name"
+						},
+						"key": {
+							"type": "string",
+							"description": "Destination file path within the Tresor"
+						},
+						"content": {
+							"type": "string",
+							"description": "Base64-encoded file content"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "tresorit.create_folder",
+				Name:        "Create Folder",
+				Description: "Create a folder inside a Tresor",
+				RiskLevel:   "medium",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["tresor", "path"],
+					"properties": {
+						"tresor": {
+							"type": "string",
+							"description": "Tresor name"
+						},
+						"path": {
+							"type": "string",
+							"description": "Folder path to create (a trailing slash is added if missing)"
+						}
+					}
+				}`)),
+			},
+			{
+				ActionType:  "tresorit.delete_file",
+				Name:        "Delete File",
+				Description: "Delete a file from a Tresor",
+				RiskLevel:   "high",
+				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
+					"type": "object",
+					"required": ["tresor", "key"],
+					"properties": {
+						"tresor": {
+							"type": "string",
+							"description": "Tresor name"
+						},
+						"key": {
+							"type": "string",
+							"description": "File path to delete"
+						}
+					}
+				}`)),
+			},
+		},
+		RequiredCredentials: []connectors.ManifestCredential{
+			{
+				Service:         "tresorit",
+				AuthType:        "custom",
+				InstructionsURL: "https://github.com/supersuit-tech/permission-slip/blob/main/connectors/tresorit/README.md",
+				Fields: []connectors.ManifestCredentialField{
+					{
+						Key:         credKeyAccessKey,
+						Label:       "Access key",
+						Placeholder: "client_id from credentials.json",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(true),
+						HelpText:    "The client_id value from the gateway's credentials.json after login.",
+					},
+					{
+						Key:         credKeySecretKey,
+						Label:       "Secret key",
+						Placeholder: "client_secret from credentials.json",
+						Secret:      ptrBool(true),
+						Required:    ptrBool(true),
+						HelpText:    "The client_secret value from the gateway's credentials.json.",
+					},
+					{
+						Key:         credKeyEndpointURL,
+						Label:       "Gateway endpoint",
+						Placeholder: "http://127.0.0.1:3000",
+						Secret:      ptrBool(false),
+						Required:    ptrBool(true),
+						HelpText:    "URL of the local Tresorit S3 gateway (default port 3000). Use http:// for loopback unless you terminate TLS locally.",
+					},
+				},
+			},
+		},
+		Templates: []connectors.ManifestTemplate{
+			{
+				ID:          "tpl_tresorit_list",
+				ActionType:  "tresorit.list_files",
+				Name:        "List files in any Tresor",
+				Description: "Agent can list files and folders in any Tresor.",
+				Parameters:  json.RawMessage(`{"tresor":"*","prefix":"*","max_keys":"*"}`),
+			},
+			{
+				ID:          "tpl_tresorit_download",
+				ActionType:  "tresorit.download_file",
+				Name:        "Download from any Tresor",
+				Description: "Agent can download files from any Tresor.",
+				Parameters:  json.RawMessage(`{"tresor":"*","key":"*"}`),
+			},
+			{
+				ID:          "tpl_tresorit_upload",
+				ActionType:  "tresorit.upload_file",
+				Name:        "Upload to any Tresor",
+				Description: "Agent can upload files to any Tresor.",
+				Parameters:  json.RawMessage(`{"tresor":"*","key":"*","content":"*"}`),
+			},
+		},
+	}
+}

--- a/connectors/tresorit/manifest.go
+++ b/connectors/tresorit/manifest.go
@@ -49,7 +49,7 @@ func (c *TresoritConnector) Manifest() *connectors.ConnectorManifest {
 				ActionType:  "tresorit.download_file",
 				Name:        "Download File",
 				Description: "Download a file from a Tresor (content returned as base64)",
-				RiskLevel:   "low",
+				RiskLevel:   "medium",
 				ParametersSchema: json.RawMessage(connectors.TrimIndent(`{
 					"type": "object",
 					"required": ["tresor", "key"],

--- a/connectors/tresorit/register.go
+++ b/connectors/tresorit/register.go
@@ -1,0 +1,7 @@
+package tresorit
+
+import "github.com/supersuit-tech/permission-slip/connectors"
+
+func init() {
+	connectors.RegisterBuiltIn(New())
+}

--- a/connectors/tresorit/response.go
+++ b/connectors/tresorit/response.go
@@ -1,0 +1,89 @@
+package tresorit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type s3ErrorResponse struct {
+	XMLName xml.Name `xml:"ErrorResponse"`
+	Error   struct {
+		Code    string `xml:"Code"`
+		Message string `xml:"Message"`
+	} `xml:"Error"`
+}
+
+type s3Error struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+	Message string   `xml:"Message"`
+}
+
+func checkResponse(statusCode int, body []byte) error {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+
+	msg := extractErrorMessage(body)
+	code := extractErrorCode(body)
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		return &connectors.RateLimitError{
+			Message: fmt.Sprintf("Tresorit gateway rate limit exceeded: %s", msg),
+		}
+	case statusCode == http.StatusForbidden:
+		hint := "verify access_key and secret_key from credentials.json"
+		if code == "InvalidAccessKeyId" || code == "SignatureDoesNotMatch" {
+			hint = "check that access_key and secret_key match the gateway credentials"
+		}
+		return &connectors.AuthError{Message: fmt.Sprintf("Tresorit gateway auth error (403): %s — %s", msg, hint)}
+	case statusCode == http.StatusUnauthorized:
+		return &connectors.AuthError{
+			Message: fmt.Sprintf("Tresorit gateway auth error (401): %s", msg),
+		}
+	case statusCode == http.StatusBadRequest:
+		return &connectors.ValidationError{Message: fmt.Sprintf("Tresorit gateway validation error: %s", msg)}
+	case statusCode == http.StatusNotFound:
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("Tresorit resource not found: %s — verify the tresor name and file path", msg),
+		}
+	default:
+		return &connectors.ExternalError{StatusCode: statusCode, Message: fmt.Sprintf("Tresorit gateway error: %s", msg)}
+	}
+}
+
+func extractErrorCode(body []byte) string {
+	var errResp s3ErrorResponse
+	if xml.Unmarshal(body, &errResp) == nil && errResp.Error.Code != "" {
+		return errResp.Error.Code
+	}
+	var simpleErr s3Error
+	if xml.Unmarshal(body, &simpleErr) == nil && simpleErr.Code != "" {
+		return simpleErr.Code
+	}
+	return ""
+}
+
+func extractErrorMessage(body []byte) string {
+	var errResp s3ErrorResponse
+	if xml.Unmarshal(body, &errResp) == nil && errResp.Error.Message != "" {
+		if errResp.Error.Code != "" {
+			return fmt.Sprintf("%s: %s", errResp.Error.Code, errResp.Error.Message)
+		}
+		return errResp.Error.Message
+	}
+
+	var simpleErr s3Error
+	if xml.Unmarshal(body, &simpleErr) == nil && simpleErr.Message != "" {
+		if simpleErr.Code != "" {
+			return fmt.Sprintf("%s: %s", simpleErr.Code, simpleErr.Message)
+		}
+		return simpleErr.Message
+	}
+
+	return string(body)
+}

--- a/connectors/tresorit/tresorit.go
+++ b/connectors/tresorit/tresorit.go
@@ -1,0 +1,201 @@
+// Package tresorit implements the Tresorit connector for Permission Slip.
+// It speaks the S3-compatible REST API exposed by Tresorit's local gateway
+// Docker container. All encryption happens inside the gateway — this connector
+// is a SigV4-signed S3 client against a custom loopback endpoint.
+package tresorit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+	"github.com/supersuit-tech/permission-slip/connectors/s3sigv4"
+)
+
+const (
+	defaultTimeout = 30 * time.Second
+	fixedRegion    = "us-east-1"
+	fixedService   = "s3"
+
+	credKeyAccessKey   = "access_key"
+	credKeySecretKey   = "secret_key"
+	credKeyEndpointURL = "endpoint_url"
+
+	// maxResponseBytes caps upstream response size.
+	maxResponseBytes = 10 * 1024 * 1024 // 10 MB
+	// maxUploadBytes caps upload payload size.
+	maxUploadBytes = 150 << 20 // 150 MB
+)
+
+// TresoritConnector owns the shared HTTP client used by all Tresorit actions.
+type TresoritConnector struct {
+	client *http.Client
+}
+
+// New creates a TresoritConnector with sensible defaults.
+func New() *TresoritConnector {
+	return &TresoritConnector{
+		client: &http.Client{Timeout: defaultTimeout},
+	}
+}
+
+// newForTest creates a TresoritConnector that uses a custom HTTP client.
+func newForTest(client *http.Client) *TresoritConnector {
+	return &TresoritConnector{client: client}
+}
+
+// ID returns "tresorit".
+func (c *TresoritConnector) ID() string { return "tresorit" }
+
+// Actions returns the registered action handlers keyed by action_type.
+func (c *TresoritConnector) Actions() map[string]connectors.Action {
+	return map[string]connectors.Action{
+		"tresorit.list_files":    &listFilesAction{conn: c},
+		"tresorit.download_file": &downloadFileAction{conn: c},
+		"tresorit.upload_file":   &uploadFileAction{conn: c},
+		"tresorit.create_folder": &createFolderAction{conn: c},
+		"tresorit.delete_file":   &deleteFileAction{conn: c},
+	}
+}
+
+// ValidateCredentials checks credential shape and verifies the local gateway
+// is reachable with a live ListBuckets call.
+func (c *TresoritConnector) ValidateCredentials(ctx context.Context, creds connectors.Credentials) error {
+	if err := validateCredentialShape(creds); err != nil {
+		return err
+	}
+
+	timeout := defaultTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+
+	return TestGatewayConnection(ctx, c, creds, timeout)
+}
+
+func validateCredentialShape(creds connectors.Credentials) error {
+	accessKey, ok := creds.Get(credKeyAccessKey)
+	if !ok || strings.TrimSpace(accessKey) == "" {
+		return &connectors.ValidationError{Message: "missing required credential: access_key"}
+	}
+	secretKey, ok := creds.Get(credKeySecretKey)
+	if !ok || strings.TrimSpace(secretKey) == "" {
+		return &connectors.ValidationError{Message: "missing required credential: secret_key"}
+	}
+	endpoint, ok := creds.Get(credKeyEndpointURL)
+	if !ok || strings.TrimSpace(endpoint) == "" {
+		return &connectors.ValidationError{Message: "missing required credential: endpoint_url"}
+	}
+	if _, err := parseEndpoint(endpoint); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseEndpoint(raw string) (*url.URL, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimRight(raw, "/")
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid endpoint_url: %v", err)}
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, &connectors.ValidationError{Message: "endpoint_url must use http or https"}
+	}
+	if u.Host == "" {
+		return nil, &connectors.ValidationError{Message: "endpoint_url must include a host (e.g. http://127.0.0.1:3000)"}
+	}
+	return u, nil
+}
+
+func endpointURL(creds connectors.Credentials) (string, error) {
+	raw, _ := creds.Get(credKeyEndpointURL)
+	u, err := parseEndpoint(raw)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+// do sends a SigV4-signed S3 request to the Tresorit gateway.
+func (c *TresoritConnector) do(ctx context.Context, creds connectors.Credentials, method, path, query string, body []byte, contentType string) ([]byte, error) {
+	base, err := endpointURL(creds)
+	if err != nil {
+		return nil, err
+	}
+
+	fullURL := base + path
+	if query != "" {
+		fullURL += "?" + query
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("creating request: %v", err)}
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	u, _ := parseEndpoint(base)
+	req.Host = u.Host
+
+	accessKey, _ := creds.Get(credKeyAccessKey)
+	secretKey, _ := creds.Get(credKeySecretKey)
+	if err := s3sigv4.SignRequest(req, s3sigv4.Credentials{
+		AccessKeyID:     accessKey,
+		SecretAccessKey: secretKey,
+	}, body, s3sigv4.SigningConfig{
+		Region:  fixedRegion,
+		Service: fixedService,
+	}); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("signing request: %v", err)}
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		if connectors.IsTimeout(err) {
+			return nil, &connectors.TimeoutError{Message: fmt.Sprintf("Tresorit gateway request timed out: %v", err)}
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, &connectors.CanceledError{Message: "Tresorit gateway request canceled"}
+		}
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("Tresorit gateway request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, &connectors.ExternalError{Message: fmt.Sprintf("reading response body: %v", err)}
+	}
+
+	if err := checkResponse(resp.StatusCode, respBytes); err != nil {
+		return nil, err
+	}
+
+	return respBytes, nil
+}
+
+func objectPath(tresor, key string) string {
+	key = strings.TrimPrefix(key, "/")
+	if key == "" {
+		return "/" + s3sigv4.URIEncodePath(tresor)
+	}
+	return "/" + s3sigv4.URIEncodePath(tresor+"/"+key)
+}
+
+func ptrBool(b bool) *bool { return &b }

--- a/connectors/tresorit/tresorit_test.go
+++ b/connectors/tresorit/tresorit_test.go
@@ -1,0 +1,140 @@
+package tresorit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestTresoritConnector_ID(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if got := c.ID(); got != "tresorit" {
+		t.Errorf("ID() = %q, want %q", got, "tresorit")
+	}
+}
+
+func TestTresoritConnector_Actions(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+
+	want := []string{
+		"tresorit.list_files",
+		"tresorit.download_file",
+		"tresorit.upload_file",
+		"tresorit.create_folder",
+		"tresorit.delete_file",
+	}
+	for _, at := range want {
+		if _, ok := actions[at]; !ok {
+			t.Errorf("Actions() missing %q", at)
+		}
+	}
+	if len(actions) != len(want) {
+		t.Errorf("Actions() returned %d actions, want %d", len(actions), len(want))
+	}
+}
+
+func TestTresoritConnector_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+	c := New()
+
+	old := testListBuckets
+	testListBuckets = func(_ context.Context, _ *TresoritConnector, _ connectors.Credentials, _ time.Duration) error {
+		return nil
+	}
+	t.Cleanup(func() { testListBuckets = old })
+
+	tests := []struct {
+		name    string
+		creds   connectors.Credentials
+		wantErr bool
+	}{
+		{name: "valid credentials", creds: validCreds(), wantErr: false},
+		{name: "missing access_key", creds: connectors.NewCredentials(map[string]string{
+			credKeySecretKey: "secret", credKeyEndpointURL: "http://127.0.0.1:3000",
+		}), wantErr: true},
+		{name: "missing secret_key", creds: connectors.NewCredentials(map[string]string{
+			credKeyAccessKey: "key", credKeyEndpointURL: "http://127.0.0.1:3000",
+		}), wantErr: true},
+		{name: "missing endpoint_url", creds: connectors.NewCredentials(map[string]string{
+			credKeyAccessKey: "key", credKeySecretKey: "secret",
+		}), wantErr: true},
+		{name: "invalid endpoint_url", creds: connectors.NewCredentials(map[string]string{
+			credKeyAccessKey: "key", credKeySecretKey: "secret", credKeyEndpointURL: "not-a-url",
+		}), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := c.ValidateCredentials(t.Context(), tt.creds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCredentials() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTresoritConnector_Manifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	m := c.Manifest()
+
+	if m.ID != "tresorit" {
+		t.Errorf("Manifest().ID = %q, want tresorit", m.ID)
+	}
+	if len(m.Actions) != 5 {
+		t.Fatalf("Manifest().Actions has %d items, want 5", len(m.Actions))
+	}
+	if err := m.Validate(); err != nil {
+		t.Errorf("Manifest().Validate() = %v", err)
+	}
+}
+
+func TestTresoritConnector_ActionsMatchManifest(t *testing.T) {
+	t.Parallel()
+	c := New()
+	actions := c.Actions()
+	manifest := c.Manifest()
+
+	manifestTypes := make(map[string]bool, len(manifest.Actions))
+	for _, a := range manifest.Actions {
+		manifestTypes[a.ActionType] = true
+	}
+	for actionType := range actions {
+		if !manifestTypes[actionType] {
+			t.Errorf("Actions() has %q but Manifest() does not", actionType)
+		}
+	}
+	for _, a := range manifest.Actions {
+		if _, ok := actions[a.ActionType]; !ok {
+			t.Errorf("Manifest() has %q but Actions() does not", a.ActionType)
+		}
+	}
+}
+
+func TestTresoritConnector_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+	var _ connectors.Connector = (*TresoritConnector)(nil)
+	var _ connectors.ManifestProvider = (*TresoritConnector)(nil)
+}
+
+func TestObjectPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		tresor, key, want string
+	}{
+		{"my-tresor", "", "/my-tresor"},
+		{"my-tresor", "docs/report.pdf", "/my-tresor/docs/report.pdf"},
+		{"my-tresor", "/docs/report.pdf", "/my-tresor/docs/report.pdf"},
+	}
+	for _, tt := range tests {
+		if got := objectPath(tt.tresor, tt.key); got != tt.want {
+			t.Errorf("objectPath(%q, %q) = %q, want %q", tt.tresor, tt.key, got, tt.want)
+		}
+	}
+}

--- a/connectors/tresorit/upload_file.go
+++ b/connectors/tresorit/upload_file.go
@@ -1,0 +1,62 @@
+package tresorit
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+type uploadFileAction struct {
+	conn *TresoritConnector
+}
+
+type uploadFileParams struct {
+	Tresor  string `json:"tresor"`
+	Key     string `json:"key"`
+	Content string `json:"content"`
+
+	decoded []byte
+}
+
+func (p *uploadFileParams) validate() error {
+	if err := validateTresorName(p.Tresor); err != nil {
+		return err
+	}
+	if err := validateObjectKey(p.Key, "key"); err != nil {
+		return err
+	}
+	if p.Content == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: content"}
+	}
+	decoded, err := base64.StdEncoding.DecodeString(p.Content)
+	if err != nil {
+		return &connectors.ValidationError{Message: "content must be valid base64-encoded data"}
+	}
+	if len(decoded) > maxUploadBytes {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("file content is %d MB, which exceeds the maximum of %d MB", len(decoded)>>20, maxUploadBytes>>20),
+		}
+	}
+	p.decoded = decoded
+	return nil
+}
+
+func (a *uploadFileAction) Execute(ctx context.Context, req connectors.ActionRequest) (*connectors.ActionResult, error) {
+	params, err := parseAndValidate[uploadFileParams](req.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = a.conn.do(ctx, req.Credentials, "PUT", objectPath(params.Tresor, params.Key), "", params.decoded, "application/octet-stream")
+	if err != nil {
+		return nil, err
+	}
+
+	return connectors.JSONResult(map[string]any{
+		"tresor": params.Tresor,
+		"key":    params.Key,
+		"size":   len(params.decoded),
+	})
+}

--- a/connectors/tresorit/upload_file_test.go
+++ b/connectors/tresorit/upload_file_test.go
@@ -1,0 +1,65 @@
+package tresorit
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+func TestUploadFile_Success(t *testing.T) {
+	t.Parallel()
+
+	content := base64.StdEncoding.EncodeToString([]byte("upload payload"))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "upload payload" {
+			t.Errorf("body = %q", string(body))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	conn := newTestConnector(&http.Client{
+		Transport: &testTransport{inner: srv.Client().Transport, testURL: srv.URL},
+	})
+	action := &uploadFileAction{conn: conn}
+
+	result, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.upload_file",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","key":"docs/new.txt","content":"` + content + `"}`),
+		Credentials: validCredsWithEndpoint(srv.URL),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(result.Data, &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if data["size"] != float64(len("upload payload")) {
+		t.Errorf("size = %v", data["size"])
+	}
+}
+
+func TestUploadFile_InvalidBase64(t *testing.T) {
+	t.Parallel()
+	action := &uploadFileAction{conn: New()}
+	_, err := action.Execute(t.Context(), connectors.ActionRequest{
+		ActionType:  "tresorit.upload_file",
+		Parameters:  json.RawMessage(`{"tresor":"my-tresor","key":"x","content":"not-base64!!!"}`),
+		Credentials: validCreds(),
+	})
+	if err == nil || !connectors.IsValidationError(err) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+}

--- a/connectors/tresorit/validation.go
+++ b/connectors/tresorit/validation.go
@@ -1,0 +1,51 @@
+package tresorit
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/supersuit-tech/permission-slip/connectors"
+)
+
+var validTresorName = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$`)
+
+type ptrValidatable[T any] interface {
+	*T
+	validate() error
+}
+
+func parseAndValidate[T any, PT ptrValidatable[T]](raw json.RawMessage) (PT, error) {
+	params := PT(new(T))
+	if err := json.Unmarshal(raw, params); err != nil {
+		return nil, &connectors.ValidationError{Message: fmt.Sprintf("invalid parameters: %v", err)}
+	}
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+	return params, nil
+}
+
+func validateTresorName(tresor string) error {
+	if strings.TrimSpace(tresor) == "" {
+		return &connectors.ValidationError{Message: "missing required parameter: tresor"}
+	}
+	if !validTresorName.MatchString(tresor) {
+		return &connectors.ValidationError{
+			Message: fmt.Sprintf("invalid tresor name %q: must be 3-63 lowercase alphanumeric characters, hyphens, or periods", tresor),
+		}
+	}
+	return nil
+}
+
+func validateObjectKey(key, field string) error {
+	if strings.TrimSpace(key) == "" {
+		return &connectors.ValidationError{Message: fmt.Sprintf("missing required parameter: %s", field)}
+	}
+	return nil
+}
+
+func stringsHasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extract AWS Signature V4 signing into `connectors/s3sigv4` so both AWS and custom S3-compatible endpoints (including `http://` loopback gateways) share the same signing code.
- Add a new `tresorit` built-in connector (protonmail-style custom credentials) that speaks path-style S3 against the customer's local Tresorit gateway Docker container.
- Actions: `list_files`, `download_file`, `upload_file`, `create_folder`, `delete_file`, with httptest coverage and operator README.

Closes #1343

## Test plan

### Claude Code
- [x] `gofmt` syntax check on all changed Go files
- [x] `go test ./connectors/s3sigv4/...` passes locally
- [ ] Full `go test ./connectors/tresorit/...` and `go test ./connectors/aws/...` — blocked in web sandbox (Go 1.25 transitive-dep constraint); relying on CI

### OpenClaw
- [ ] End-to-end verify against a running Tresorit S3 gateway (Early Adopter access required)
- [ ] Confirm credential validation surfaces actionable errors when the gateway is down

https://claude.ai/code
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9515459-55ab-4458-b9c2-97cb0e12a96f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9515459-55ab-4458-b9c2-97cb0e12a96f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

